### PR TITLE
Pyex: optimizations

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -1451,6 +1451,9 @@ br_status seq_rewriter::mk_seq_contains(expr* a, expr* b, expr_ref& result) {
         }
     }
 
+    // This is for Z3-Noodler as it may itroduce seq.unit functions, which are not supported
+    return BR_FAILED;
+
     unsigned offs = 0;
     unsigned sz = as.size();
     expr* b0 = bs.get(0);

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -1843,13 +1843,14 @@ br_status seq_rewriter::mk_seq_index(expr* a, expr* b, expr* c, expr_ref& result
     default:
         break;
     }
-    if (is_zero && !as.empty() && str().is_unit(as.get(0))) {
-        expr_ref a1(str().mk_concat(as.size() - 1, as.data() + 1, as[0]->get_sort()), m());
-        expr_ref b1(str().mk_index(a1, b, c), m());
-        result = m().mk_ite(str().mk_prefix(b, a), zero(), 
-                            m().mk_ite(m_autil.mk_ge(b1, zero()), m_autil.mk_add(one(), b1), minus_one()));
-        return BR_REWRITE3;
-    }
+    // REWRITES
+    // if (is_zero && !as.empty() && str().is_unit(as.get(0))) {
+    //     expr_ref a1(str().mk_concat(as.size() - 1, as.data() + 1, as[0]->get_sort()), m());
+    //     expr_ref b1(str().mk_index(a1, b, c), m());
+    //     result = m().mk_ite(str().mk_prefix(b, a), zero(), 
+    //                         m().mk_ite(m_autil.mk_ge(b1, zero()), m_autil.mk_add(one(), b1), minus_one()));
+    //     return BR_REWRITE3;
+    // }
     expr_ref ra(a, m());
     if (str().is_unit(b) && m().is_value(b) && 
         reduce_by_char(ra, b, 4)) {

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -1846,7 +1846,7 @@ br_status seq_rewriter::mk_seq_index(expr* a, expr* b, expr* c, expr_ref& result
     default:
         break;
     }
-    // REWRITES
+    // FIXME: Not suitable for Z3-Noodler as it itroduces ite constructs inside predicates.
     // if (is_zero && !as.empty() && str().is_unit(as.get(0))) {
     //     expr_ref a1(str().mk_concat(as.size() - 1, as.data() + 1, as[0]->get_sort()), m());
     //     expr_ref b1(str().mk_index(a1, b, c), m());

--- a/src/smt/CMakeLists.txt
+++ b/src/smt/CMakeLists.txt
@@ -76,6 +76,7 @@ z3_add_component(smt
     theory_str_noodler/nielsen_decision_procedure.cpp
     theory_str_noodler/formula.cpp
     theory_str_noodler/util.cc
+    theory_str_noodler/expr_cases.cpp
     theory_str_noodler/regex.cpp
     theory_str_noodler/aut_assignment.cpp
     theory_str_mc.cpp

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -141,7 +141,7 @@ namespace smt::noodler {
                 len = cmp.num_of_states() - 1;
             else 
                 len = -1;
-            return cmp.num_of_states() == cmp.delta.num_of_transitions() + 1;
+            return (cmp.num_of_states() == cmp.delta.num_of_transitions() + 1) && (cmp.final.size() == 1);
         }
 
         /**

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -197,6 +197,9 @@ namespace smt::noodler {
          */
         bool is_sat() const {
             for (const auto& pr : *this) {
+                if(pr.second->final.size() == 0) {
+                    return false;
+                }
                 if(pr.second->is_lang_empty())
                     return false;
             }

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -160,6 +160,19 @@ namespace smt::noodler {
         }
 
         /**
+         * @brief Check if the given terms have disjoint languages.
+         * 
+         * @param t1 First term
+         * @param t2 Second term
+         * @return true <-> L(t1) and L(t2) are disjoint.
+         */
+        bool are_disjoint(const BasicTerm &t1, const BasicTerm& t2) const {
+            mata::nfa::Nfa aut_t1 = *this->at(t1);
+            mata::nfa::Nfa aut_t2 = *this->at(t2);
+            return  mata::nfa::intersection(aut_t1, aut_t2).is_lang_empty();
+        }
+
+        /**
          * @brief Check if the language of the basic term has a fixed length
          * 
          * @param t BasicTerm

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -786,6 +786,9 @@ namespace smt::noodler {
             prep_handler.underapprox_languages();
         }
         prep_handler.propagate_eps();
+        // Refinement of languages is beneficial only for instances containing not(contains) or disequalities (it is used to reduce the number of 
+        // disequations/not(contains). For a strong reduction you need to have languages as precise as possible). In the case of 
+        // pure equalitities it could create bigger automata, which may be problem later during the noodlification.
         if(this->formula.contains_type(PredicateType::Inequation) || this->not_contains.get_predicates().size() > 0) {
             // Refine languages is applied in the order given by the predicates. Single iteration 
             // might not update crucial variables that could contradict the formula. 
@@ -797,6 +800,8 @@ namespace smt::noodler {
         prep_handler.propagate_eps();
         prep_handler.infer_alignment();
         prep_handler.remove_regular();
+        // Skip_len_sat is not compatible with not(contains) as the preprocessing may skip equations with variables 
+        // inside not(contains). (Note that if opt == PreprocessType::UNDERAPPROX, there is no not(contains)).
         if(this->not_contains.get_predicates().empty()) {
             prep_handler.skip_len_sat();
         }
@@ -1029,7 +1034,7 @@ namespace smt::noodler {
     }
 
     /**
-     * @brief Syntactically unify not contains terms. If they are included (in the sense of vectors) the 
+     * @brief Check if it is possible to syntactically unify not contains terms. If they are included (in the sense of vectors) the 
      * not(contain) is unsatisfiable.
      * 
      * @param prep FormulaPreprocessor

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -853,7 +853,7 @@ namespace smt::noodler {
         }
 
         // try to replace the not contains predicates (so-far we replace it by regular constraints)
-        if(replace_not_contains() == l_false || can_unify_not_contains(prep_handler) == l_false) {
+        if(replace_not_contains() == l_false || can_unify_not_contains(prep_handler) == l_true) {
             return l_false;
         }
 
@@ -1038,12 +1038,12 @@ namespace smt::noodler {
      * not(contain) is unsatisfiable.
      * 
      * @param prep FormulaPreprocessor
-     * @return l_false -> unsatisfiable 
+     * @return l_true -> can be unified
      */
     lbool DecisionProcedure::can_unify_not_contains(const FormulaPreprocessor& prep) {
         for(const Predicate& pred : this->not_contains.get_predicates()) {
             if(prep.can_unify_contain(pred.get_params()[0], pred.get_params()[1])) {
-                return l_false;
+                return l_true;
             }
 
         }

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -786,6 +786,7 @@ namespace smt::noodler {
         }
         prep_handler.propagate_variables();
         prep_handler.propagate_eps();
+        prep_handler.infer_alignment();
         prep_handler.remove_regular();
         if(this->not_contains.get_predicates().empty()) {
             prep_handler.skip_len_sat();
@@ -810,6 +811,7 @@ namespace smt::noodler {
             }   
         );
         prep_handler.generate_equiv(len_eq_vars);
+        prep_handler.common_prefix_propagation();
         prep_handler.propagate_variables();
         prep_handler.generate_identities();
         prep_handler.remove_regular();

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -787,7 +787,9 @@ namespace smt::noodler {
         prep_handler.propagate_variables();
         prep_handler.propagate_eps();
         prep_handler.remove_regular();
-        prep_handler.skip_len_sat();
+        if(this->not_contains.get_predicates().empty()) {
+            prep_handler.skip_len_sat();
+        }
         prep_handler.generate_identities();
         prep_handler.propagate_variables();
         prep_handler.refine_languages();

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -800,9 +800,9 @@ namespace smt::noodler {
         prep_handler.propagate_eps();
         prep_handler.infer_alignment();
         prep_handler.remove_regular();
-        // Skip_len_sat is not compatible with not(contains) as the preprocessing may skip equations with variables 
-        // inside not(contains). (Note that if opt == PreprocessType::UNDERAPPROX, there is no not(contains)).
-        if(this->not_contains.get_predicates().empty()) {
+        // Skip_len_sat is not compatible with not(contains) and conversions as the preprocessing may skip equations with variables 
+        // inside not(contains)/conversion. (Note that if opt == PreprocessType::UNDERAPPROX, there is no not(contains)).
+        if(this->not_contains.get_predicates().empty() && this->conversions.empty()) {
             prep_handler.skip_len_sat();
         }
         prep_handler.generate_identities();

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -820,6 +820,8 @@ namespace smt::noodler {
             prep_handler.remove_regular();
             prep_handler.skip_len_sat();
         }
+        prep_handler.reduce_regular_sequence(1);
+        prep_handler.remove_regular();
 
         // Refresh the instance
         this->formula = prep_handler.get_modified_formula();

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -789,7 +789,7 @@ namespace smt::noodler {
         // Refinement of languages is beneficial only for instances containing not(contains) or disequalities (it is used to reduce the number of 
         // disequations/not(contains). For a strong reduction you need to have languages as precise as possible). In the case of 
         // pure equalitities it could create bigger automata, which may be problem later during the noodlification.
-        if(this->formula.contains_type(PredicateType::Inequation) || this->not_contains.get_predicates().size() > 0) {
+        if(this->formula.contains_pred_type(PredicateType::Inequation) || this->not_contains.get_predicates().size() > 0) {
             // Refine languages is applied in the order given by the predicates. Single iteration 
             // might not update crucial variables that could contradict the formula. 
             // Two iterations seem to be a good trade-off since the automata could explode in the fixpoint.

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -786,8 +786,10 @@ namespace smt::noodler {
             prep_handler.underapprox_languages();
         }
         prep_handler.propagate_eps();
-        prep_handler.refine_languages();
-        prep_handler.refine_languages();
+        if(this->formula.contains_type(PredicateType::Inequation) || this->not_contains.get_predicates().size() > 0) {
+            prep_handler.refine_languages();
+            prep_handler.refine_languages();
+        }
         prep_handler.propagate_variables();
         prep_handler.propagate_eps();
         prep_handler.infer_alignment();

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -341,6 +341,15 @@ namespace smt::noodler {
          */
         lbool replace_not_contains();
 
+        /**
+         * @brief Syntactically unify not contains terms. If they they are included (in the sense of vectors) the 
+         * not(contain) is unsatisfiable.
+         * 
+         * @param prep FormulaPreprocessor
+         * @return l_false -> unsatisfiable 
+         */
+        lbool unify_not_contains(const FormulaPreprocessor& prep);
+
     public:
         
         /**

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -343,7 +343,7 @@ namespace smt::noodler {
         lbool replace_not_contains();
 
         /**
-         * @brief Check if it is possible to syntactically unify not contains terms. If they they are included (in the sense of vectors) the 
+         * @brief Check if it is possible to syntactically unify not contains terms. If they are included (in the sense of vectors) the 
          * not(contain) is unsatisfiable.
          * 
          * @param prep FormulaPreprocessor

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -30,6 +30,9 @@ namespace smt::noodler {
         FROM_INT,
     };
 
+    // Term conversion: to_int/from_int ...
+    using TermConversion = std::tuple<BasicTerm,BasicTerm,ConversionType>;
+
     inline std::string get_conversion_name(ConversionType type) {
         switch (type)
         {
@@ -307,7 +310,7 @@ namespace smt::noodler {
         Formula formula;
         AutAssignment init_aut_ass;
         // contains to/from_code/int conversions
-        std::vector<std::tuple<BasicTerm,BasicTerm,ConversionType>> conversions;
+        std::vector<TermConversion> conversions;
 
         // the length formula from preprocessing, get_lengths should create conjunct with it
         LenNode preprocessing_len_formula = LenNode(LenFormulaType::TRUE,{});
@@ -370,7 +373,7 @@ namespace smt::noodler {
              Formula formula, AutAssignment init_aut_ass,
              std::unordered_set<BasicTerm> init_length_sensitive_vars,
              const theory_str_noodler_params &par,
-             std::vector<std::tuple<BasicTerm,BasicTerm,ConversionType>> conversions
+             std::vector<TermConversion> conversions
         ) : init_length_sensitive_vars(init_length_sensitive_vars),
             formula(formula),
             init_aut_ass(init_aut_ass),

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -347,7 +347,7 @@ namespace smt::noodler {
          * not(contain) is unsatisfiable.
          * 
          * @param prep FormulaPreprocessor
-         * @return l_false -> unsatisfiable 
+         * @return l_true -> can be unified 
          */
         lbool can_unify_not_contains(const FormulaPreprocessor& prep);
 

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -339,7 +339,7 @@ namespace smt::noodler {
         /**
          * @brief Construct constraints to get rid of not_contains predicates.
          */
-        void replace_not_contains();
+        lbool replace_not_contains();
 
     public:
         

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -348,7 +348,7 @@ namespace smt::noodler {
          * @param prep FormulaPreprocessor
          * @return l_false -> unsatisfiable 
          */
-        lbool unify_not_contains(const FormulaPreprocessor& prep);
+        lbool can_unify_not_contains(const FormulaPreprocessor& prep);
 
     public:
         

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -338,11 +338,12 @@ namespace smt::noodler {
 
         /**
          * @brief Construct constraints to get rid of not_contains predicates.
+         * @return l_false -> unsatisfiable constaint; l_undef if it is not evident
          */
         lbool replace_not_contains();
 
         /**
-         * @brief Syntactically unify not contains terms. If they they are included (in the sense of vectors) the 
+         * @brief Check if it is possible to syntactically unify not contains terms. If they they are included (in the sense of vectors) the 
          * not(contain) is unsatisfiable.
          * 
          * @param prep FormulaPreprocessor

--- a/src/smt/theory_str_noodler/expr_cases.cpp
+++ b/src/smt/theory_str_noodler/expr_cases.cpp
@@ -1,0 +1,36 @@
+#include <cassert>
+
+#include "util/z3_exception.h"
+
+#include "util.h"
+#include "theory_str_noodler.h"
+#include "inclusion_graph.h"
+#include "aut_assignment.h"
+
+namespace {
+    using mata::nfa::Nfa;
+}
+
+namespace smt::noodler::expr_cases {
+
+bool is_contains_index(expr* e, expr*& ind, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a) {
+    // e.g. (str.contains (str.substr value2 0 (+ n (str.indexof value2 "A" 0))) "A")
+    expr *subs = nullptr, *val = nullptr, *val_ind = nullptr, *str = nullptr, *str_ind = nullptr, *offset_ind = nullptr;
+    if(m_util_s.str.is_contains(e, subs, val)) {     // subs = (str.substr value2 0 (+ n (str.indexof value2 "A" 0)))
+        expr *subb1 = nullptr, *subb2 = nullptr, *num = nullptr;
+        rational num_val; //n
+        if(m_util_s.str.is_extract(subs, str, subb1, subb2)) {
+            if(m_util_a.is_zero(subb1) && m_util_a.is_add(subb2, num, ind) && m_util_a.is_numeral(num, num_val) && num_val.get_int32() > 0) { 
+                if(m_util_s.str.is_index(ind, str_ind, val_ind) || (m_util_s.str.is_index(ind, str_ind, val_ind, offset_ind) && m_util_a.is_zero(offset_ind))) {
+                    if(str->hash() != str_ind->hash() || val->hash() != val_ind->hash()) {
+                        return false;
+                    }
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+}

--- a/src/smt/theory_str_noodler/expr_cases.h
+++ b/src/smt/theory_str_noodler/expr_cases.h
@@ -1,0 +1,46 @@
+#ifndef _NOODLER_EXPR_CASES_H_
+#define _NOODLER_EXPR_CASES_H_
+
+#include <functional>
+#include <list>
+#include <set>
+#include <stack>
+#include <map>
+#include <memory>
+#include <queue>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "smt/params/smt_params.h"
+#include "ast/arith_decl_plugin.h"
+#include "ast/seq_decl_plugin.h"
+#include "smt/params/theory_str_params.h"
+#include "smt/smt_kernel.h"
+#include "smt/smt_theory.h"
+#include "smt/smt_arith_value.h"
+#include "util/scoped_vector.h"
+#include "util/union_find.h"
+#include "ast/rewriter/seq_rewriter.h"
+#include "ast/rewriter/th_rewriter.h"
+
+#include "formula.h"
+#include "aut_assignment.h"
+
+namespace smt::noodler::expr_cases {
+
+/**
+ * @brief Check if the given contraint @p e is of the form 
+ * (str.contains (str.substr val 0 (+ n (str.indexof val S 0))) S) where n > 0
+ * 
+ * @param e Constraint to be checked
+ * @param ind Extracted (str.indexof val S 0) term
+ * @param m Ast manager
+ * @param m_util_s string ast util
+ * @param m_util_a arith ast util
+ * @return true <-> if of the particular form.
+ */
+bool is_contains_index(expr* e, expr*& ind, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a);
+
+}
+#endif

--- a/src/smt/theory_str_noodler/formula.cpp
+++ b/src/smt/theory_str_noodler/formula.cpp
@@ -3,7 +3,6 @@
 
 namespace smt::noodler {
     std::set<BasicTerm> Predicate::get_vars() const {
-        assert(is_eq_or_ineq());
         std::set<BasicTerm> vars;
         for (const auto& side: params) {
             for (const auto &term: side) {

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -523,6 +523,15 @@ namespace smt::noodler {
             this->predicates = new_predicates;
         } 
 
+        bool contains_type(PredicateType type) const {
+            for(const Predicate& pred : this->predicates) {
+                if(pred.get_type() == type) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
         /**
          * @brief Get union of variables from all predicates
          *

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -523,7 +523,13 @@ namespace smt::noodler {
             this->predicates = new_predicates;
         } 
 
-        bool contains_type(PredicateType type) const {
+        /**
+         * @brief Does the Formula contain a predicate of a type @p type ?
+         * 
+         * @param type Type of the predicate.
+         * @return true <-> Formula contains predicate of type @p type.
+         */
+        bool contains_pred_type(PredicateType type) const {
             for(const Predicate& pred : this->predicates) {
                 if(pred.get_type() == type) {
                     return true;

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1311,14 +1311,6 @@ namespace smt::noodler {
      */
     void FormulaPreprocessor::common_prefix_propagation() {
         TermReplaceMap replace_map = construct_replace_map();
-        // for(const auto& pr : this->formula.get_predicates()) {
-        //     if(!pr.second.is_equation()) continue;
-        //     if(pr.second.get_left_side().size() != 1) continue;
-
-        //     const BasicTerm &var = pr.second.get_left_side()[0];
-        //     replace_map[var].insert(pr.second.get_right_side());
-        // }
-
         size_t i = 0;
         for(const auto& pr1 : this->formula.get_predicates()) {
             if(!pr1.second.is_equation()) continue;
@@ -1480,7 +1472,8 @@ namespace smt::noodler {
     bool FormulaPreprocessor::can_unify(const Concat& con1, const Concat& con2, const std::function<bool(const Concat&, const Concat&)> &check) const {
         TermReplaceMap replace_map = construct_replace_map();
 
-        // TODO: make as a parameter (although not sure what to do with that)
+        // TODO: make as a parameter (although not sure how to set it in an optimal way). Moreover this algorithm could be 
+        // rewrited using ideas of LL(1) parsing. Then this parameter becomes useless.
         int max_unifs = 4;
         Concat tmp1 = con1;
         Concat tmp2 = con2;

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1180,6 +1180,194 @@ namespace smt::noodler {
     }
 
     /**
+     * @brief Infer equalities from required alignments. For instance for 
+     * X = Y1 "A" Y2
+     * X = Z1 "A" Z2 where "A" not in L(Y1) and "A" not in L(Z1)
+     * infer Y1 = Z1.
+     * 
+     * Works also for a propagated case, for instance
+     * X = Y1 "A" Y2
+     * X = W Z2 
+     * W = Z1 "A" Z3 where "A" not in L(Y1) and "A" not in L(Z1)
+     */
+    void FormulaPreprocessor::infer_alignment() {
+        using VarSeparator = std::map<BasicTerm, std::set<BasicTerm>>;
+        // separators for each variable: map of literals -> set of basic terms: 
+        // for each literal (L) contains terms (T) that preceeds that literal: there is equation ... = T L
+        std::map<BasicTerm, VarSeparator> separators {};
+
+        bool changed = true;
+        while(changed) {
+            changed = false;
+            for(const auto& pr : this->formula.get_predicates()) {
+                if(!pr.second.is_equation()) continue;
+                if(pr.second.get_left_side().size() != 1) continue;
+
+                // base case
+                const Concat& side = pr.second.get_right_side();
+                const BasicTerm& left_var = pr.second.get_left_side()[0];
+                if(pr.second.get_left_side().size() == 1) {
+                    changed = changed || add_var_separator(side, separators[left_var]);
+                }
+
+                // propagation of var separators
+                // for the case X = Y .... -> add separators from Y to X
+                if(side.size() > 0 && side[0] != left_var) {
+                    changed = changed || propagate_var_separators(left_var, side[0], separators);
+                }
+            }
+        }
+
+        // construct new equations from computed separators
+        for(const auto& pr : separators) {
+            for(const auto& a : pr.second) {
+                if(a.second.size() <=  1) continue;
+                BasicTerm fst = *a.second.begin();
+                for(const BasicTerm& dest : a.second) {
+                    if(dest != fst) {
+                        this->formula.add_predicate(Predicate( PredicateType::Equation, {Concat{fst}, Concat{dest}}));
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @brief Propagate variable separators. Add separators from variable @p src to the variable @p dest. 
+     * 
+     * @param dest Variable to be updated
+     * @param src Variable whose separators are copied to @p dest.
+     * @param separators Separators
+     * @return true <-> the propagation added a new element to @p separators.
+     */
+    bool FormulaPreprocessor::propagate_var_separators(const BasicTerm& dest, const BasicTerm& src, std::map<BasicTerm, std::map<BasicTerm, std::set<BasicTerm>>>& separators) {
+        bool changed = false;
+        for(const auto& var_sep: separators[src]) {
+            std::set<BasicTerm>& st = separators[dest][var_sep.first];
+            size_t before = st.size();
+            st.insert(var_sep.second.begin(), var_sep.second.end());
+            changed = changed || st.size() != before;
+        }
+        return changed;
+    }
+
+    /**
+     * @brief Add a new separator to @p container (separators of a variable).
+     * 
+     * @param side Equations side to be used for the update
+     * @param container Separators of a variable
+     * @return true <-> a new element was added to @p container.
+     */
+    bool FormulaPreprocessor::add_var_separator(const Concat& side, std::map<BasicTerm, std::set<BasicTerm>>& container) {
+        if(side.size() < 2) {
+            return false;
+        }
+        if(!side[1].is_literal()) {
+            return false;
+        }
+        if(this->aut_ass.are_disjoint(side[0], side[1])) {
+            if(container[side[1]].contains(side[0])) {
+                return false;
+            }
+            container[side[1]].insert(side[0]);
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * @brief Propagate equations from a common prefix. For instance for
+     * X = W1 W2 Y
+     * X = W1 W2 W3 W4
+     * infer Y = W3 W4.
+     * 
+     * Works also for a propagated case, for instance
+     * X = W1 W2 Y
+     * X = K W3 W4
+     * K = W1 W2
+     * infer Y = W3 W4
+     */
+    void FormulaPreprocessor::common_prefix_propagation() {
+        TermReplaceMap replace_map = construct_replace_map();
+        // for(const auto& pr : this->formula.get_predicates()) {
+        //     if(!pr.second.is_equation()) continue;
+        //     if(pr.second.get_left_side().size() != 1) continue;
+
+        //     const BasicTerm &var = pr.second.get_left_side()[0];
+        //     replace_map[var].insert(pr.second.get_right_side());
+        // }
+
+        size_t i = 0;
+        for(const auto& pr1 : this->formula.get_predicates()) {
+            if(!pr1.second.is_equation()) continue;
+
+            Concat c1 = flatten_concat(pr1.second.get_right_side(), replace_map);
+
+            for(const auto& pr2 : this->formula.get_predicates()) {
+                if(!pr2.second.is_equation()) continue;
+                if(pr1 == pr2) continue;
+                if(pr1.second.get_left_side() != pr2.second.get_left_side()) continue;
+                
+
+                Concat c2 = flatten_concat(pr2.second.get_right_side(), replace_map);
+                // compute the common prefix
+                for(i = 0; i < std::min(c1.size(), c2.size()); i++) {
+                    if(c1[i] != c2[i]) break;
+                }
+                // i is the first mismatching index
+                if(c1.size() == i + 1) {
+                    Predicate new_pred = Predicate(PredicateType::Equation, { Concat{c1[i]}, Concat(c2.begin() + i, c2.end()) });
+                    this->formula.add_predicate(new_pred);
+                } else if (c2.size() == i + 1) {
+                    Predicate new_pred = Predicate(PredicateType::Equation, { Concat{c2[i]}, Concat(c1.begin() + i, c1.end()) });
+                    this->formula.add_predicate(new_pred);
+                }
+            }
+        }
+    }
+
+    /**
+     * @brief Construct replace map. Replace map contains all items of the form X -> {W1 W2, W3, ...} if 
+     * there are quations X = W1 W2, X = W3, ... 
+     * 
+     * @return TermReplaceMap Constructed replace map
+     */
+    TermReplaceMap FormulaPreprocessor::construct_replace_map() const {
+        TermReplaceMap replace_map {};
+        for(const auto& pr : this->formula.get_predicates()) {
+            if(!pr.second.is_equation()) continue;
+            if(pr.second.get_left_side().size() != 1) continue;
+
+            const BasicTerm &var = pr.second.get_left_side()[0];
+            replace_map[var].insert(pr.second.get_right_side());
+        }
+        return replace_map;
+    }
+
+    /**
+     * @brief Flatten the given concatenation @p con according to the replace map. In particular, 
+     * replace all variables in @p con with the corresponding item in @p replace_map. 
+     * Applicable only if there is exactly one corresponding guy in @p replace_map (i.e., does not work 
+     * recursively).
+     * 
+     * @param con Conjunction to be flattened.
+     * @param replace_map Replace map
+     * @return Concat Conjunction with subtituted terms.
+     */
+    Concat FormulaPreprocessor::flatten_concat(const Concat& con, TermReplaceMap& replace_map) {
+        Concat ret {};
+        for(const BasicTerm& bt : con) {
+            if(replace_map[bt].size() == 1) {
+                const Concat& rpl = *replace_map[bt].begin();
+                ret.insert(ret.end(), rpl.begin(), rpl.end());
+            } else {
+                ret.push_back(bt);
+            }
+        }
+        return ret;
+    }
+
+    /**
      * @brief Underapproximates the languages. Replace co-finite languages with length constraints while 
      * setting their languages to \Sigma^*.
      */
@@ -1260,14 +1448,42 @@ namespace smt::noodler {
     }
 
     /**
+     * @brief Heuristicaly check if @p con1 and @p con2 can be unified, meaning that if we replace 
+     * variables with their replacements, can we get that @p con1  == @p con2 ? 
+     * 
+     * @param con1 First conjunction
+     * @param con2 Second conjunction
+     * @return true -> they can be unified
+     */
+    bool FormulaPreprocessor::can_unify(const Concat& con1, const Concat& con2) {
+        TermReplaceMap replace_map = construct_replace_map();
+
+        // TODO: make as a parameter (although not sure what to do with that)
+        int max_unifs = 4;
+        Concat tmp1 = con1;
+        Concat tmp2 = con2;
+        for(int i = 0; i < max_unifs; i++) {
+            tmp2 = con2;
+            for(int j = 0; j < max_unifs; j++) {
+                if(tmp1 == tmp2) {
+                    return true;
+                }
+                tmp2 = flatten_concat(tmp2, replace_map);
+            }
+            tmp1 = flatten_concat(tmp1, replace_map);
+        }
+        return false;
+    }
+
+    /**
      * @brief Check if the instance is clearly unsatisfiable. It checks trivial (dis)equations
      * of the form x != x, ab = cd (x is term, a,b,c,d are constants).
      * 
      * @return True --> unsat for sure.
      */
-    bool FormulaPreprocessor::contains_unsat_eqs_or_diseqs() const {
-        for(const auto& pr : this->formula.get_predicates()) {
-            if(pr.second.is_inequation() && pr.second.get_left_side() == pr.second.get_right_side()) {
+    bool FormulaPreprocessor::contains_unsat_eqs_or_diseqs() {
+        for(const auto& pr : this->formula.get_predicates()) {            
+            if(pr.second.is_inequation() && can_unify(pr.second.get_left_side(), pr.second.get_right_side())) {
                 return true;
             }
             if(pr.second.is_equation() && pr.second.is_str_const()) {

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1152,7 +1152,21 @@ namespace smt::noodler {
                 for(size_t i = 0; i < std::min(pc1.get_right_side().size(), pc2.get_right_side().size()); i++) {
                     BasicTerm t1 = pc1.get_right_side()[i];
                     BasicTerm t2 = pc2.get_right_side()[i];
-                    if(same_length(ec, t1, t2)) {
+                    if(t1 == t2) {
+                        continue;
+                    } else if(same_length(ec, t1, t2)) {
+                        Predicate new_pred(PredicateType::Equation, {Concat({t1}), Concat({t2})});
+                        new_preds.insert(new_pred);
+                    } else {
+                        break;
+                    }
+                }
+                for(size_t i = std::min(pc1.get_right_side().size(), pc2.get_right_side().size()) - 1; i >= 0; i--) {
+                    BasicTerm t1 = pc1.get_right_side()[i];
+                    BasicTerm t2 = pc2.get_right_side()[i];
+                    if(t1 == t2) {
+                        continue;
+                    } else if(same_length(ec, t1, t2)) {
                         Predicate new_pred(PredicateType::Equation, {Concat({t1}), Concat({t2})});
                         new_preds.insert(new_pred);
                     } else {

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -640,6 +640,7 @@ namespace smt::noodler {
                 BasicTerm fresh_var = util::mk_noodler_var_fresh("regular_seq");
                 this->formula.replace(pr.first, Concat({fresh_var}));
                 update_reg_constr(fresh_var, pr.first);
+                this->add_to_len_formula(Predicate(PredicateType::Equation, std::vector<Concat>({Concat({fresh_var}), pr.first})).get_formula_eq());
                 new_eqs.insert(Predicate(PredicateType::Equation, std::vector<Concat>({Concat({fresh_var}), pr.first})));
             }
         }

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1161,9 +1161,11 @@ namespace smt::noodler {
                         break;
                     }
                 }
-                for(size_t i = std::min(pc1.get_right_side().size(), pc2.get_right_side().size()) - 1; i >= 0; i--) {
+
+                size_t i = pc1.get_right_side().size() - 1, j = pc2.get_right_side().size() - 1;
+                for(; i >= 0 && j >= 0; i--, j--) {
                     BasicTerm t1 = pc1.get_right_side()[i];
-                    BasicTerm t2 = pc2.get_right_side()[i];
+                    BasicTerm t2 = pc2.get_right_side()[j];
                     if(t1 == t2) {
                         continue;
                     } else if(same_length(ec, t1, t2)) {

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1162,7 +1162,7 @@ namespace smt::noodler {
                     }
                 }
 
-                size_t i = pc1.get_right_side().size() - 1, j = pc2.get_right_side().size() - 1;
+                int i = int(pc1.get_right_side().size() - 1), j = int(pc2.get_right_side().size() - 1);
                 for(; i >= 0 && j >= 0; i--, j--) {
                     BasicTerm t1 = pc1.get_right_side()[i];
                     BasicTerm t2 = pc2.get_right_side()[j];

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -293,6 +293,8 @@ namespace smt::noodler {
 
     //----------------------------------------------------------------------------------------------------------------------------------
 
+    using TermReplaceMap = std::map<BasicTerm, std::set<Concat>>;
+
     /**
      * @brief Class for formula preprocessing.
      */
@@ -324,6 +326,13 @@ namespace smt::noodler {
         void gather_extended_vars(Predicate::EquationSideType side, std::set<BasicTerm>& res);
 
         bool same_length(const BasicTermEqiv& ec, const BasicTerm&t1, const BasicTerm& t2) const;
+        
+        bool add_var_separator(const Concat& side, std::map<BasicTerm, std::set<BasicTerm>>& container);
+        bool propagate_var_separators(const BasicTerm& dest, const BasicTerm& src, std::map<BasicTerm, std::map<BasicTerm, std::set<BasicTerm>>>& separators);
+        Concat flatten_concat(const Concat& con, std::map<BasicTerm, std::set<Concat>>& replace_map);
+        bool can_unify(const Concat& con1, const Concat& con2);
+        TermReplaceMap construct_replace_map() const;
+
 
     public:
         FormulaPreprocessor(Formula conj, AutAssignment ass, std::unordered_set<BasicTerm> lv, const theory_str_noodler_params &par) :
@@ -359,11 +368,13 @@ namespace smt::noodler {
         void skip_len_sat();
         void underapprox_languages();
         void generate_equiv(const BasicTermEqiv& ec);
+        void infer_alignment();
+        void common_prefix_propagation();
 
         void refine_languages();
         void reduce_diseqalities();
 
-        bool contains_unsat_eqs_or_diseqs() const;
+        bool contains_unsat_eqs_or_diseqs();
 
         /**
          * @brief Replace all occurrences of find with replace. Warning: do not modify the automata assignment.

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -329,8 +329,8 @@ namespace smt::noodler {
         
         bool add_var_separator(const Concat& side, std::map<BasicTerm, std::set<BasicTerm>>& container);
         bool propagate_var_separators(const BasicTerm& dest, const BasicTerm& src, std::map<BasicTerm, std::map<BasicTerm, std::set<BasicTerm>>>& separators);
-        Concat flatten_concat(const Concat& con, std::map<BasicTerm, std::set<Concat>>& replace_map);
-        bool can_unify(const Concat& con1, const Concat& con2);
+        Concat flatten_concat(const Concat& con, std::map<BasicTerm, std::set<Concat>>& replace_map) const;
+        bool can_unify(const Concat& con1, const Concat& con2, const std::function<bool(const Concat&, const Concat&)> &check) const;
         TermReplaceMap construct_replace_map() const;
 
 
@@ -375,6 +375,7 @@ namespace smt::noodler {
         void reduce_diseqalities();
 
         bool contains_unsat_eqs_or_diseqs();
+        bool can_unify_contain(const Concat& left, const Concat& right) const;
 
         /**
          * @brief Replace all occurrences of find with replace. Warning: do not modify the automata assignment.

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1399,7 +1399,7 @@ namespace smt::noodler {
         // s = eps -> |v| = |a| + |t|
         add_axiom({~s_emp, mk_literal(m.mk_eq(m_util_s.str.mk_length(v), m_util_a.mk_add(m_util_s.str.mk_length(a), m_util_s.str.mk_length(t))))});
 
-        zstring str_a;
+        zstring str_a, str_b;
         // str.replace "A" s t where a = "A"
         if(m_util_s.str.is_string(a, str_a) && str_a.length() == 1) {
             // s = emp -> v = t.a
@@ -1443,6 +1443,12 @@ namespace smt::noodler {
         add_axiom({~a_emp, s_emp, mk_eq(v, a, false)});
         // (not(contains(a,s))) -> v = a
         add_axiom({cnt, mk_eq(v, a, false)});
+
+        // if both strings are explicit and cnt holds, extract exact lengths of the result.
+        if(m_util_s.str.is_string(s, str_a) && m_util_s.str.is_string(t, str_b) && str_a.length() >= str_b.length()) {
+            add_axiom({~cnt, mk_literal(m.mk_eq(m_util_s.str.mk_length(v), m_util_a.mk_sub(m_util_s.str.mk_length(a), m_util_a.mk_int(str_a.length() - str_b.length()) )))});
+        }
+        
         // s = eps -> v = t.a
         add_axiom({~s_emp, mk_eq(v, mk_concat(t, a),false)});
         // contains(a,s) && a != eps && s != eps -> a = x.s.y

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -928,6 +928,10 @@ namespace smt::noodler {
         // simplify the expression. This was commented before and it caused 
         // problems at some point, I am not pretty sure of what kind.
         m_rewrite(ex);
+
+        // since ex might be different to e, propagate basic string axioms
+        string_theory_propagation(ex, true);
+
         if (!ctx.e_internalized(ex)) {
             ctx.internalize(ex, false);
         }

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1379,7 +1379,7 @@ namespace smt::noodler {
         literal s_emp = mk_eq_empty(s);
 
         // if s = t -> the result is unchanged
-        add_axiom({mk_eq(s, t, false), mk_eq(v, a,false)});
+        add_axiom({~mk_eq(s, t, false), mk_eq(v, a,false)});
 
         zstring str_a;
         // str.replace "A" s t where a = "A"
@@ -2101,6 +2101,11 @@ namespace smt::noodler {
             }
             refinement = refinement == nullptr ? in_app : m.mk_and(refinement, in_app);
             //STRACE("str", tout << wi.first << " != " << wi.second << '\n';);
+        }
+
+        for(const auto& nc : this->m_not_contains_todo_rel) {
+            app_ref nc_app(m_util_s.str.mk_contains(nc.first, nc.second), m);
+            refinement = refinement == nullptr ? nc_app : m.mk_and(refinement, nc_app);
         }
 
         return expr_ref(refinement, m);

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1390,6 +1390,15 @@ namespace smt::noodler {
             // add_axiom({~mk_eq(s, a, false), mk_eq(v, t,false)});
             // s != eps && s != a -> v = a
             add_axiom({mk_eq(s, a, false), s_emp, mk_eq(v, a,false)});
+            
+
+            // The following axioms are redundant in the sense of completeness, but in the nested replace calls 
+            // they can relate the contains predicate from the general replace (and thence the SAT solver can help a lot).
+            literal cnt = mk_literal(m_util_s.str.mk_contains(a, s));
+            add_axiom({~cnt, mk_eq(v, t,false)});
+            add_axiom({cnt, s_emp, mk_eq(v, a,false)});
+            ctx.force_phase(cnt);
+
             // replace(a,s,t) = v
             add_axiom({mk_eq(v, r, false)});
             predicate_replace.insert(r, v.get());

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1126,7 +1126,7 @@ namespace smt::noodler {
         expr_ref y = mk_str_var_fresh("post_substr");
         expr_ref xe(m_util_s.str.mk_concat(x, v), m);
         expr_ref xey(m_util_s.str.mk_concat(x, v, y), m);
-        
+
         rational rl;
         expr * num_len;
         if(m_util_a.is_numeral(l, rl)) {
@@ -1157,8 +1157,8 @@ namespace smt::noodler {
              this->len_vars.insert(v);
         }
 
-        string_theory_propagation(xe, false, false, true);
-        string_theory_propagation(xey, false, false, true);
+        string_theory_propagation(xe);
+        string_theory_propagation(xey);
         // 0 <= i <= |s| -> xvy = s
         add_axiom({~i_ge_0, ~ls_le_i, mk_eq(xey, s, false)});
         // 0 <= i <= |s| && 0 <= l <= |s| - i -> |v| = l
@@ -1309,8 +1309,8 @@ namespace smt::noodler {
         literal l_ge_zero = mk_literal(m_util_a.mk_ge(l, zero));
         literal ls_le_0 = mk_literal(m_util_a.mk_le(ls, zero));
 
-        string_theory_propagation(xe, false, false, true);
-        string_theory_propagation(xey, false, false, true);
+        string_theory_propagation(xe);
+        string_theory_propagation(xey);
 
         // create axioms in_substri is Sigma
         for(const expr_ref& val : vars) {

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -817,7 +817,7 @@ namespace smt::noodler {
         // Create automata assignment for the formula
         AutAssignment aut_assignment{create_aut_assignment_for_formula(instance, symbols_in_formula)};
 
-        std::vector<std::tuple<BasicTerm,BasicTerm,ConversionType>> conversions = get_conversions_as_basicterms(aut_assignment, symbols_in_formula);
+        std::vector<TermConversion> conversions = get_conversions_as_basicterms(aut_assignment, symbols_in_formula);
 
         // Get the initial length vars that are needed here (i.e they are in aut_assignment)
         std::unordered_set<BasicTerm> init_length_sensitive_vars{ get_init_length_vars(aut_assignment) };
@@ -833,7 +833,7 @@ namespace smt::noodler {
         }
 
         // try underapproximation (if enabled) to solve
-        if(m_params.m_underapproximation && is_underapprox_suitable(instance, aut_assignment)) {
+        if(m_params.m_underapproximation && is_underapprox_suitable(instance, aut_assignment, conversions)) {
             STRACE("str", tout << "Try underapproximation" << std::endl);
             if (solve_underapprox(instance, aut_assignment, init_length_sensitive_vars, conversions) == l_true) {
                 STRACE("str", tout << "Sat from underapproximation" << std::endl;);

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1378,6 +1378,9 @@ namespace smt::noodler {
         literal a_emp = mk_eq_empty(a);
         literal s_emp = mk_eq_empty(s);
 
+        // if s = t -> the result is unchanged
+        add_axiom({mk_eq(s, t, false), mk_eq(v, a,false)});
+
         zstring str_a;
         // str.replace "A" s t where a = "A"
         if(m_util_s.str.is_string(a, str_a) && str_a.length() == 1) {

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1394,7 +1394,7 @@ namespace smt::noodler {
 
             // The following axioms are redundant in the sense of completeness, but in the nested replace calls 
             // they can relate the contains predicate from the general replace (and thence the SAT solver can help a lot).
-            literal cnt = mk_literal(m_util_s.str.mk_contains(a, s));
+            literal cnt = mk_literal(m_util_s.str.mk_contains(s, a));
             add_axiom({~cnt, mk_eq(v, t,false)});
             add_axiom({cnt, s_emp, mk_eq(v, a,false)});
             ctx.force_phase(cnt);

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -304,7 +304,7 @@ namespace smt::noodler {
          * Side effect: string variables in conversions which are not mapped in the automata
          * assignment @p ass will be mapped to sigma* after this.
          */
-        std::vector<std::tuple<BasicTerm,BasicTerm,ConversionType>> get_conversions_as_basicterms(AutAssignment &ass, const std::set<mata::Symbol>& noodler_alphabet);
+        std::vector<TermConversion> get_conversions_as_basicterms(AutAssignment &ass, const std::set<mata::Symbol>& noodler_alphabet);
 
         /**
          * Solves relevant language (dis)equations from m_lang_eq_or_diseq_todo_rel. If some of them
@@ -351,9 +351,10 @@ namespace smt::noodler {
          * 
          * @param instance Current instance converted to Formula
          * @param aut_ass Current automata assignment
+         * @param convs String-Int conversions
          * @return true <-> suitable for underapproximation
          */
-        bool is_underapprox_suitable(const Formula& instance, const AutAssignment& aut_ass) const;
+        bool is_underapprox_suitable(const Formula& instance, const AutAssignment& aut_ass, const std::vector<TermConversion>& convs) const;
 
         /**
          * @brief Wrapper for running the Nielsen transformation.

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -224,9 +224,17 @@ namespace smt::noodler {
         void set_conflict(const literal_vector& ls);
 
         expr_ref construct_refinement();
-        void string_theory_propagation(expr * ex, bool init = false, bool neg = false);
+        /**
+         * @brief Introduce string axioms for a formula @p ex. 
+         * 
+         * @param ex Formula whose terms should be inspected.
+         * @param init Is it an initial string formula (formula from input)?
+         * @param neg Is the formula under negation?
+         * @param var_lengths Introduce lengths axioms for variables of the form x = eps -> |x| = 0? 
+         */
+        void string_theory_propagation(expr * ex, bool init = false, bool neg = false, bool var_lengths = false);
         void propagate_concat_axiom(enode * cat);
-        void propagate_basic_string_axioms(enode * str);
+        void propagate_basic_string_axioms(enode * str, bool var_lengths = false);
 
         /**
          * Creates theory axioms that hold iff either any of the negated assumption from @p neg_assumptions holds,

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -34,6 +34,7 @@ Eternal glory to Yu-Fang.
 #include "decision_procedure.h"
 #include "expr_solver.h"
 #include "util.h"
+#include "expr_cases.h"
 #include "regex.h"
 #include "var_union_find.h"
 #include "nielsen_decision_procedure.h"

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -552,6 +552,8 @@ namespace smt::noodler {
                         block_curr_len(len_formula, false);
                         STRACE("str", tout << "loop-protection: unsat " << std::endl;);
                         return l_false;
+                    } else { // returns SAT
+                        return l_true;
                     }
                 }
             }

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -560,8 +560,6 @@ namespace smt::noodler {
                         block_curr_len(len_formula, false);
                         STRACE("str", tout << "loop-protection: unsat " << std::endl;);
                         return l_false;
-                    } else { // returns SAT
-                        return l_true;
                     }
                 }
             }

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -229,7 +229,7 @@ namespace smt::noodler {
                                                 const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
                                                 std::vector<std::tuple<BasicTerm,BasicTerm,ConversionType>> conversions) {
         DecisionProcedure dec_proc = DecisionProcedure{ instance, aut_assignment, init_length_sensitive_vars, m_params, conversions };
-        if (dec_proc.preprocess(PreprocessType::UNDERAPPROX) == l_false) {
+        if (dec_proc.preprocess(PreprocessType::UNDERAPPROX, this->var_eqs.get_equivalence_bt()) == l_false) {
             return l_false;
         }
 

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -437,8 +437,9 @@ namespace smt::noodler {
         int ln = 0;
         /**
          * Check each variable occurring within the instance. The instance is suitable for underapproximation if 
-         * language of the variable is 1) sigma star (approximated by the first condition) 2) co-finite (complement is a finite language), or 
-         * 3) singleton meaning that the variable is string literal. 
+         * 1) predicates are (dis)equations only and 2) language of the variable is a) sigma star (approximated by 
+         * the first condition) b) co-finite (complement is a finite language), or c) singleton meaning that the 
+         * variable is string literal. 
          */
         for(const Predicate& pred : instance.get_predicates()) {
             if(!pred.is_eq_or_ineq()) {

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -433,7 +433,10 @@ namespace smt::noodler {
         return incl.is_cyclic();
     }
 
-    bool theory_str_noodler::is_underapprox_suitable(const Formula& instance, const AutAssignment& aut_ass) const {
+    bool theory_str_noodler::is_underapprox_suitable(const Formula& instance, const AutAssignment& aut_ass, const std::vector<TermConversion>& convs) const {
+        if(!convs.empty()) {
+            return false;
+        }
         int ln = 0;
         /**
          * Check each variable occurring within the instance. The instance is suitable for underapproximation if 

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -436,6 +436,9 @@ namespace smt::noodler {
          * 3) singleton meaning that the variable is string literal. 
          */
         for(const Predicate& pred : instance.get_predicates()) {
+            if(!pred.is_eq_or_ineq()) {
+                return false;
+            }
             for(const BasicTerm& var : pred.get_vars()) {
                 
                 if(aut_ass.at(var)->num_of_states() <= 1) {

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -297,6 +297,11 @@ namespace smt::noodler {
             }
             refinement = refinement == nullptr ? in_app : m.mk_and(refinement, in_app);
         }
+
+        for(const auto& nc : this->m_not_contains_todo_rel) {
+            app_ref nc_app(m.mk_not(m_util_s.str.mk_contains(nc.first, nc.second)), m);
+            refinement = refinement == nullptr ? nc_app : m.mk_and(refinement, nc_app);
+        }
         
         if(m_params.m_loop_protect && add_axiomatized) {
             this->axiomatized_instances.push_back({expr_ref(refinement, this->m), stored_instance{ .lengths = len_formula, .initial_length = init_lengths}});


### PR DESCRIPTION
This PR introduces several heuristics and optimisations:

- enlarging `not(contains)` fragment by checking syntactic subsumption over string terms
- theory rewrite during `mk_literal`
- specialisations of various predicates/function (`contains`, `not(prefix)`, `not(suffix)`, `replace`)
- new preprocessing: alignment inference and leveraging generate equivalent
- minor changes in seq_rewrite to avoid `seq.unit` during solving