### PR TITLE
Fix constructors, compilable tests

### DIFF
--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -37,6 +37,7 @@ namespace smt::noodler {
     public:
         using std::unordered_map<BasicTerm, std::shared_ptr<Mata::Nfa::Nfa>>::unordered_map;
 
+        // used for tests, do not use normally
         AutAssignment(std::map<BasicTerm, Mata::Nfa::Nfa> val) {
             for (const auto &key_value : val) {
                 this->operator[](key_value.first) = std::make_shared<Mata::Nfa::Nfa>(key_value.second);

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -94,15 +94,6 @@ namespace smt::noodler {
         return result;
     }
 
-    DecisionProcedure::DecisionProcedure(ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, const theory_str_noodler_params& par) 
-        : prep_handler(Formula(), AutAssignment(), {}, par), m{ m }, m_util_s{ m_util_s },
-        m_util_a{ m_util_a },
-        init_length_sensitive_vars{ },
-        formula { },
-        init_aut_ass{ },
-        m_params(par) {
-    }
-
     bool DecisionProcedure::compute_next_solution() {
         // iteratively select next state of solving that can lead to solution and
         // process one of the unprocessed nodes (or possibly find solution)
@@ -855,20 +846,6 @@ namespace smt::noodler {
         return res;
     }
 
-    /**
-     * @brief Set new instance for the decision procedure.
-     * 
-     * @param equalities Equalities
-     * @param init_aut_ass Initial automata assignment
-     * @param init_length_sensitive_vars Length sensitive vars
-     */
-    void DecisionProcedure::set_instance(const Formula &equalities, AutAssignment &init_aut_ass, const std::unordered_set<BasicTerm>& init_length_sensitive_vars) {
-        this->init_length_sensitive_vars = init_length_sensitive_vars;
-        this->formula = equalities;
-        this->init_aut_ass = init_aut_ass;
-        this->prep_handler = FormulaPreprocess(equalities, init_aut_ass, init_length_sensitive_vars, m_params);
-    }
-
     void DecisionProcedure::conv_str_lits_to_fresh_lits() {
         size_t counter{ 0 };
         std::map<zstring, zstring> str_literals{};
@@ -902,20 +879,5 @@ namespace smt::noodler {
             }
         }
     }
-
-    DecisionProcedure::DecisionProcedure(
-             const Formula &equalities, AutAssignment init_aut_ass,
-             const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
-             ast_manager& m, seq_util& m_util_s, arith_util& m_util_a,
-             const BasicTermEqiv& len_eq_vars,
-             const theory_str_noodler_params& par
-     ) : prep_handler(equalities, init_aut_ass, init_length_sensitive_vars, par), m{ m }, m_util_s{ m_util_s },
-     m_util_a{ m_util_a },
-     init_length_sensitive_vars{ init_length_sensitive_vars },
-         formula { equalities },
-         init_aut_ass{ init_aut_ass },
-         m_params(par),
-         len_eq_vars{ len_eq_vars } {
-         }
 
 } // Namespace smt::noodler.

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -350,9 +350,13 @@ namespace smt::noodler {
         expr_ref len_diseqs(const std::map<BasicTerm, expr_ref>& variable_map, const SolvingState &state);
 
     public:
-        DecisionProcedure(ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, const theory_str_noodler_params& par);
 
-        DecisionProcedure(ast_manager& m, seq_util& m_util_s, arith_util& m_util_a);
+        DecisionProcedure(ast_manager &m, seq_util &m_util_s, arith_util &m_util_a, const theory_str_noodler_params &par) 
+          : prep_handler(Formula(), AutAssignment(), {}, par),
+            m(m),
+            m_util_s(m_util_s),
+            m_util_a(m_util_a),
+            m_params(par) { }
         
         /**
          * Initialize a new decision procedure that can solve word equations
@@ -370,15 +374,35 @@ namespace smt::noodler {
          * @param len_eq_vars Equivalence class holding variables with the same length
          * @param par Parameters for Noodler string theory.
          */
-        DecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass,
-                           const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
-                           ast_manager& m, seq_util& m_util_s, arith_util& m_util_a,
-                           const BasicTermEqiv& len_eq_vars,
-                           const theory_str_noodler_params& par
-         );
-
-        void set_instance(const Formula &equalities, AutAssignment &init_aut_ass,
-                          const std::unordered_set<BasicTerm>& init_length_sensitive_vars);
+        DecisionProcedure(
+             Formula equalities, AutAssignment init_aut_ass,
+             std::unordered_set<BasicTerm> init_length_sensitive_vars,
+             ast_manager &m, seq_util &m_util_s, arith_util &m_util_a,
+             BasicTermEqiv len_eq_vars,
+             const theory_str_noodler_params &par
+        ) : prep_handler(equalities, init_aut_ass, init_length_sensitive_vars, par),
+            m{m},
+            m_util_s{m_util_s},
+            m_util_a{m_util_a},
+            init_length_sensitive_vars(init_length_sensitive_vars),
+            formula(equalities),
+            init_aut_ass(init_aut_ass),
+            m_params(par),
+            len_eq_vars(len_eq_vars) { }
+        /**
+         * @brief Set new instance for the decision procedure.
+         * 
+         * @param equalities Equalities
+         * @param init_aut_ass Initial automata assignment
+         * @param init_length_sensitive_vars Length sensitive vars
+         */
+        void set_instance(Formula equalities, AutAssignment init_aut_ass, std::unordered_set<BasicTerm> init_length_sensitive_vars) {
+            this->init_length_sensitive_vars = init_length_sensitive_vars;
+            this->formula = equalities;
+            this->init_aut_ass = init_aut_ass;
+            this->prep_handler = FormulaPreprocess(equalities, init_aut_ass, init_length_sensitive_vars, m_params);
+        }
+        
         bool compute_next_solution() override;
 
         /**

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -325,7 +325,7 @@ namespace smt::noodler {
         bool same_length(const BasicTermEqiv& ec, const BasicTerm&t1, const BasicTerm& t2) const;
 
     public:
-        FormulaPreprocess(const Formula& conj, const AutAssignment& ass, const std::unordered_set<BasicTerm>& lv, const theory_str_noodler_params& par) :
+        FormulaPreprocess(Formula conj, AutAssignment ass, std::unordered_set<BasicTerm> lv, const theory_str_noodler_params &par) :
             formula(conj),
             fresh_var_cnt(0),
             aut_ass(ass),

--- a/src/test/noodler/decision-procedure.cpp
+++ b/src/test/noodler/decision-procedure.cpp
@@ -29,7 +29,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         init_ass[get_var('y')] = regex_to_nfa("a*");
         init_ass[get_var('z')] = regex_to_nfa("b");
         init_ass[get_var('u')] = regex_to_nfa("b*");
-        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
         CHECK(!proc.compute_next_solution());
     }
@@ -43,7 +43,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         init_ass[get_var('y')] = regex_to_nfa("a*");
         init_ass[get_var('z')] = regex_to_nfa("a*");
         init_ass[get_var('u')] = regex_to_nfa("a*");
-        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
         CHECK(proc.compute_next_solution());
     }
@@ -56,7 +56,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         init_ass[get_var('x')] = regex_to_nfa("a*");
         init_ass[get_var('y')] = regex_to_nfa("a+b+");
         init_ass[get_var('z')] = regex_to_nfa("b*");
-        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
         CHECK(!proc.compute_next_solution());
     }
@@ -70,7 +70,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         init_ass[get_var('y')] = regex_to_nfa("a*");
         init_ass[get_var('z')] = regex_to_nfa("b");
         init_ass[get_var('u')] = regex_to_nfa("b*");
-        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
         CHECK(!proc.compute_next_solution());
     }
@@ -84,7 +84,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         init_ass[get_var('y')] = regex_to_nfa("a*");
         init_ass[get_var('z')] = regex_to_nfa("a*");
         init_ass[get_var('u')] = regex_to_nfa("a*");
-        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
         CHECK(proc.compute_next_solution());
         CHECK(proc.compute_next_solution());
@@ -100,7 +100,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         init_ass[get_var('y')] = regex_to_nfa("ab*");
         init_ass[get_var('z')] = regex_to_nfa("ab*");
         init_ass[get_var('u')] = regex_to_nfa("a*");
-        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
 
         REQUIRE(proc.compute_next_solution());
@@ -131,7 +131,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         init_ass[get_var('z')] = regex_to_nfa("b");
         init_ass[get_var('u')] = regex_to_nfa("b*");
         init_ass[get_var('r')] = regex_to_nfa("a*");
-        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
         CHECK(!proc.compute_next_solution());
     }
@@ -146,7 +146,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         init_ass[get_var('z')] = regex_to_nfa("a*");
         init_ass[get_var('u')] = regex_to_nfa("(a|b)*");
         init_ass[get_var('r')] = regex_to_nfa("aaa");
-        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
         CHECK(proc.compute_next_solution());
     }
@@ -161,7 +161,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         init_ass[get_var('z')] = regex_to_nfa("b");
         init_ass[get_var('u')] = regex_to_nfa("b*");
         init_ass[get_var('r')] = regex_to_nfa("a*");
-        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { BasicTerm(BasicTermType::Variable, "x"), BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
         CHECK(!proc.compute_next_solution());
     }
@@ -178,7 +178,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         init_ass[get_var('r')] = regex_to_nfa("ab*a");
         DecisionProcedureCUT proc(equalities, init_ass, {
             BasicTerm(BasicTermType::Variable, "x"),
-            BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s, m_util_a, noodler_params);
+            BasicTerm(BasicTermType::Variable, "z") }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
 
         REQUIRE(proc.compute_next_solution());
@@ -234,7 +234,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
                 BasicTerm(BasicTermType::Variable, "x"),
                 BasicTerm(BasicTermType::Variable, "z"),
                 BasicTerm(BasicTermType::Variable, "r") },
-            m, m_util_s, m_util_a, noodler_params);
+            m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
 
         REQUIRE(proc.compute_next_solution());
@@ -253,7 +253,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         // equalities.add_predicate(create_equality("yx", "r"));
         AutAssignment init_ass;
         init_ass[get_var('x')] = regex_to_nfa("aa?b*");
-        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
         CHECK(!proc.compute_next_solution());
     }
@@ -264,7 +264,7 @@ TEST_CASE("Decision Procedure", "[noodler]") {
         // equalities.add_predicate(create_equality("yx", "r"));
         AutAssignment init_ass;
         init_ass[get_var('x')] = regex_to_nfa("a*b*");
-        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, noodler_params);
+        DecisionProcedureCUT proc(equalities, init_ass, { }, m, m_util_s, m_util_a, {}, noodler_params);
         proc.init_computation();
         CHECK(proc.compute_next_solution());
     }

--- a/src/test/noodler/formula-preprocess.cpp
+++ b/src/test/noodler/formula-preprocess.cpp
@@ -10,7 +10,7 @@ using namespace smt::noodler;
 
 static Mata::Nfa::Nfa regex_to_nfa(const std::string& regex) {
     Mata::Nfa::Nfa aut;
-    Mata::RE2Parser::create_nfa(&aut, regex);
+    Mata::Parser::create_nfa(&aut, regex);
     return aut;
 }
 

--- a/src/test/noodler/test_utils.h
+++ b/src/test/noodler/test_utils.h
@@ -27,8 +27,8 @@ class DecisionProcedureCUT : public DecisionProcedure {
 public:
     DecisionProcedureCUT(const Formula &equalities, AutAssignment init_aut_ass,
                          const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
-                         ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, const theory_str_noodler_params& par
-    ) : DecisionProcedure(equalities, std::move(init_aut_ass), init_length_sensitive_vars, m, m_util_s, m_util_a, par) {}
+                         ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, const BasicTermEqiv& len_eq_vars, const theory_str_noodler_params& par
+    ) : DecisionProcedure(equalities, std::move(init_aut_ass), init_length_sensitive_vars, m, m_util_s, m_util_a, len_eq_vars, par) {}
 
     using DecisionProcedure::compute_next_solution;
     using DecisionProcedure::get_lengths;
@@ -57,7 +57,7 @@ inline BasicTerm get_var(char var) {
 
 inline std::shared_ptr<Mata::Nfa::Nfa> regex_to_nfa(const std::string& regex) {
     Mata::Nfa::Nfa aut;
-    Mata::RE2Parser::create_nfa(&aut, regex);
+    Mata::Parser::create_nfa(&aut, regex);
     return std::make_shared<Mata::Nfa::Nfa>(aut);
 }
 


### PR DESCRIPTION
I removed references from constructors of DecisionProcedure when we have to copy passed value anyway (so that compilers can use `move`).

I also made tests compilable, but some preprocessing tests fail.