### PR TITLE
Optimization of predicate instantiation

### DIFF
--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -135,7 +135,7 @@ namespace smt::noodler {
         }
 
         /**
-         * @brief Check if the automataon accepts only a single word. It is only underapproximation,
+         * @brief Check if the automaton accepts only a single word. It is only underapproximation,
          * as is_singleton is false for the NFA p1 -a-> p2, q1 -a-> q2 where p1, q1 are initial and p2, q2 are final.
          * To get a precise information, the determinization+minimization might be necessary, which is often 
          * expensive. 
@@ -218,7 +218,7 @@ namespace smt::noodler {
          * @param restr_nfa Language restriction represented by an NFA.
          */
         void restrict_lang(const BasicTerm& t, const Mata::Nfa::Nfa& restr_nfa) {
-            (*this)[t] = std::make_shared<Mata::Nfa::Nfa>(Mata::Nfa::intersection(restr_nfa, *(*this)[t]));
+            (*this)[t] = std::make_shared<Mata::Nfa::Nfa>(Mata::Nfa::intersection(restr_nfa, *this->at(t)));
         }
 
         /**

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -212,6 +212,16 @@ namespace smt::noodler {
         }
 
         /**
+         * @brief Restrict language of the given basic term @p t by @p restr_nfa.  
+         * 
+         * @param t Basic term to be restricted
+         * @param restr_nfa Language restriction represented by an NFA.
+         */
+        void restrict_lang(const BasicTerm& t, const Mata::Nfa::Nfa& restr_nfa) {
+            (*this)[t] = std::make_shared<Mata::Nfa::Nfa>(Mata::Nfa::intersection(restr_nfa, *(*this)[t]));
+        }
+
+        /**
          * @brief Get the length formula representing all possible lengths of the automaton for @p var
          */
         LenNode get_lengths(const BasicTerm& var) const;

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -135,6 +135,21 @@ namespace smt::noodler {
         }
 
         /**
+         * @brief Check if the automataon accepts only a single word. It is only underapproximation,
+         * as is_singleton is false for the NFA p1 -a-> p2, q1 -a-> q2 where p1, q1 are initial and p2, q2 are final.
+         * To get a precise information, the determinization+minimization might be necessary, which is often 
+         * expensive. 
+         * 
+         * @param t Variable
+         * @return True -> is surely singleton, False -> inconclusive
+         */
+        bool is_singleton(const BasicTerm& t) const {
+            Mata::Nfa::Nfa aut = *this->at(t);
+            aut.trim();
+            return aut.size() == aut.get_num_of_trans() + 1 && aut.initial.size() == 1 && aut.final.size() == 1;
+        }
+
+        /**
          * @brief Check if the language of the basic term has a fixed length
          * 
          * @param t BasicTerm

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -806,7 +806,7 @@ namespace smt::noodler {
             this->init_aut_ass.reduce(); // reduce all automata in the automata assignment
         }
 
-        if(prep_handler.contains_unsat_predicates()) {
+        if(prep_handler.contains_unsat_eqs_or_diseqs()) {
             return l_false;
         }
 

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -787,6 +787,10 @@ namespace smt::noodler {
         this->init_length_sensitive_vars = prep_handler.get_len_variables();
         this->preprocessing_len_formula = prep_handler.get_len_formula();
 
+        if(prep_handler.contains_unsat_predicates()) {
+            return l_false;
+        }
+
         if(this->formula.get_predicates().size() > 0) {
             this->init_aut_ass.reduce(); // reduce all automata in the automata assignment
         }

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -794,12 +794,17 @@ namespace smt::noodler {
         this->init_length_sensitive_vars = prep_handler.get_len_variables();
         this->preprocessing_len_formula = prep_handler.get_len_formula();
 
-        if(prep_handler.contains_unsat_predicates()) {
-            return l_false;
-        }
-
         if(this->formula.get_predicates().size() > 0) {
             this->init_aut_ass.reduce(); // reduce all automata in the automata assignment
+        }
+
+        // there remains some not contains --> return undef
+        if(this->not_contains.get_predicates().size() > 0) {
+            return l_undef;
+        }
+
+        if(prep_handler.contains_unsat_predicates()) {
+            return l_false;
         }
 
         STRACE("str-nfa", tout << "Automata after preprocessing" << std::endl << init_aut_ass.print());

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -82,6 +82,7 @@ namespace smt::noodler {
             return LenNode(LenFormulaType::AND, {result, LenNode(LenFormulaType::LEQ, {0, var})});
         } else {
             util::throw_error("Variable was neither in automata assignment nor was substituted");
+            return LenNode(BasicTerm(BasicTermType::Literal)); // return something to get rid of warnings
         }
     }
 
@@ -129,6 +130,12 @@ namespace smt::noodler {
     }
 
     lbool DecisionProcedure::compute_next_solution() {
+
+        // if we have a not contains, we give unknown
+        if(this->not_contains.get_predicates().size() > 0) {
+            return l_undef;
+        }
+
         // iteratively select next state of solving that can lead to solution and
         // process one of the unprocessed nodes (or possibly find solution)
         STRACE("str", tout << "------------------------"

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -797,13 +797,13 @@ namespace smt::noodler {
         // try to replace the not contains predicates (so-far we replace it by regular constraints)
         replace_not_contains();
 
-        if(this->formula.get_predicates().size() > 0) {
-            this->init_aut_ass.reduce(); // reduce all automata in the automata assignment
-        }
-
         // there remains some not contains --> return undef
         if(this->not_contains.get_predicates().size() > 0) {
             return l_undef;
+        }
+
+        if(this->formula.get_predicates().size() > 0) {
+            this->init_aut_ass.reduce(); // reduce all automata in the automata assignment
         }
 
         if(prep_handler.contains_unsat_predicates()) {

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -296,6 +296,11 @@ namespace smt::noodler {
          */
         Formula not_contains{};
 
+        /**
+         * @brief Construct constraints to get rid of not_contains predicates.
+         */
+        void replace_not_contains();
+
     public:
         
         /**

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -291,6 +291,11 @@ namespace smt::noodler {
          */
         LenNode diseqs_formula();
 
+        /**
+         * Formula containing all not_contains predicate (nothing else)
+         */
+        Formula not_contains{};
+
     public:
         
         /**
@@ -300,20 +305,24 @@ namespace smt::noodler {
          * keeping the length dependencies between variables (for the variables that
          * occur in some length constraint in the rest of the formula).
          * 
-         * @param equalities encodes the word equations
+         * @param formula encodes the string formula (including equations, not contains)
          * @param init_aut_ass gives regular constraints (maps each variable from @p equalities to some NFA), assumes all NFAs are non-empty
          * @param init_length_sensitive_vars the variables that occur in length constraints in the rest of formula
          * @param len_eq_vars Equivalence class holding variables with the same length
          * @param par Parameters for Noodler string theory.
          */
         DecisionProcedure(
-             Formula equalities, AutAssignment init_aut_ass,
+             Formula formula, AutAssignment init_aut_ass,
              std::unordered_set<BasicTerm> init_length_sensitive_vars,
              const theory_str_noodler_params &par
         ) : init_length_sensitive_vars(init_length_sensitive_vars),
-            formula(equalities),
+            formula(formula),
             init_aut_ass(init_aut_ass),
-            m_params(par) { }
+            m_params(par) {
+            
+            // we extract from the input formula all not_contains predicates and add them to not_contains formula
+            this->formula.extract_predicates(PredicateType::NotContains, this->not_contains);
+        }
         
         /**
          * Do some preprocessing (can be called only before init_computation). Can

--- a/src/smt/theory_str_noodler/expr_solver.h
+++ b/src/smt/theory_str_noodler/expr_solver.h
@@ -33,13 +33,14 @@ Eternal glory to Yu-Fang.
 namespace smt::noodler {
     class int_expr_solver:expr_solver{
         bool unsat_core=false;
-        kernel m_kernel;
         ast_manager& m;
         bool initialized;
         expr_ref_vector erv;
     public:
+        kernel m_kernel;
+    public:
         int_expr_solver(ast_manager& m, smt_params fp):
-                m_kernel(m, fp), m(m),erv(m){
+                m(m),erv(m),m_kernel(m, fp){
             fp.m_string_solver = symbol("none");
             initialized=false;
        }

--- a/src/smt/theory_str_noodler/formula.cpp
+++ b/src/smt/theory_str_noodler/formula.cpp
@@ -112,6 +112,18 @@ namespace smt::noodler {
                 }
                 return result;
             }
+
+            case PredicateType::NotContains: {
+                std::string result{ "Notcontains " };
+                for (const auto& item: params[0]) {
+                    result += " " + item.to_string();
+                }
+                result += " ,";
+                for (const auto& item: params[1]) {
+                    result += " " + item.to_string();
+                }
+                return result;
+            }
         }
 
         throw std::runtime_error("Unhandled predicate type passed as 'this' to to_string().");

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -297,6 +297,17 @@ namespace smt::noodler {
         }
 
         /**
+         * @brief Check if the predicate contains only constant strings.
+         */
+        bool is_str_const() const {
+            for(const auto& side : this->params) {
+                for(const BasicTerm& t : side)
+                    if(!t.is_literal()) return false;
+            }
+            return true;
+        }
+
+        /**
          * @brief Get the length formula of the equation. For an equation X1 X2 X3 ... = Y1 Y2 Y3 ...
          * creates a formula |X1|+|X2|+|X3|+ ... = |Y1|+|Y2|+|Y3|+ ...
          *

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -513,6 +513,14 @@ namespace smt::noodler {
             return ret;
         }
 
+        /**
+         * @brief Extract and remove predicate of the type @p type from the formula. 
+         * The predicates of the type @p type are stored in the output @p extracted
+         * It removes the extracted predicates from the current formula.
+         * 
+         * @param type Predicate type
+         * @param[out] extracted Where to store extracted predicates
+         */
         void extract_predicates(PredicateType type, Formula& extracted) {
             std::vector<Predicate> new_predicates {};
             for(const Predicate& pred : this->predicates) {

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -31,6 +31,7 @@ namespace smt::noodler {
     enum struct PredicateType {
         Equation,
         Inequation,
+        NotContains,
     };
 
     [[nodiscard]] static std::string to_string(PredicateType predicate_type) {
@@ -39,6 +40,8 @@ namespace smt::noodler {
                 return "Equation";
             case PredicateType::Inequation:
                 return "Inequation";
+            case PredicateType::NotContains:
+                return "Notcontains";
         }
 
         throw std::runtime_error("Unhandled predicate type passed to to_string().");
@@ -509,6 +512,18 @@ namespace smt::noodler {
             }
             return ret;
         }
+
+        void extract_predicates(PredicateType type, Formula& extracted) {
+            std::vector<Predicate> new_predicates {};
+            for(const Predicate& pred : this->predicates) {
+                if(pred.get_type() == type) {
+                    extracted.add_predicate(pred);
+                } else {
+                    new_predicates.emplace_back(pred);
+                }
+            }
+            this->predicates = new_predicates;
+        } 
 
         /**
          * @brief Get union of variables from all predicates

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1050,6 +1050,18 @@ namespace smt::noodler {
                     update_reg_constr(var, pr.second.get_left_side());
             }
         }
+
+        // Check if there is a regular constraint of the form "A" in .... 
+        // In that case, we construct automaton for "A" and make a product with the 
+        // corresponding language of the Basic Term "A".
+        for(const auto& pr : this->aut_ass) {
+            if(pr.first.is_literal()) {
+                Mata::Nfa::Nfa word_aut = util::create_word_nfa(pr.first.get_name());
+                Mata::Nfa::Nfa inters = Mata::Nfa::intersection(*(pr.second), word_aut);
+                inters.trim();
+                this->aut_ass[pr.first] = std::make_shared<Mata::Nfa::Nfa>(Mata::Nfa::reduce(inters));
+            }
+        }
     }
 
     /**

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1020,6 +1020,9 @@ namespace smt::noodler {
 
     /**
      * @brief Refine languages for equations of the form X = R (|X|=1) to the L(X) = L(X) \cap L(R).
+     * Moreover, for the literal terms l from the current automata assignments, restrict its 
+     * languages to L(l) = L(l) \cap {l}. Recall that the automata assignment contains not only 
+     * variables but also literals.
      */
     void FormulaPreprocessor::refine_languages() {
         std::set<BasicTerm> ineq_vars;

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1074,12 +1074,14 @@ namespace smt::noodler {
                 continue;
 
             if(this->formula.single_occurr(pr.second.get_left_set())) {
-                if(is_sigma_star(pr.second.get_left_set())) {
+                auto left_set = pr.second.get_left_set();
+                if(left_set.size() > 0 && is_sigma_star(left_set)) {
                     rem_ids.insert(pr.first);
                 }
             }
             if(this->formula.single_occurr(pr.second.get_right_set())) {
-                if(is_sigma_star(pr.second.get_right_set())) {
+                auto right_set = pr.second.get_right_set();
+                if(right_set.size() > 0 && is_sigma_star(right_set)) {
                     rem_ids.insert(pr.first);
                 }               
             }
@@ -1238,6 +1240,31 @@ namespace smt::noodler {
         for(const size_t & i : rem_ids) {
             this->formula.remove_predicate(i);
         }
+    }
+
+    /**
+     * @brief Check if the instance is clearly unsatisfiable.
+     * 
+     * @return True --> unsat for sure.
+     */
+    bool FormulaPreprocessor::contains_unsat_predicates() const {
+        for(const auto& pr : this->formula.get_predicates()) {
+            if(pr.second.is_inequation() && pr.second.get_left_side() == pr.second.get_right_side()) {
+                return true;
+            }
+            if(pr.second.is_equation() && pr.second.is_str_const()) {
+                zstring left{};
+                zstring right{};
+                for(const BasicTerm& t : pr.second.get_left_side()) {
+                    left = left + t.get_name();
+                }
+                for(const BasicTerm& t : pr.second.get_right_side()) {
+                    right = right + t.get_name();
+                }
+                if(left != right) return true;
+            }
+        }
+        return false;
     }
 
 } // Namespace smt::noodler.

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1255,11 +1255,12 @@ namespace smt::noodler {
     }
 
     /**
-     * @brief Check if the instance is clearly unsatisfiable.
+     * @brief Check if the instance is clearly unsatisfiable. It checks trivial (dis)equations
+     * of the form x != x, ab = cd (x is term, a,b,c,d are constants).
      * 
      * @return True --> unsat for sure.
      */
-    bool FormulaPreprocessor::contains_unsat_predicates() const {
+    bool FormulaPreprocessor::contains_unsat_eqs_or_diseqs() const {
         for(const auto& pr : this->formula.get_predicates()) {
             if(pr.second.is_inequation() && pr.second.get_left_side() == pr.second.get_right_side()) {
                 return true;

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -16,6 +16,7 @@
 #include "formula.h"
 #include "aut_assignment.h"
 #include "var_union_find.h"
+#include "util.h"
 
 namespace smt::noodler {
 

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -363,7 +363,7 @@ namespace smt::noodler {
         void refine_languages();
         void reduce_diseqalities();
 
-        bool contains_unsat_predicates() const;
+        bool contains_unsat_eqs_or_diseqs() const;
 
         /**
          * @brief Replace all occurrences of find with replace. Warning: do not modify the automata assignment.

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -362,6 +362,8 @@ namespace smt::noodler {
         void refine_languages();
         void reduce_diseqalities();
 
+        bool contains_unsat_predicates() const;
+
         /**
          * @brief Replace all occurrences of find with replace. Warning: do not modify the automata assignment.
          *

--- a/src/smt/theory_str_noodler/inclusion_graph.cc
+++ b/src/smt/theory_str_noodler/inclusion_graph.cc
@@ -1,4 +1,5 @@
 #include "inclusion_graph.h"
+#include "util.h"
 
 namespace {
     using namespace smt::noodler;
@@ -25,6 +26,9 @@ namespace {
         auto& predicate{ node->get_predicate() };
         std::string result{};
         switch (predicate.get_type()) {
+            case PredicateType::NotContains: {
+                util::throw_error("Decision procedure can handle only equations and disequations");
+            }
             case PredicateType::Equation:
             case PredicateType::Inequation: {
                 std::string left_side{};

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.cpp
@@ -45,11 +45,6 @@ namespace smt::noodler {
      * @return True -> satisfiable
      */
     lbool NielsenDecisionProcedure::compute_next_solution() {
-        // if we have a not contains, we give unknown
-        if(this->not_contains.get_predicates().size() > 0) {
-            return l_undef;
-        }
-
         // if the compute_next_solution was called for the first time
         if(this->graphs.size() == 0) {
             std::vector<Formula> instances = divide_independent_formula(this->formula);

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.cpp
@@ -45,6 +45,11 @@ namespace smt::noodler {
      * @return True -> satisfiable
      */
     lbool NielsenDecisionProcedure::compute_next_solution() {
+        // if we have a not contains, we give unknown
+        if(this->not_contains.get_predicates().size() > 0) {
+            return l_undef;
+        }
+
         // if the compute_next_solution was called for the first time
         if(this->graphs.size() == 0) {
             std::vector<Formula> instances = divide_independent_formula(this->formula);

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.h
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.h
@@ -272,11 +272,6 @@ namespace smt::noodler {
 
         LenNode length_formula_for_solution = LenNode(LenFormulaType::TRUE);
 
-        /**
-         * Formula containing all not_contains predicate (nothing else)
-         */
-        Formula not_contains{};
-
     protected:
         // functions for the construction of a Nielsen graph
         bool is_pred_unsat(const Predicate& pred) const;
@@ -330,11 +325,8 @@ namespace smt::noodler {
              init_aut_ass{ init_aut_ass },
              m_params(par) { 
             
-            // we extract from the input formula all not_contains predicates and add them to not_contains formula
-            this->formula.extract_predicates(PredicateType::NotContains, this->not_contains);
-
             // Nielsen currently supports only quadratic equations (no inequalities and not(contains))
-            if(!this->formula.is_quadratic() || this->not_contains.get_predicates().size() > 0) {
+            if(!this->formula.is_quadratic()) {
                 util::throw_error("Nielsen supports quadratic equations only");
             }
         }

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.h
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.h
@@ -329,9 +329,14 @@ namespace smt::noodler {
              formula { equalities },
              init_aut_ass{ init_aut_ass },
              m_params(par) { 
-                
+            
             // we extract from the input formula all not_contains predicates and add them to not_contains formula
             this->formula.extract_predicates(PredicateType::NotContains, this->not_contains);
+
+            // Nielsen currently supports only quadratic equations (no inequalities and not(contains))
+            if(!this->formula.is_quadratic() || this->not_contains.get_predicates().size() > 0) {
+                util::throw_error("Nielsen supports quadratic equations only");
+            }
         }
 
         lbool compute_next_solution() override;

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.h
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.h
@@ -272,6 +272,11 @@ namespace smt::noodler {
 
         LenNode length_formula_for_solution = LenNode(LenFormulaType::TRUE);
 
+        /**
+         * Formula containing all not_contains predicate (nothing else)
+         */
+        Formula not_contains{};
+
     protected:
         // functions for the construction of a Nielsen graph
         bool is_pred_unsat(const Predicate& pred) const;
@@ -323,7 +328,11 @@ namespace smt::noodler {
          ) : init_length_sensitive_vars{ init_length_sensitive_vars },
              formula { equalities },
              init_aut_ass{ init_aut_ass },
-             m_params(par) { }
+             m_params(par) { 
+                
+            // we extract from the input formula all not_contains predicates and add them to not_contains formula
+            this->formula.extract_predicates(PredicateType::NotContains, this->not_contains);
+        }
 
         lbool compute_next_solution() override;
         LenNode get_initial_lengths() override {

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1144,11 +1144,12 @@ namespace smt::noodler {
         expr_ref v = mk_str_var_fresh("substr");
 
         int val = r.get_int32();
-        for(int i = 0; i < val; i++) {
+        for(int v = 0; v < val; v++) {
             expr_ref var = mk_str_var_fresh("pre_substr");
             expr_ref re(m_util_s.re.mk_in_re(var, m_util_s.re.mk_full_char(nullptr)), m);
             x = m_util_s.str.mk_concat(x, var);
             add_axiom({~i_ge_0, ~ls_le_i, mk_literal(re)});
+            add_axiom({~i_ge_0, ~ls_le_i, mk_eq(m_util_s.str.mk_length(var), m_util_a.mk_int(1), false)});
         }
 
         expr_ref le(m_util_s.str.mk_length(v), m);
@@ -1344,7 +1345,9 @@ namespace smt::noodler {
         // create axioms in_substri is Sigma
         for(const expr_ref& val : vars) {
             expr_ref re(m_util_s.re.mk_in_re(val, m_util_s.re.mk_full_char(nullptr)), m);
-            add_axiom({~i_ge_0, ~ls_le_i, mk_literal(re)});
+            literal pred_ge = mk_literal(m_util_a.mk_ge(pred, m_util_a.mk_int(0)));
+            add_axiom({~i_ge_0, ~ls_le_i, ~pred_ge, mk_literal(re)});
+            add_axiom({~i_ge_0, ~ls_le_i, ~pred_ge, mk_eq(m_util_s.str.mk_length(val), m_util_a.mk_int(1), false)});
         }
         // 0 <= i <= |s| -> xvy = s
         add_axiom({~i_ge_0, ~ls_le_i, mk_eq(xey, s, false)});
@@ -1864,6 +1867,7 @@ namespace smt::noodler {
                 m_util_s.re.mk_star(m_util_s.re.mk_full_char(nullptr)))) ), m);
           
             add_axiom({mk_literal(e), ~mk_literal(re)});
+            add_axiom({mk_literal(cont), mk_literal(re)});
         } else if(m_util_s.str.is_string(x, s) && s.length() == 1) { // special case for not(contains "A" t)
             expr_ref re(m_util_s.re.mk_in_re(x, m_util_s.re.mk_to_re(m_util_s.str.mk_string(s)) ), m);
             add_axiom({mk_literal(e), ~mk_literal(re)});

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1011,13 +1011,6 @@ namespace smt::noodler {
         literal_vector lv;
         for (const auto &l : ls) {
             if (l != null_literal && l != false_literal) {
-                expr_ref ex = ctx.literal2expr(l);
-                // if the expression is not internalized, internalize it and make relevant
-                if(!ctx.e_internalized(ex)) {
-                    // TODO: when I set the second argument to false; I got assertion violation.
-                    ctx.internalize(ex, true);
-                }
-                
                 ctx.mark_as_relevant(l);
                 lv.push_back(l);
             }
@@ -1418,11 +1411,12 @@ namespace smt::noodler {
         // str.replace "A" s t where a = "A"
         if(m_util_s.str.is_string(a, str_a) && str_a.length() == 1) {
             // s = emp -> v = t.a
-            add_axiom({~s_emp, mk_eq(v, mk_concat(t, a),false)});
-            // add_axiom({~mk_literal(m.mk_not(m.mk_eq(s, eps))), mk_eq(v, mk_concat(t, a),false)});
+            // NOTE: if we use ~s_emp, this diseqation does not become relevant
+            add_axiom({mk_literal(m.mk_not(m.mk_eq(s, eps))), mk_eq(v, mk_concat(t, a),false)});
             // s = a -> v = t
             // NOTE: if we use ~mk_eq(s, a), this diseqation does not become relevant
-            add_axiom({~mk_eq(s, a, false), mk_eq(v, t,false)});
+            add_axiom({mk_literal(m.mk_not(m.mk_eq(s, a))), mk_eq(v, t,false)});
+            // add_axiom({~mk_eq(s, a, false), mk_eq(v, t,false)});
             // s != eps && s != a -> v = a
             add_axiom({mk_eq(s, a, false), s_emp, mk_eq(v, a,false)});
             // replace(a,s,t) = v
@@ -1432,7 +1426,7 @@ namespace smt::noodler {
         // str.replace "" s t where a = ""
         } else if(m_util_s.str.is_string(a, str_a) && str_a.length() == 0) {
             // s = emp -> v = t.a
-            add_axiom({~s_emp, mk_eq(v,t,false)});
+            add_axiom({mk_literal(m.mk_not(m.mk_eq(s, eps))), mk_eq(v,t,false)});
             // s = emp -> v = t.a
             add_axiom({s_emp, mk_eq_empty(v)});
             // replace(a,s,t) = v

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1011,12 +1011,11 @@ namespace smt::noodler {
         literal_vector lv;
         for (const auto &l : ls) {
             if (l != null_literal && l != false_literal) {
-                expr_ref ex{ctx.literal2expr(l), m};
+                expr_ref ex = ctx.literal2expr(l);
                 // if the expression is not internalized, internalize it and make relevant
                 if(!ctx.e_internalized(ex)) {
-                    ctx.internalize(ex, false);
-                    enode *const n = ctx.get_enode(ex);
-                    ctx.mark_as_relevant(n);
+                    // TODO: when I set the second argument to false; I got assertion violation.
+                    ctx.internalize(ex, true);
                 }
                 
                 ctx.mark_as_relevant(l);

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1880,7 +1880,12 @@ namespace smt::noodler {
         expr *x = nullptr, *y = nullptr;
         VERIFY(m_util_s.str.is_contains(e, x, y));
         STRACE("str", tout  << "assign not(contains) " << mk_pp(e, m) << std::endl;);
-        m_not_contains_todo.push_back({{x, m},{y, m}});
+
+        zstring s;
+        // not(contains) was not axiomatized in handle_not_contains
+        if(!m_util_s.str.is_string(y) && !(m_util_s.str.is_string(x, s) && s.length() == 1)) {
+            m_not_contains_todo.push_back({{x, m},{y, m}});
+        }
     }
 
     void theory_str_noodler::handle_in_re(expr *const e, const bool is_true) {

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -997,6 +997,14 @@ namespace smt::noodler {
         literal_vector lv;
         for (const auto &l : ls) {
             if (l != null_literal && l != false_literal) {
+                expr_ref ex{ctx.literal2expr(l), m};
+                // if the expression is not internalized, internalize it and make relevant
+                if(!ctx.e_internalized(ex)) {
+                    ctx.internalize(ex, false);
+                    enode *const n = ctx.get_enode(ex);
+                    ctx.mark_as_relevant(n);
+                }
+                
                 ctx.mark_as_relevant(l);
                 lv.push_back(l);
             }
@@ -1397,10 +1405,11 @@ namespace smt::noodler {
         // str.replace "A" s t where a = "A"
         if(m_util_s.str.is_string(a, str_a) && str_a.length() == 1) {
             // s = emp -> v = t.a
-            add_axiom({mk_literal(m.mk_not(m.mk_eq(s, eps))), mk_eq(v, mk_concat(t, a),false)});
+            add_axiom({~s_emp, mk_eq(v, mk_concat(t, a),false)});
+            // add_axiom({~mk_literal(m.mk_not(m.mk_eq(s, eps))), mk_eq(v, mk_concat(t, a),false)});
             // s = a -> v = t
             // NOTE: if we use ~mk_eq(s, a), this diseqation does not become relevant
-            add_axiom({mk_literal(m.mk_not(m.mk_eq(s, a))), mk_eq(v, t,false)});
+            add_axiom({~mk_eq(s, a, false), mk_eq(v, t,false)});
             // s != eps && s != a -> v = a
             add_axiom({mk_eq(s, a, false), s_emp, mk_eq(v, a,false)});
             // replace(a,s,t) = v

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -945,7 +945,7 @@ namespace smt::noodler {
         ast_manager &m = get_manager();
         context &ctx = get_context();
         expr_ref ex{e, m};
-        m_rewrite(ex);
+        // m_rewrite(ex);
         if (!ctx.e_internalized(ex)) {
             ctx.internalize(ex, false);
         }
@@ -1389,6 +1389,7 @@ namespace smt::noodler {
         expr_ref y = mk_str_var_fresh("replace_right");
         expr_ref xty = mk_concat(x, mk_concat(t, y));
         expr_ref xsy = mk_concat(x, mk_concat(s, y));
+        expr_ref eps(m_util_s.str.mk_string(""), m);
         literal a_emp = mk_eq_empty(a);
         literal s_emp = mk_eq_empty(s);
 
@@ -1396,7 +1397,7 @@ namespace smt::noodler {
         // str.replace "A" s t where a = "A"
         if(m_util_s.str.is_string(a, str_a) && str_a.length() == 1) {
             // s = emp -> v = t.a
-            add_axiom({~s_emp, mk_eq(v, mk_concat(t, a),false)});
+            add_axiom({mk_literal(m.mk_not(m.mk_eq(s, eps))), mk_eq(v, mk_concat(t, a),false)});
             // s = a -> v = t
             // NOTE: if we use ~mk_eq(s, a), this diseqation does not become relevant
             add_axiom({mk_literal(m.mk_not(m.mk_eq(s, a))), mk_eq(v, t,false)});

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1220,7 +1220,7 @@ namespace smt::noodler {
             return;
         }
 
-        // check the form str.substr "B" x y
+        // check the form str.substr "B" i l
         zstring str_s;
         if(m_util_s.str.is_string(s, str_s) && str_s.length() == 1) {
             expr_ref zero(m_util_a.mk_int(0), m);
@@ -1228,12 +1228,23 @@ namespace smt::noodler {
             expr_ref eps(m_util_s.str.mk_string(""), m);
 
             literal i_eq_0 = mk_literal(m_util_a.mk_eq(i, zero));
+            literal i_ge_0 = mk_literal(m_util_a.mk_ge(i, zero));
+            literal l_eq_0 = mk_literal(m_util_a.mk_eq(l, zero));
             literal i_ge_1 = mk_literal(m_util_a.mk_ge(i, one));
             literal l_ge_1 = mk_literal(m_util_a.mk_ge(l, one));
+            literal l_ge_0 = mk_literal(m_util_a.mk_ge(l, zero));
 
-            add_axiom({~i_eq_0, ~l_ge_1, mk_eq(v, s, false)});
-            add_axiom({~i_ge_1, mk_eq(v, eps, false)});
-            add_axiom({~i_eq_0, l_ge_1, mk_eq(v, eps, false)});
+            // i < 0 -> v = eps
+            add_axiom({i_ge_0, mk_eq(v, eps, false)});
+            // l < 0 -> v = eps
+            add_axiom({l_ge_0, mk_eq(v, eps, false)});
+            // l >= 0 && i = 0 && i >= 1 -> v = eps
+            add_axiom({~l_ge_0, ~i_eq_0, ~l_ge_1, mk_eq(v, s, false)});
+            // l >= 0 && i >= 1 -> v = eps
+            add_axiom({~l_ge_0, ~i_ge_1, mk_eq(v, eps, false)});
+            // l >= 0 && i = 0 && l < 1 -> v = eps
+            add_axiom({~l_ge_0, ~i_eq_0, l_ge_1, mk_eq(v, eps, false)});
+            // substr(s, i, l) = v
             add_axiom({mk_eq(v, e, false)});
             this->predicate_replace.insert(e, v.get());
             return;

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -277,6 +277,9 @@ namespace smt::noodler {
 
         /**
          * @brief Check if the length formula @p len_formula is satisfiable with the existing length constraints.
+         * 
+         * @param[out] unsat_core If this parameter is NOT nullptr, the LIA solver stores here unsat core of 
+         * the current @p len_formula. If the parameter is nullptr, the unsat core is not computed.
          */
         lbool check_len_sat(expr_ref len_formula, expr_ref* unsat_core=nullptr);
 

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -95,6 +95,7 @@ namespace smt::noodler {
         vector<expr_pair> m_word_diseq_todo_rel; // pair contains left and right side of the disequality
         vector<expr_pair_flag> m_lang_eq_or_diseq_todo_rel; // contains and right side of the (dis)equality and a flag - true -> equality, false -> diseq
         vector<expr_pair_flag> m_membership_todo_rel; // contains the variable and reg. lang. + flag telling us if it is negated (false -> negated)
+        vector<expr_pair> m_not_contains_todo_rel; // not contains
 
     public:
         char const * get_name() const override { return "noodler"; }

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -278,7 +278,7 @@ namespace smt::noodler {
         /**
          * @brief Check if the length formula @p len_formula is satisfiable with the existing length constraints.
          */
-        lbool check_len_sat(expr_ref len_formula);
+        lbool check_len_sat(expr_ref len_formula, expr_ref* unsat_core=nullptr);
 
         /**
          * @brief Blocks current SAT assignment for given @p len_formula

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -44,6 +44,14 @@ namespace smt::noodler {
     class theory_str_noodler : public theory {
     protected:
 
+        /**
+         * Structure for storing items for the loop protection.
+         */
+        struct stored_instance {
+            expr_ref lengths; // length formula 
+            bool initial_length; // was the length formula obtained from the initial length checking?
+        };
+
         int m_scope_level = 0;
         const theory_str_noodler_params& m_params;
         th_rewriter m_rewrite;
@@ -69,7 +77,7 @@ namespace smt::noodler {
         obj_hashtable<expr> propgated_string_theory;
         obj_hashtable<expr> m_has_length;          // is length applied
         expr_ref_vector     m_length;             // length applications themselves
-        std::vector<std::pair<expr_ref, expr_ref>> axiomatized_instances;
+        std::vector<std::pair<expr_ref, stored_instance>> axiomatized_instances;
 
         // TODO what are these?
         vector<std::pair<obj_hashtable<expr>,std::vector<app_ref>>> len_state;
@@ -289,9 +297,13 @@ namespace smt::noodler {
         /**
          * @brief Blocks current SAT assignment for given @p len_formula
          * 
+         * @param len_formula Length formula corresponding to the current instance
+         * @param add_axiomatized Add item to the vector of axiomatized instances (for the loop protection)
+         * @param init_lengths Was the length formula obtained from the initial length checking (for the fool protection)
+         * 
          * TODO explain better
          */
-        void block_curr_len(expr_ref len_formula);
+        void block_curr_len(expr_ref len_formula, bool add_axiomatized = true, bool init_lengths = false);
 
         /***************** FINAL_CHECK_EH HELPING FUNCTIONS END *******************/
     };

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -201,6 +201,9 @@ namespace smt::noodler {
         void handle_not_contains(expr *e);
         void handle_in_re(expr *e, bool is_true);
 
+        // methods for assigning boolean values to predicates
+        void assign_not_contains(expr *e);
+
         void set_conflict(const literal_vector& ls);
 
         expr_ref construct_refinement();

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -116,19 +116,19 @@ namespace smt::noodler {
         AutAssignment aut_assignment{};
         aut_assignment.set_alphabet(noodler_alphabet);
         for (const auto &word_equation: m_membership_todo_rel) {
-            const expr_ref& variable{ std::get<0>(word_equation) };
-            assert(is_app(variable));
-            const auto& variable_app{ to_app(variable) };
-            assert(variable_app->get_num_args() == 0);
-            const auto& variable_name{ variable_app->get_decl()->get_name().str() };
-            BasicTerm variable_term{ BasicTermType::Variable, variable_name };
-            if(m_util_s.str.is_string(variable_app)) {
-                variable_term = BasicTerm(BasicTermType::Literal, variable_name);
+            const expr_ref& var_expr{ std::get<0>(word_equation) };
+            assert(is_app(var_expr));
+            const auto& var_app{ to_app(var_expr) };
+            assert(var_app->get_num_args() == 0);
+            const std::string& variable_name{ var_app->get_decl()->get_name().str() };
+            BasicTerm term{ BasicTermType::Variable, variable_name };
+            if(m_util_s.str.is_string(var_app)) {
+                term = BasicTerm(BasicTermType::Literal, variable_name);
             }
             // If the regular constraint is in a negative form, create a complement of the regular expression instead.
             const bool make_complement{ !std::get<2>(word_equation) };
             Nfa nfa{ util::conv_to_nfa(to_app(std::get<1>(word_equation)), m_util_s, m, noodler_alphabet, make_complement, make_complement) };
-            auto aut_ass_it{ aut_assignment.find(variable_term) };
+            auto aut_ass_it{ aut_assignment.find(term) };
             if (aut_ass_it != aut_assignment.end()) {
                 // This variable already has some regular constraints. Hence, we create an intersection of the new one
                 //  with the previously existing.
@@ -136,9 +136,9 @@ namespace smt::noodler {
                         Mata::Nfa::reduce(Mata::Nfa::intersection(nfa, *aut_ass_it->second)));
 
             } else { // We create a regular constraint for the current variable for the first time.
-                aut_assignment[variable_term] = std::make_shared<Nfa>(std::forward<Nfa>(std::move(nfa)));
+                aut_assignment[term] = std::make_shared<Nfa>(std::forward<Nfa>(std::move(nfa)));
                 // TODO explain after this function is moved to theory_str_noodler, we do this because var_name contains only variables occuring in instance and not those that occur only in str.in_re
-                var_name.insert({variable_term, variable});
+                this->var_name.insert({term, var_expr});
             }
         }
 

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -121,8 +121,10 @@ namespace smt::noodler {
             const auto& variable_app{ to_app(variable) };
             assert(variable_app->get_num_args() == 0);
             const auto& variable_name{ variable_app->get_decl()->get_name().str() };
-            // TODO are we sure that variable is really variable and not string literal? i.e. can Z3 give us `string literal in RE`?
-            const BasicTerm variable_term{ BasicTermType::Variable, variable_name };
+            BasicTerm variable_term{ BasicTermType::Variable, variable_name };
+            if(m_util_s.str.is_string(variable_app)) {
+                variable_term = BasicTerm(BasicTermType::Literal, variable_name);
+            }
             // If the regular constraint is in a negative form, create a complement of the regular expression instead.
             const bool make_complement{ !std::get<2>(word_equation) };
             Nfa nfa{ util::conv_to_nfa(to_app(std::get<1>(word_equation)), m_util_s, m, noodler_alphabet, make_complement, make_complement) };

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -121,9 +121,11 @@ namespace smt::noodler {
             const auto& var_app{ to_app(var_expr) };
             assert(var_app->get_num_args() == 0);
             const std::string& variable_name{ var_app->get_decl()->get_name().str() };
+
+            zstring s;
             BasicTerm term{ BasicTermType::Variable, variable_name };
-            if(m_util_s.str.is_string(var_app)) {
-                term = BasicTerm(BasicTermType::Literal, variable_name);
+            if(m_util_s.str.is_string(var_app, s)) {
+                term = BasicTerm(BasicTermType::Literal, s.encode());
             }
             // If the regular constraint is in a negative form, create a complement of the regular expression instead.
             const bool make_complement{ !std::get<2>(word_equation) };

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -269,7 +269,7 @@ namespace smt::noodler {
         return ret;
     }
 
-    void theory_str_noodler::block_curr_len(expr_ref len_formula) {
+    void theory_str_noodler::block_curr_len(expr_ref len_formula, bool add_axiomatized, bool init_lengths) {
         STRACE("str-block", tout << __LINE__ << " enter " << __FUNCTION__ << std::endl;);
 
         context& ctx = get_context();
@@ -300,8 +300,8 @@ namespace smt::noodler {
             refinement = refinement == nullptr ? in_app : m.mk_and(refinement, in_app);
         }
         
-        if(m_params.m_loop_protect) {
-            this->axiomatized_instances.push_back({expr_ref(refinement, this->m), len_formula});
+        if(m_params.m_loop_protect && add_axiomatized) {
+            this->axiomatized_instances.push_back({expr_ref(refinement, this->m), stored_instance{ .lengths = len_formula, .initial_length = init_lengths}});
         }
         if (refinement != nullptr) {
             add_axiom(m.mk_or(m.mk_not(refinement), len_formula));

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -241,7 +241,7 @@ namespace smt::noodler {
         return l_false;
     }
 
-    lbool theory_str_noodler::check_len_sat(expr_ref len_formula) {
+    lbool theory_str_noodler::check_len_sat(expr_ref len_formula, expr_ref* unsat_core) {
         if (len_formula == m.mk_true()) {
             // we assume here that existing length constraints are satisfiable, so adding true will do nothing
             return l_true;
@@ -255,6 +255,13 @@ namespace smt::noodler {
         }
         m_int_solver.initialize(get_context(), include_ass);
         auto ret = m_int_solver.check_sat(len_formula);
+        // construct an unsat core --> might be expensive
+        // TODO: better interface of m_int_solver
+        if(unsat_core != nullptr) {
+            for(unsigned i=0;i<m_int_solver.m_kernel.get_unsat_core_size();i++){
+                *unsat_core = m.mk_and(*unsat_core, m_int_solver.m_kernel.get_unsat_core_expr(i));
+            }
+        }
         return ret;
     }
 

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -43,6 +43,15 @@ namespace smt::noodler {
             instance.add_predicate(inst);
         }
 
+        // construct not contains predicates
+        for(const auto& not_contains : this->m_not_contains_todo_rel) {
+            std::vector<BasicTerm> left, right;
+            util::collect_terms(to_app(not_contains.first), m, this->m_util_s, this->predicate_replace, this->var_name, left);
+            util::collect_terms(to_app(not_contains.second), m, this->m_util_s, this->predicate_replace, this->var_name, right);
+            Predicate inst(PredicateType::NotContains, std::vector<Concat>{left, right});
+            instance.add_predicate(inst);
+        }
+
         return instance;
     }
 
@@ -61,6 +70,11 @@ namespace smt::noodler {
 
         for (const auto &membership: m_membership_todo_rel) {
             util::extract_symbols(std::get<1>(membership), m_util_s, m, symbols_in_formula);
+        }
+        // extract from not contains
+        for(const auto& not_contains : m_not_contains_todo_rel) {
+            util::extract_symbols(not_contains.first, m_util_s, m, symbols_in_formula);
+            util::extract_symbols(not_contains.second, m_util_s, m, symbols_in_formula);
         }
 
         /* Get number of dummy symbols needed for disequations and 'x not in RE' predicates.


### PR DESCRIPTION
This PR updates:

- predicate instantiation for special cases. In particular `substr` and `replace`
- improvement of loop protection, which now generates a theory lemma from unsat core
- basic infrastructure for not(contains) handling inside a decision procedure
- support for not(contains) where the first argument is literal
- various bug fixes and improvements