### PR TITLE
Small optimization in remove_regular

### DIFF
--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -315,9 +315,8 @@ namespace smt::noodler {
 
             assert(pr.second.get_left_side().size() == 1);
 
-            // right side containts len variables; skip
+            // if right side contains len vars (except when we have X = Y), we must do splitting => cannot remove
             bool is_right_side_len = !set_disjoint(this->len_variables, pr.second.get_side_vars(Predicate::EquationSideType::Right));
-            // TODO: why do we not skip situation where on the right side we have exactly one len variable? can we really remove the equation then? will it not fuck up for example disequations? we should at least remember that right side var was substituted by left side var
             if(pr.second.get_side_vars(Predicate::EquationSideType::Right).size() > 1 && is_right_side_len) {
                 continue;
             }
@@ -326,8 +325,11 @@ namespace smt::noodler {
             update_reg_constr(left_var, pr.second.get_right_side());
 
             if(is_right_side_len) {
+                // In the situation where we have X = Y and Y is length
                 // we propagate the lengthness of right side variable to the left side
                 this->len_variables.insert(left_var);
+                // and add len constraint |X| = |Y|
+                this->add_to_len_formula(pr.second.get_formula_eq()); 
             }
 
             this->formula.remove_predicate(pr.first);

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -326,7 +326,7 @@ namespace smt::noodler {
             update_reg_constr(left_var, pr.second.get_right_side());
 
             if(is_right_side_len) {
-                // TODO: I assume we add left to len if we have one length variable on the right side
+                // we propagate the lengthness of right side variable to the left side
                 this->len_variables.insert(left_var);
             }
 

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -317,7 +317,7 @@ namespace smt::noodler {
 
             // right side containts len variables; skip
             bool is_right_side_len = !set_disjoint(this->len_variables, pr.second.get_side_vars(Predicate::EquationSideType::Right));
-            // TODO: why do we not skip situation where on the right side we have exactly one len variable? can we really remove the equation then?
+            // TODO: why do we not skip situation where on the right side we have exactly one len variable? can we really remove the equation then? will it not fuck up for example disequations?
             if(pr.second.get_side_vars(Predicate::EquationSideType::Right).size() > 1 && is_right_side_len) {
                 continue;
             }

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -317,7 +317,7 @@ namespace smt::noodler {
 
             // right side containts len variables; skip
             bool is_right_side_len = !set_disjoint(this->len_variables, pr.second.get_side_vars(Predicate::EquationSideType::Right));
-            // TODO: why do we not skip situation where on the right side we have exactly one len variable? can we really remove the equation then? will it not fuck up for example disequations?
+            // TODO: why do we not skip situation where on the right side we have exactly one len variable? can we really remove the equation then? will it not fuck up for example disequations? we should at least remember that right side var was substituted by left side var
             if(pr.second.get_side_vars(Predicate::EquationSideType::Right).size() > 1 && is_right_side_len) {
                 continue;
             }


### PR DESCRIPTION
I added small optimization in removing regular equations, so that when we delete some regular equations and we check that some other equations did not become regular, we do it now only by checking if the left var `X` occurs exactly once in the formula (and we do not check this for variables on the right side anymore, as they should not occur in the system anymore).

I also added one TODO, I am not sure if `remove_regular` works correctly, we remove also equations of the form `X = Y` where `Y` is length variable not occuring anywhere else in the system. I think we should then remember that `Y` was substituted by `X`.