### PR TITLE
Handling of `from_int` and `to_int`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The following functions/predicates of the [SMTLIB Strings theory](https://smtlib
 str.replace_all
 str.replace_re_all
 ```
-Furthermore, we do not support string variables as arguments of `str.to_re` and `re.range` and there is only a limited support for `str.to_int`, `str.from_int` and negated version of `str.contains` (non-negated is fully supported).
+Furthermore, we do not support string variables as arguments of `str.to_re` and `re.range`.
 
 ## Publications
 - Y. Chen, D. Chocholatý, V. Havlena, L. Holík, O. Lengál, and J. Síč. [Solving String Constraints with Lengths by Stabilization](https://doi.org/10.1145/3622872). In *Proc. of OOPSLA'23*, Cascais, Portugal, Volume 7, Issue OOPSLA2, pages  2112–2141, 2023. ACM.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For a brief overview of the architecture, see [SMT-COMP'23 Z3-Noodler descriptio
 
 ### Dependencies
 
-1) The [Mata](https://github.com/VeriFIT/mata/) library for efficient handling of finite automata. Minimum required version of `mata` is `v1.1.0`.
+1) The [Mata](https://github.com/VeriFIT/mata/) library for efficient handling of finite automata. Minimum required version of `mata` is `v1.2.0`.
     ```shell
     git clone 'https://github.com/VeriFIT/mata.git'
     cd mata

--- a/README.md
+++ b/README.md
@@ -58,16 +58,12 @@ cd build/
 ```
 
 ## Limitations
-The following functions/predicates of the [SMTLIB Strings theory](https://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml) are not supported at the moment.
+The following functions/predicates of the [SMTLIB Strings theory](https://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml) are not supported at the moment:
 ```
 str.replace_all
 str.replace_re_all
-str.to_int
-str.from_int
 ```
-
-We provide a full support for `str.contains`, but a limited support for its negated version.
-We also do not support string variables as arguments of `str.to_re` and `re.range`.
+Furthermore, we do not support string variables as arguments of `str.to_re` and `re.range` and there is only a limited support for `str.to_int`, `str.from_int` and negated version of `str.contains` (non-negated is fully supported).
 
 ## Publications
 - Y. Chen, D. Chocholatý, V. Havlena, L. Holík, O. Lengál, and J. Síč. [Solving String Constraints with Lengths by Stabilization](https://doi.org/10.1145/3622872). In *Proc. of OOPSLA'23*, Cascais, Portugal, Volume 7, Issue OOPSLA2, pages  2112–2141, 2023. ACM.

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -884,7 +884,7 @@ namespace smt::noodler {
      * i = to_int(s)
      *  - same as to_code, we want to encode into LIA the possible values of i
      *  - again, s can be substituted: s = s_1 ... s_n, each s_i can be shared with variables from different to_int (or even to_code/from_code)
-     *  - for each s_i, we create an int variable int_version_of(s_i), encoding the possible values of s_i as int
+     *  - for each s_i, we create an int variable int_version_of(s_i), encoding the possible values of s_i as int (so that we can synch this value between different to_int...)
      *  - take each word w = w_1 ... w_n, where w_i is the word of the language L_i of the automaton for s_i (we assume finite L_i, otherwise ERROR)
      *      - create conjunction C of following conjuncts
      *              |s_i| == |w_i| && int_version_of(s_i) = to_int('1'.w_i) [ && code_version_of(s_i) = to_code(w_i) ]

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -848,7 +848,7 @@ namespace smt::noodler {
                     }
 
                     std::vector<std::vector<mata::Word>> new_cases;
-                    for (auto word : mata::nfa::get_words(*aut, aut->num_of_states())) {
+                    for (auto word : aut->get_words(aut->num_of_states())) {
                         for (const auto& old_case : cases) {
                             std::vector<mata::Word> new_case = old_case;
                             new_case.push_back(word);
@@ -912,7 +912,7 @@ namespace smt::noodler {
                     }
 
                     // add "|s| == |w| && i == to_int(w)" to C
-                    formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LeNNode>{ string_var, full_word.size() });
+                    formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ string_var, full_word.size() });
                     formula_for_case.succ.push_back(word_to_int(full_word, int_var, false, conv.type == ConversionType::FROM_INT));
 
                     cases_as_formula.succ.push_back(formula_for_case);

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -617,6 +617,242 @@ namespace smt::noodler {
         return LenNode(LenFormulaType::AND, conjuncts);
     }
 
+    std::set<BasicTerm> DecisionProcedure::get_vars_substituted_in_code_conversions() {
+        std::set<BasicTerm> result;
+        for (const TermConversion& conv : conversions) {
+            switch (conv.type)
+            {
+                case ConversionType::FROM_CODE:
+                case ConversionType::TO_CODE:
+                {
+                    for (const BasicTerm& var : solution.get_substituted_vars(conv.string_var)) {
+                        result.insert(var);
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+        return result;
+    }
+
+    // see the comment of get_formula_for_conversions for explanation
+    LenNode DecisionProcedure::get_formula_for_code_subst_vars(const std::set<BasicTerm>& code_subst_vars) {
+        LenNode result(LenFormulaType::AND);
+
+        // for each code substituting variable c, create the formula
+        //   (|c| != 1 && code_version_of(c) == -1) || (|c| == 1 && code_version_of(c) is code point of one of the chars in the language of automaton for c)
+        for (const BasicTerm& c : code_subst_vars) {
+            // non_char_case = (|c| != 1 && code_version_of(c) == -1)
+            LenNode non_char_case(LenFormulaType::AND, { {LenFormulaType::NEQ, std::vector<LenNode>{c, 1}}, {LenFormulaType::EQ, std::vector<LenNode>{code_version_of(c),-1}} });
+
+            // char_case = (|c| == 1 && code_version_of(c) is code point of one of the chars in the language of automaton for c)
+            LenNode char_case(LenFormulaType::AND, { {LenFormulaType::EQ, std::vector<LenNode>{c, 1}}, /* code_version_of(c) is code point of one of the chars in the language of automaton for c */ });
+
+            // the rest is just computing 'code_version_of(c) is code point of one of the chars in the language of automaton for c'
+
+            // chars in the language of c (except dummy symbol)
+            std::set<mata::Symbol> real_symbols_of_code_var;
+            bool is_there_dummy_symbol = false;
+            for (mata::Symbol s : mata::strings::get_accepted_symbols(*solution.aut_ass.at(c))) { // iterate trough chars of c
+                if (!is_dummy_symbol(s)) {
+                    real_symbols_of_code_var.insert(s);
+                } else {
+                    is_there_dummy_symbol = true;
+                }
+            }
+
+            if (!is_there_dummy_symbol) {
+                // if there is no dummy symbol, we can just create disjunction that code_version_of(c) is equal to one of the symbols in real_symbols_of_code_var
+                std::vector<LenNode> equal_to_one_of_symbols;
+                for (mata::Symbol s : real_symbols_of_code_var) {
+                    equal_to_one_of_symbols.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{code_version_of(c), s});
+                }
+                char_case.succ.emplace_back(LenFormulaType::OR, equal_to_one_of_symbols);
+            } else {
+                // if there is dummy symbol, then code_version_of(c) can be code point of any char, except those in the alphabet but not in real_symbols_of_code_var
+                // (0 <= code_version_of(c) <= max_char) - code_version_of(c) is valid code_point
+                char_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{0, code_version_of(c)});
+                char_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{code_version_of(c), zstring::max_char()});
+                // code_version_of(c) is not equal to code point of some symbol in the alphabet that is not in real_symbols_of_code_var
+                for (mata::Symbol s : solution.aut_ass.get_alphabet()) {
+                    if (!is_dummy_symbol(s) && !real_symbols_of_code_var.contains(s)) {
+                        char_case.succ.emplace_back(LenFormulaType::NEQ, std::vector<LenNode>{code_version_of(c), s});
+                    }
+                }
+            }
+            
+            result.succ.emplace_back(LenFormulaType::OR, std::vector<LenNode>{
+                non_char_case,
+                char_case
+            });
+        }
+
+        return result;
+    }
+
+    LenNode DecisionProcedure::word_to_int(const mata::Word& word, const BasicTerm &var, bool start_with_one, bool handle_invalid_as_from_int) {
+        LenNode result(0);
+
+        bool is_invalid = true;
+
+        rational resulting_int = (start_with_one ? rational(1) : rational(0));
+
+        for (mata::Symbol s : word) {
+            is_invalid = false; // word is not empty, it might not be invalid
+            if (48 <= s && s <= 57) { // s is a code point of digit
+                rational real_digit(s - 48);
+                resulting_int = resulting_int*10 + real_digit;
+            } else {
+                // it is possible that s is a dummy symbol, but we assume that all digits are explicitly in the alphabet, see the assumptions
+                // therefore s here always represents a non-digit symbol
+                is_invalid = true;
+                break;
+            }
+        }
+
+        if (!is_invalid) {
+            return LenNode(LenFormulaType::EQ, std::vector<LenNode>{var, resulting_int});
+        } else if (!handle_invalid_as_from_int) {
+            // var == -1
+            return LenNode(LenFormulaType::EQ, std::vector<LenNode>{var, -1});
+        } else {
+            // var < 0
+            return LenNode(LenFormulaType::LESS, std::vector<LenNode>{var, 0});
+        }
+    };
+
+    // see the comment of get_formula_for_conversions for explanation
+    LenNode DecisionProcedure::get_formula_for_code_conversion(const TermConversion& conv) {
+        const BasicTerm& s = conv.string_var;
+        const BasicTerm& c = conv.int_var;
+
+        // First we create the first conjunct of (1)
+        LenNode invalid_value(LenFormulaType::AND);
+        if (conv.type == ConversionType::TO_CODE) {
+            // (|s| != 1 && c == -1)
+            invalid_value.succ.emplace_back(LenFormulaType::NEQ, std::vector<LenNode>{s, 1});
+            invalid_value.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{c, -1});
+        } else {
+            // (|s| == 0 && c is not a valid code point)
+            invalid_value.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{s, 0});
+            // non-valid code point means that 'c < 0 || c > max_char'
+            invalid_value.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{c, 0});
+            invalid_value.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{zstring::max_char(), c});
+        }
+
+        // Now we create the second disjunct of (1):
+        //    (|s| == 1 && c >= 0 && c is equal to one of code_version_of(s_i))
+        // that is shared in both to_code and from_code
+
+        // c is equal to one of code_version_of(s_i)
+        LenNode equal_to_one_subst_var(LenFormulaType::OR);
+        for (const BasicTerm& subst_var : solution.get_substituted_vars(s)) {
+            equal_to_one_subst_var.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{c, code_version_of(subst_var)});
+        }
+
+        
+        return LenNode(LenFormulaType::OR, std::vector<LenNode>{
+            // (|s| == 1 && c >= 0 && equal_to_one_subst_var)
+            LenNode(LenFormulaType::AND, { {LenFormulaType::EQ, std::vector<LenNode>{s, 1}}, {LenFormulaType::LEQ, std::vector<LenNode>{0, c}}, equal_to_one_subst_var}),
+            invalid_value
+        });
+    }
+
+    // see the comment of get_formula_for_conversions for explanation
+    LenNode DecisionProcedure::get_formula_for_int_conversion(const TermConversion& conv, const std::set<BasicTerm>& code_subst_vars) {
+        const BasicTerm& s = conv.string_var;
+        const BasicTerm& i = conv.int_var;
+
+        // s = s_1 ... s_n, subst_vars = <s_1, ..., s_n>
+        const std::vector<BasicTerm>& subst_vars = solution.get_substituted_vars(s);
+
+        // cases should be the collection of all words w = w_1 ... w_n, where w_i is the word of the language L_i of the automaton for s_i
+        std::vector<std::vector<mata::Word>> cases = {{}};
+        for (const BasicTerm& subst_var : solution.get_substituted_vars(s)) {
+            // TODO split automaton to only-digit and some-non-digit part and do something smarter with some-non-digit part
+            auto aut = solution.aut_ass.at(subst_var);
+            if (!aut->is_acyclic()) {
+                STRACE("str-conversion", tout << "failing NFA:" << *aut << std::endl;);
+                util::throw_error("cannot process to_int/from_int for automaton with infinite language");
+            }
+
+            std::vector<std::vector<mata::Word>> new_cases;
+            for (auto word : aut->get_words(aut->num_of_states())) {
+                for (const auto& old_case : cases) {
+                    std::vector<mata::Word> new_case = old_case;
+                    new_case.push_back(word);
+                    new_cases.push_back(new_case);
+                }
+            }
+            cases = new_cases;
+        }
+
+        LenNode cases_as_formula(LenFormulaType::OR);
+
+        for (const auto& one_case : cases) {
+            assert(subst_vars.size() == one_case.size());
+
+            mata::Word full_word; // the word w
+            LenNode formula_for_case(LenFormulaType::AND); // conjunct C
+            for (unsigned i = 0; i < subst_vars.size(); ++i) {
+                const BasicTerm& subst_var = subst_vars[i]; // var s_i
+                mata::Word word_of_subst_var = one_case[i]; // word w_i
+
+                // creating formula
+                //   |s_i| == |w_i| && int_version_of(s_i) = to_int('1'.w_i) [ && code_version_of(s_i) = to_code(w_i) ]
+
+                // |s_i| = |w_i|
+                formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ subst_var, word_of_subst_var.size() });
+
+                // int_version_of(s_i) = to_int('1'.w_i)
+                // we add 1 at the beginning for the cases with 0s at the beginning of w_i,
+                // so that for example if w_i="00013", it does not turn it into 13 but into 100013
+                formula_for_case.succ.push_back(word_to_int(word_of_subst_var, int_version_of(subst_var), true, false));
+
+                if (code_subst_vars.contains(subst_var)) {
+                    // in the case that s_i is also one of the code vars, we need to force the exact value of code var, i.e., we add the optional part
+                    //      code_version_of(s_i) = to_code(w_i)
+                    if (word_of_subst_var.size() == 1) {
+                        mata::Symbol code_point = word_of_subst_var[0];
+                        if (48 <= code_point && code_point <= 57) {
+                            // code point for a digit -> we need the exact value
+                            //      code_version_of(s_i) == w_i[0]
+                            formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ code_version_of(subst_var), code_point });
+                        } else {
+                            // code point for something else (could be even a dummy symbol, but we assume digits are not represented by dummy symbol, see the assumptions)
+                            // -> we can just say that code var should be valid and not be equal to code point of digit, because it has the same semantics for all cases where we do not have digit
+                            
+                            // code_version_of(s_i) is valid...
+                            //      0 <= code_version_of(s_i) <= max_char
+                            formula_for_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{ 0, code_version_of(subst_var) });
+                            formula_for_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{ code_version_of(subst_var), zstring::max_char() });
+                            // ...but not a digit
+                            //      code_version_of(s_i) < 48 && 57 < code_version_of(s_i)
+                            formula_for_case.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{ code_version_of(subst_var), 48 });
+                            formula_for_case.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{ 57, code_version_of(subst_var) });
+                        }
+                    } else {
+                        formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ code_version_of(subst_var), -1 });
+                    }
+                }
+
+                // add w_i to the end of w
+                full_word.insert(full_word.end(), word_of_subst_var.begin(), word_of_subst_var.end());
+            }
+
+            // add "|s| == |w| && i == to_int(w)" to C
+            formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ s, full_word.size() });
+            formula_for_case.succ.push_back(word_to_int(full_word, i, false, conv.type == ConversionType::FROM_INT));
+
+            cases_as_formula.succ.push_back(formula_for_case);
+
+        }
+
+        return cases_as_formula;
+    }
+
     /**
      * Creates a LIA formula that encodes to_code/from_code/to_int/from_int functions.
      * Assumes that
@@ -630,12 +866,12 @@ namespace smt::noodler {
      *  - in the solution, s can be substituted: s = s_1 ... s_n (note that we should have |s| = |s_1| + ... + |s_n| from solution.get_lengths)
      *  - note that there can be another c' = to_code(s'), where some s_i can be also in the substitution of s',
      *    therefore, we need to share the information about s_i between s and s'
-     *  - hence, for each s_i, we create an int variable s_i!to_code which represents the possible code values of s_i
+     *  - hence, for each s_i, we create an int variable code_version_of(s_i) which represents the possible code values of s_i
      *  - we then create formula
-     *      (|s_i| != 1 && s_i!to_code == -1) || (|s_i| == 1 && s_i!to_code is code point of one of the chars in the language of automaton for s_i)
+     *      (|s_i| != 1 && code_version_of(s_i) == -1) || (|s_i| == 1 && code_version_of(s_i) is code point of one of the chars in the language of automaton for s_i)
      *  - finally, we put
-     *      (|s| != 1 && c == -1) || (|s| == 1 && c >= 0 && c is equal to one of s_i!to_code)                                               (1)
-     *  - 'c >= 0' should force that c is equal to the s_i!to_code which has '|s_i| == 1', because all others should be -1
+     *      (|s| != 1 && c == -1) || (|s| == 1 && c >= 0 && c is equal to one of code_version_of(s_i))                                               (1)
+     *  - 'c >= 0' should force that c is equal to the code_version_of(s_i) which has '|s_i| == 1', because all others should be -1
      * 
      * s = from_code(c)
      *  - we have solutions for the result s, from this we can create LIA formula restricting the possible values of c
@@ -648,13 +884,13 @@ namespace smt::noodler {
      * i = to_int(s)
      *  - same as to_code, we want to encode into LIA the possible values of i
      *  - again, s can be substituted: s = s_1 ... s_n, each s_i can be shared with variables from different to_int (or even to_code/from_code)
-     *  - for each s_i, we create an int variable s_i!to_int, encoding the possible values of s_i as int
+     *  - for each s_i, we create an int variable int_version_of(s_i), encoding the possible values of s_i as int
      *  - take each word w = w_1 ... w_n, where w_i is the word of the language L_i of the automaton for s_i (we assume finite L_i, otherwise ERROR)
      *      - create conjunction C of following conjuncts
-     *              |s_i| == |w_i| && s_i!to_int = to_int('1'.w_i) [ && s_i!to_code = to_code(w_i) ]
+     *              |s_i| == |w_i| && int_version_of(s_i) = to_int('1'.w_i) [ && code_version_of(s_i) = to_code(w_i) ]
      *          - last part in [] is optional, happens only if s_i substitutes some s used in to_code/from_code
      *          - to_int('1'.w_i) and to_code(w_i) can be computed, as w_i is a literal, not a variable
-     *          - we add 1 at the beginning of s_i!to_int, because w_i can potentionally start with 0, but we want to encode the exact value of w_i ("005" and "5" should be taken as two different words)
+     *          - we add 1 at the beginning of int_version_of(s_i), because w_i can potentionally start with 0, but we want to encode the exact value of w_i ("005" and "5" should be taken as two different words)
      *          - if w_i is empty/contains non-digits, then to_int('1'.w_i) returns -1 (we do not need to differentiate between non-valid inputs)
      *      - add to C
      *              |s| == |w| && i == to_int(w)                                                                                            (2)
@@ -672,121 +908,17 @@ namespace smt::noodler {
             tout << "Creating formula for conversions" << std::endl;
         );
 
-        // we will encode semantics of to_code/from_code (to_int/from_int) into special LIA to_code/to_int vars
-        auto to_code_var = [](const BasicTerm& var) -> BasicTerm { return BasicTerm(BasicTermType::Variable, var.get_name() + "!to_code"); };
-        auto to_int_var = [](const BasicTerm& var) -> BasicTerm { return BasicTerm(BasicTermType::Variable, var.get_name() + "!to_int"); };
-
         // the resulting formula 
         LenNode result(LenFormulaType::AND);
 
         // collect all code variables, i.e. those that substitute string variables used in to_code/from_code predicates
-        std::set<BasicTerm> code_vars;
-        for (const TermConversion& conv : conversions) {
-            switch (conv.type)
-            {
-                case ConversionType::FROM_CODE:
-                case ConversionType::TO_CODE:
-                {
-                    for (const BasicTerm& var : solution.get_substituted_vars(conv.string_var)) {
-                        code_vars.insert(var);
-                    }
-                    break;
-                }
-                default:
-                    break;
-            }
-        }
+        std::set<BasicTerm> code_subst_vars = get_vars_substituted_in_code_conversions();
 
-
-        // for each code variable code_var, create the formula
-        //   (|code_var| != 1 && code_var!to_code == -1) || (|code_var| == 1 && code_var!to_code is code point of one of the chars in the language of automaton for code_var)
-        for (const BasicTerm& code_var : code_vars) {
-            // non_char_case = (|code_var| != 1 && code_var!to_code == -1)
-            LenNode non_char_case(LenFormulaType::AND, { {LenFormulaType::NEQ, std::vector<LenNode>{code_var, 1}}, {LenFormulaType::EQ, std::vector<LenNode>{to_code_var(code_var),-1}} });
-
-            // char_case = (|code_var| == 1 && code_var!to_code is code point of one of the chars in the language of automaton for code_var)
-            LenNode char_case(LenFormulaType::AND, { {LenFormulaType::EQ, std::vector<LenNode>{code_var, 1}}, /* code_var!to_code is code point of one of the chars in the language of automaton for code_var */ });
-
-            // the rest is just computing 'code_var!to_code is code point of one of the chars in the language of automaton for code_var'
-
-            // chars in the language of code_var (except dummy symbol)
-            std::set<mata::Symbol> real_symbols_of_code_var;
-            bool is_there_dummy_symbol = false;
-            for (mata::Symbol s : mata::strings::get_accepted_symbols(*solution.aut_ass.at(code_var))) { // iterate trough chars of code_var
-                if (!is_dummy_symbol(s)) {
-                    real_symbols_of_code_var.insert(s);
-                } else {
-                    is_there_dummy_symbol = true;
-                }
-            }
-
-            if (!is_there_dummy_symbol) {
-                // if there is no dummy symbol, we can just create disjunction that code_var!to_code is equal to one of the symbols in real_symbols_of_code_var
-                std::vector<LenNode> equal_to_one_of_symbols;
-                for (mata::Symbol s : real_symbols_of_code_var) {
-                    equal_to_one_of_symbols.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{to_code_var(code_var), s});
-                }
-                char_case.succ.emplace_back(LenFormulaType::OR, equal_to_one_of_symbols);
-            } else {
-                // if there is dummy symbol, then code_var!to_code can be code point of any char, except those in the alphabet but not in real_symbols_of_code_var
-                // (0 <= code_var!to_code <= max_char) - code_var!to_code is valid code_point
-                char_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{0, to_code_var(code_var)});
-                char_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{to_code_var(code_var), zstring::max_char()});
-                // code_var!to_code is not equal to code point of some symbol in the alphabet that is not in real_symbols_of_code_var
-                for (mata::Symbol s : solution.aut_ass.get_alphabet()) {
-                    if (!is_dummy_symbol(s) && !real_symbols_of_code_var.contains(s)) {
-                        char_case.succ.emplace_back(LenFormulaType::NEQ, std::vector<LenNode>{to_code_var(code_var), s});
-                    }
-                }
-            }
-            
-            result.succ.emplace_back(LenFormulaType::OR, std::vector<LenNode>{
-                non_char_case,
-                char_case
-            });
-        }
-
-        // Returns formula encoding "var = to_int(word)".
-        // If start_with_one==true, we instead encode "var = to_int('1'.word)".
-        // For invalid inputs (word is empty/contains non-digits), to_int should return -1,
-        // except for when handle_invalid_as_from_int==true, then we just put that 'var < 0'.
-        auto word_to_int = [](const mata::Word& word, const BasicTerm &var, bool start_with_one, bool handle_invalid_as_from_int) {
-            LenNode result(0);
-
-            bool is_invalid = true;
-
-            rational resulting_int = (start_with_one ? rational(1) : rational(0));
-
-            for (mata::Symbol s : word) {
-                is_invalid = false; // word is not empty, it might not be invalid
-                if (48 <= s && s <= 57) { // s is a code point of digit
-                    rational real_digit(s - 48);
-                    resulting_int = resulting_int*10 + real_digit;
-                } else {
-                    // it is possible that s is a dummy symbol, but we assume that all digits are explicitly in the alphabet, see the assumptions
-                    // therefore s here always represents a non-digit symbol
-                    is_invalid = true;
-                    break;
-                }
-            }
-
-            if (!is_invalid) {
-                return LenNode(LenFormulaType::EQ, std::vector<LenNode>{var, resulting_int});
-            } else if (!handle_invalid_as_from_int) {
-                // var == -1
-                return LenNode(LenFormulaType::EQ, std::vector<LenNode>{var, -1});
-            } else {
-                // var < 0
-                return LenNode(LenFormulaType::LESS, std::vector<LenNode>{var, 0});
-            }
-        };
+        result.succ.push_back(get_formula_for_code_subst_vars(code_subst_vars));
 
         for (const TermConversion& conv : conversions) {
-            const BasicTerm& string_var = conv.string_var;
-            const BasicTerm& int_var = conv.int_var;
-
             STRACE("str-conversion",
-                tout << " processing " << get_conversion_name(conv.type) << " with string var " << string_var << " and int var " << int_var << std::endl;
+                tout << " processing " << get_conversion_name(conv.type) << " with string var " << conv.string_var << " and int var " << conv.int_var << std::endl;
             );
 
             switch (conv.type)
@@ -794,133 +926,13 @@ namespace smt::noodler {
             case ConversionType::TO_CODE:
             case ConversionType::FROM_CODE:
             {
-                // s = string_var, c = int_var
-
-                // First we create the first conjunct of (1)
-                LenNode invalid_value(LenFormulaType::AND);
-                if (conv.type == ConversionType::TO_CODE) {
-                    // (|s| != 1 && c == -1)
-                    invalid_value.succ.emplace_back(LenFormulaType::NEQ, std::vector<LenNode>{string_var, 1});
-                    invalid_value.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{int_var, -1});
-                } else {
-                    // (|s| == 0 && c is not a valid code point)
-                    invalid_value.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{string_var, 0});
-                    // non-valid code point means that 'c < 0 || c > max_char'
-                    invalid_value.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{int_var, 0});
-                    invalid_value.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{zstring::max_char(), int_var});
-                }
-
-                // Now we create the second disjunct of (1):
-                //    (|s| == 1 && c >= 0 && c is equal to one of s_i!to_code)
-                // that is shared in both to_code and from_code
-
-                // c is equal to one of s_i!to_code
-                LenNode equal_to_one_subst_var(LenFormulaType::OR);
-                for (const BasicTerm& subst_var : solution.get_substituted_vars(string_var)) {
-                    equal_to_one_subst_var.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{int_var, to_code_var(subst_var)});
-                }
-
-                
-                result.succ.emplace_back(LenFormulaType::OR, std::vector<LenNode>{
-                    // (|s| == 1 && c >= 0 && equal_to_one_subst_var)
-                    LenNode(LenFormulaType::AND, { {LenFormulaType::EQ, std::vector<LenNode>{string_var, 1}}, {LenFormulaType::LEQ, std::vector<LenNode>{0, int_var}}, equal_to_one_subst_var}),
-                    invalid_value
-                });
-
+                result.succ.push_back(get_formula_for_code_conversion(conv));
                 break;
             }
             case ConversionType::TO_INT:
             case ConversionType::FROM_INT:
             {
-                // s = string_var, i = int_var
-
-                // s = s_1 ... s_n, subst_vars = <s_1, ..., s_n>
-                const std::vector<BasicTerm>& subst_vars = solution.get_substituted_vars(string_var);
-
-                // cases should be the collection of all words w = w_1 ... w_n, where w_i is the word of the language L_i of the automaton for s_i
-                std::vector<std::vector<mata::Word>> cases = {{}};
-                for (const BasicTerm& subst_var : solution.get_substituted_vars(string_var)) {
-                    // TODO split automaton to only-digit and some-non-digit part and do something smarter with some-non-digit part
-                    auto aut = solution.aut_ass.at(subst_var);
-                    if (!aut->is_acyclic()) {
-                        STRACE("str-conversion", tout << "failing NFA:" << *aut << std::endl;);
-                        util::throw_error("cannot process to_int/from_int for automaton with infinite language");
-                    }
-
-                    std::vector<std::vector<mata::Word>> new_cases;
-                    for (auto word : aut->get_words(aut->num_of_states())) {
-                        for (const auto& old_case : cases) {
-                            std::vector<mata::Word> new_case = old_case;
-                            new_case.push_back(word);
-                            new_cases.push_back(new_case);
-                        }
-                    }
-                    cases = new_cases;
-                }
-
-                LenNode cases_as_formula(LenFormulaType::OR);
-
-                for (const auto& one_case : cases) {
-                    assert(subst_vars.size() == one_case.size());
-
-                    mata::Word full_word; // the word w
-                    LenNode formula_for_case(LenFormulaType::AND); // conjunct C
-                    for (unsigned i = 0; i < subst_vars.size(); ++i) {
-                        const BasicTerm& subst_var = subst_vars[i]; // var s_i
-                        mata::Word word_of_subst_var = one_case[i]; // word w_i
-
-                        // creating formula
-                        //   |s_i| == |w_i| && s_i!to_int = to_int('1'.w_i) [ && s_i!to_code = to_code(w_i) ]
-
-                        // |s_i| = |w_i|
-                        formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ subst_var, word_of_subst_var.size() });
-
-                        // s_i!to_int = to_int('1'.w_i)
-                        // we add 1 at the beginning for the cases with 0s at the beginning of w_i,
-                        // so that for example if w_i="00013", it does not turn it into 13 but into 100013
-                        formula_for_case.succ.push_back(word_to_int(word_of_subst_var, to_int_var(subst_var), true, false));
-
-                        if (code_vars.contains(subst_var)) {
-                            // in the case that s_i is also one of the code vars, we need to force the exact value of code var, i.e., we add the optional part
-                            //      s_i!to_code = to_code(w_i)
-                            if (word_of_subst_var.size() == 1) {
-                                mata::Symbol code_point = word_of_subst_var[0];
-                                if (48 <= code_point && code_point <= 57) {
-                                    // code point for a digit -> we need the exact value
-                                    //      s_i!to_code == w_i[0]
-                                    formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ to_code_var(subst_var), code_point });
-                                } else {
-                                    // code point for something else (could be even a dummy symbol, but we assume digits are not represented by dummy symbol, see the assumptions)
-                                    // -> we can just say that code var should be valid and not be equal to code point of digit, because it has the same semantics for all cases where we do not have digit
-                                    
-                                    // s_i!to_code is valid...
-                                    //      0 <= s_i!to_code <= max_char
-                                    formula_for_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{ 0, to_code_var(subst_var) });
-                                    formula_for_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{ to_code_var(subst_var), zstring::max_char() });
-                                    // ...but not a digit
-                                    //      s_i!to_code < 48 && 57 < s_i!to_code
-                                    formula_for_case.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{ to_code_var(subst_var), 48 });
-                                    formula_for_case.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{ 57, to_code_var(subst_var) });
-                                }
-                            } else {
-                                formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ to_code_var(subst_var), -1 });
-                            }
-                        }
-
-                        // add w_i to the end of w
-                        full_word.insert(full_word.end(), word_of_subst_var.begin(), word_of_subst_var.end());
-                    }
-
-                    // add "|s| == |w| && i == to_int(w)" to C
-                    formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ string_var, full_word.size() });
-                    formula_for_case.succ.push_back(word_to_int(full_word, int_var, false, conv.type == ConversionType::FROM_INT));
-
-                    cases_as_formula.succ.push_back(formula_for_case);
-
-                }
-
-                result.succ.push_back(cases_as_formula);
-
+                result.succ.push_back(get_formula_for_int_conversion(conv, code_subst_vars));
                 break;
             }
             default:

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -619,10 +619,53 @@ namespace smt::noodler {
 
     /**
      * Creates a LIA formula that encodes to_code/from_code/to_int/from_int functions.
+     * Assumes that
+     *      - solution is flattened,
+     *      - will be used in conjunction with the result of solution.get_lengths,
+     *      - the resulting string variable of from_code/from_int is restricted to only valid results of from_code/from_int (should be done in theory_str_noodler::handle_conversion),
+     *      - if to_int/from_int will be processed, code points of all digits (symbols 48,..,57) should be in the alphabet (should be done in theory_str_noodler::final_check_eh).
      * 
+     * c = to_code(s)
+     *  - we have the possible solutions of s, from these, we want to create LIA formula for all possible values of c
+     *  - in the solution, s can be substituted: s = s_1 ... s_n (note that we should have |s| = |s_1| + ... + |s_n| from solution.get_lengths)
+     *  - note that there can be another c' = to_code(s'), where some s_i can be also in the substitution of s',
+     *    therefore, we need to share the information about s_i between s and s'
+     *  - hence, for each s_i, we create an int variable s_i!to_code which represents the possible code values of s_i
+     *  - we then create formula
+     *      (|s_i| != 1 && s_i!to_code == -1) || (|s_i| == 1 && s_i!to_code is code point of one of the chars in the language of automaton for s_i)
+     *  - finally, we put
+     *      (|s| != 1 && c == -1) || (|s| == 1 && c >= 0 && c is equal to one of s_i!to_code)                                               (1)
+     *  - 'c >= 0' should force that c is equal to the s_i!to_code which has '|s_i| == 1', because all others should be -1
      * 
+     * s = from_code(c)
+     *  - we have solutions for the result s, from this we can create LIA formula restricting the possible values of c
+     *  - we can do the same thing as for to_code, but the first conjunct (|s| != 1 && c == -1) in (1) is replaced with
+     *      (|s| == 0 && c is not a valid code point)
+     *  - we assume that s is restricted to only values that can come from "from_code" (empty string or some char)
+     *      - should be done during processing of from_code in theory_str_noodler, by adding a regular constraint
+     *      - basically means that |s| <= 1
      * 
-     * @return LenNode 
+     * i = to_int(s)
+     *  - same as to_code, we want to encode into LIA the possible values of i
+     *  - again, s can be substituted: s = s_1 ... s_n, each s_i can be shared with variables from different to_int (or even to_code/from_code)
+     *  - for each s_i, we create an int variable s_i!to_int, encoding the possible values of s_i as int
+     *  - take each word w = w_1 ... w_n, where w_i is the word of the language L_i of the automaton for s_i (we assume finite L_i, otherwise ERROR)
+     *      - create conjunction C of following conjuncts
+     *              |s_i| == |w_i| && s_i!to_int = to_int('1'.w_i) [ && s_i!to_code = to_code(w_i) ]
+     *          - last part in [] is optional, happens only if s_i substitutes some s used in to_code/from_code
+     *          - to_int('1'.w_i) and to_code(w_i) can be computed, as w_i is a literal, not a variable
+     *          - we add 1 at the beginning of s_i!to_int, because w_i can potentionally start with 0, but we want to encode the exact value of w_i ("005" and "5" should be taken as two different words)
+     *          - if w_i is empty/contains non-digits, then to_int('1'.w_i) returns -1 (we do not need to differentiate between non-valid inputs)
+     *      - add to C
+     *              |s| == |w| && i == to_int(w)                                                                                            (2)
+     *          - again, to_int(w) returns -1 for non-valid input (w is empt/contains non-digits)
+     *      - the cases where w/w_i 
+     *  - final LIA formula is taken as a disjunction of all the conjunctions from the previous step
+     * 
+     * s = from_int(i)
+     *  - similarly to from_code, we want to restrict the values of the argument i from the possible valuations of result s
+     *  - we do the same thing as to_int, but instead of 'i == to_int(w)' in (2) for non-valid w, we put 'i < 0'
+     *  - we assume (as in from_code) that s is restricted to only possible outputs of from_int, mainly that w cannot start with 0 and the only non-valid w is empty string
      */
     LenNode DecisionProcedure::get_formula_for_conversions() {
         STRACE("str-conversion",
@@ -633,10 +676,10 @@ namespace smt::noodler {
         auto to_code_var = [](const BasicTerm& var) -> BasicTerm { return BasicTerm(BasicTermType::Variable, var.get_name() + "!to_code"); };
         auto to_int_var = [](const BasicTerm& var) -> BasicTerm { return BasicTerm(BasicTermType::Variable, var.get_name() + "!to_int"); };
 
-        // the resulting formula will be conjunctions of the conjuncts in result_conjuncts
-        std::vector<LenNode> result_conjuncts;
+        // the resulting formula 
+        LenNode result(LenFormulaType::AND);
 
-        // collect all variables that substitute string variables used in to_code/from_code predicates
+        // collect all code variables, i.e. those that substitute string variables used in to_code/from_code predicates
         std::set<BasicTerm> code_vars;
         for (const TermConversion& conv : conversions) {
             switch (conv.type)
@@ -655,11 +698,18 @@ namespace smt::noodler {
         }
 
 
-        // TODO comment to_code vars
+        // for each code variable code_var, create the formula
+        //   (|code_var| != 1 && code_var!to_code == -1) || (|code_var| == 1 && code_var!to_code is code point of one of the chars in the language of automaton for code_var)
         for (const BasicTerm& code_var : code_vars) {
-            // disjunction that will say that code_var!to_code is equal to code point of one of the chars in code_var when |code_var| = 1 or var!to_code=-1 if |code_var| != 1
-            LenNode char_case(LenFormulaType::AND, { {LenFormulaType::EQ, std::vector<LenNode>{code_var, 1}}, /* this is where we put the rest of the shit*/ });
+            // non_char_case = (|code_var| != 1 && code_var!to_code == -1)
+            LenNode non_char_case(LenFormulaType::AND, { {LenFormulaType::NEQ, std::vector<LenNode>{code_var, 1}}, {LenFormulaType::EQ, std::vector<LenNode>{to_code_var(code_var),-1}} });
 
+            // char_case = (|code_var| == 1 && code_var!to_code is code point of one of the chars in the language of automaton for code_var)
+            LenNode char_case(LenFormulaType::AND, { {LenFormulaType::EQ, std::vector<LenNode>{code_var, 1}}, /* code_var!to_code is code point of one of the chars in the language of automaton for code_var */ });
+
+            // the rest is just computing 'code_var!to_code is code point of one of the chars in the language of automaton for code_var'
+
+            // chars in the language of code_var (except dummy symbol)
             std::set<mata::Symbol> real_symbols_of_code_var;
             bool is_there_dummy_symbol = false;
             for (mata::Symbol s : mata::strings::get_accepted_symbols(*solution.aut_ass.at(code_var))) { // iterate trough chars of code_var
@@ -670,37 +720,36 @@ namespace smt::noodler {
                 }
             }
 
-            if (is_there_dummy_symbol) {
-                // TODO rewrite comments
-                // if s represents symbols not in the alphabet => var!to_code must be a code point of such a symbol which is not in alphabet, i.e. it is...
-                // ...valid code point (0 <= code_var!to_code <= max_char) and...
-                char_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{0, to_code_var(code_var)});
-                char_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{to_code_var(code_var), zstring::max_char()});
-                // ...it is not equal to code point of some symbol in the alphabet that is not in real_symbols_of_code_var
-                for (mata::Symbol s : solution.aut_ass.get_alphabet()) {
-                    if (!is_dummy_symbol(s) && !real_symbols_of_code_var.contains(s)) {
-                        char_case.succ.emplace_back(LenFormulaType::NEQ, std::vector<LenNode>{to_code_var(code_var), s});
-                    }
-                }
-            } else {
-                // TODO rewrite cmoments
-                // Disjunction representing that result is equal to code point of one of the chars of some var_i
+            if (!is_there_dummy_symbol) {
+                // if there is no dummy symbol, we can just create disjunction that code_var!to_code is equal to one of the symbols in real_symbols_of_code_var
                 std::vector<LenNode> equal_to_one_of_symbols;
                 for (mata::Symbol s : real_symbols_of_code_var) {
                     equal_to_one_of_symbols.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{to_code_var(code_var), s});
                 }
                 char_case.succ.emplace_back(LenFormulaType::OR, equal_to_one_of_symbols);
+            } else {
+                // if there is dummy symbol, then code_var!to_code can be code point of any char, except those in the alphabet but not in real_symbols_of_code_var
+                // (0 <= code_var!to_code <= max_char) - code_var!to_code is valid code_point
+                char_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{0, to_code_var(code_var)});
+                char_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{to_code_var(code_var), zstring::max_char()});
+                // code_var!to_code is not equal to code point of some symbol in the alphabet that is not in real_symbols_of_code_var
+                for (mata::Symbol s : solution.aut_ass.get_alphabet()) {
+                    if (!is_dummy_symbol(s) && !real_symbols_of_code_var.contains(s)) {
+                        char_case.succ.emplace_back(LenFormulaType::NEQ, std::vector<LenNode>{to_code_var(code_var), s});
+                    }
+                }
             }
-
-
-            LenNode non_char_case(LenFormulaType::AND, { {LenFormulaType::NEQ, std::vector<LenNode>{code_var, 1}}, {LenFormulaType::EQ, std::vector<LenNode>{to_code_var(code_var),-1}} }); // TODO should I do !(0 <= to_code_var(code_var) <= MAX) instead of to_code_var(code_var) = -1?
             
-            result_conjuncts.emplace_back(LenFormulaType::OR, std::vector<LenNode>{
+            result.succ.emplace_back(LenFormulaType::OR, std::vector<LenNode>{
                 non_char_case,
                 char_case
             });
         }
 
+        // Returns formula encoding "var = to_int(word)".
+        // If start_with_one==true, we instead encode "var = to_int('1'.word)".
+        // For invalid inputs (word is empty/contains non-digits), to_int should return -1,
+        // except for when handle_invalid_as_from_int==true, then we just put that 'var < 0'.
         auto word_to_int = [](const mata::Word& word, const BasicTerm &var, bool start_with_one, bool handle_invalid_as_from_int) {
             LenNode result(0);
 
@@ -709,13 +758,12 @@ namespace smt::noodler {
             rational resulting_int = (start_with_one ? rational(1) : rational(0));
 
             for (mata::Symbol s : word) {
-                is_invalid = false;
-                if (48 <= s && s <= 57) {
-                    // s is code point of a digit
+                is_invalid = false; // word is not empty, it might not be invalid
+                if (48 <= s && s <= 57) { // s is a code point of digit
                     rational real_digit(s - 48);
                     resulting_int = resulting_int*10 + real_digit;
                 } else {
-                    // it is possible that s is a dummy symbol, but we assume that all digits are explicitly in the alphabet, see theory_str_noodler::final_check_eh()
+                    // it is possible that s is a dummy symbol, but we assume that all digits are explicitly in the alphabet, see the assumptions
                     // therefore s here always represents a non-digit symbol
                     is_invalid = true;
                     break;
@@ -725,8 +773,10 @@ namespace smt::noodler {
             if (!is_invalid) {
                 return LenNode(LenFormulaType::EQ, std::vector<LenNode>{var, resulting_int});
             } else if (!handle_invalid_as_from_int) {
+                // var == -1
                 return LenNode(LenFormulaType::EQ, std::vector<LenNode>{var, -1});
             } else {
+                // var < 0
                 return LenNode(LenFormulaType::LESS, std::vector<LenNode>{var, 0});
             }
         };
@@ -736,7 +786,7 @@ namespace smt::noodler {
             const BasicTerm& int_var = conv.int_var;
 
             STRACE("str-conversion",
-                tout << " procesing " << get_conversion_name(conv.type) << " with string var " << string_var << " and int var " << int_var << std::endl;
+                tout << " processing " << get_conversion_name(conv.type) << " with string var " << string_var << " and int var " << int_var << std::endl;
             );
 
             switch (conv.type)
@@ -744,28 +794,35 @@ namespace smt::noodler {
             case ConversionType::TO_CODE:
             case ConversionType::FROM_CODE:
             {
-                
-                // TODO explain shit?
+                // s = string_var, c = int_var
+
+                // First we create the first conjunct of (1)
+                LenNode invalid_value(LenFormulaType::AND);
+                if (conv.type == ConversionType::TO_CODE) {
+                    // (|s| != 1 && c == -1)
+                    invalid_value.succ.emplace_back(LenFormulaType::NEQ, std::vector<LenNode>{string_var, 1});
+                    invalid_value.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{int_var, -1});
+                } else {
+                    // (|s| == 0 && c is not a valid code point)
+                    invalid_value.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{string_var, 0});
+                    // non-valid code point means that 'c < 0 || c > max_char'
+                    invalid_value.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{int_var, 0});
+                    invalid_value.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{zstring::max_char(), int_var});
+                }
+
+                // Now we create the second disjunct of (1):
+                //    (|s| == 1 && c >= 0 && c is equal to one of s_i!to_code)
+                // that is shared in both to_code and from_code
+
+                // c is equal to one of s_i!to_code
                 LenNode equal_to_one_subst_var(LenFormulaType::OR);
                 for (const BasicTerm& subst_var : solution.get_substituted_vars(string_var)) {
                     equal_to_one_subst_var.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{int_var, to_code_var(subst_var)});
                 }
 
-                // TODO explain
-                LenNode invalid_value(LenFormulaType::AND);
-                if (conv.type == ConversionType::TO_CODE) {
-                    // |string_var| != 1 AND int_var = -1    
-                    invalid_value.succ.emplace_back(LenFormulaType::NEQ, std::vector<LenNode>{string_var, 1});
-                    invalid_value.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{int_var, -1});
-                } else {
-                    // |string_var| = 0 AND !(0 <= int_var <= max_char)
-                    invalid_value.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{string_var, 0});
-                    invalid_value.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{int_var, 0});
-                    invalid_value.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{zstring::max_char(), int_var});
-                }
                 
-                result_conjuncts.emplace_back(LenFormulaType::OR, std::vector<LenNode>{
-                    // TODO comment: |result| = 1 AND argument >=0 AND argument is equal to one of the code value of the substituted vars of result TODO explain that |result| = 1 forces exactly one substituted var to be ||=1 whose code value we want, others code value will be -1 ignored by |int_var| >= 0
+                result.succ.emplace_back(LenFormulaType::OR, std::vector<LenNode>{
+                    // (|s| == 1 && c >= 0 && equal_to_one_subst_var)
                     LenNode(LenFormulaType::AND, { {LenFormulaType::EQ, std::vector<LenNode>{string_var, 1}}, {LenFormulaType::LEQ, std::vector<LenNode>{0, int_var}}, equal_to_one_subst_var}),
                     invalid_value
                 });
@@ -775,13 +832,15 @@ namespace smt::noodler {
             case ConversionType::TO_INT:
             case ConversionType::FROM_INT:
             {
+                // s = string_var, i = int_var
 
+                // s = s_1 ... s_n, subst_vars = <s_1, ..., s_n>
                 const std::vector<BasicTerm>& subst_vars = solution.get_substituted_vars(string_var);
 
-                // each vector in cases should contain exactly one word from the language of automaton for each subst_var
+                // cases should be the collection of all words w = w_1 ... w_n, where w_i is the word of the language L_i of the automaton for s_i
                 std::vector<std::vector<mata::Word>> cases = {{}};
                 for (const BasicTerm& subst_var : solution.get_substituted_vars(string_var)) {
-                    // TODO split automaton to only-digit and not-only-digit part and do some smarter way with not-only-digit part
+                    // TODO split automaton to only-digit and some-non-digit part and do something smarter with some-non-digit part
                     auto aut = solution.aut_ass.at(subst_var);
                     if (!aut->is_acyclic()) {
                         STRACE("str-conversion", tout << "failing NFA:" << *aut << std::endl;);
@@ -804,30 +863,42 @@ namespace smt::noodler {
                 for (const auto& one_case : cases) {
                     assert(subst_vars.size() == one_case.size());
 
-                    mata::Word full_word;
-                    LenNode formula_for_case(LenFormulaType::AND);
+                    mata::Word full_word; // the word w
+                    LenNode formula_for_case(LenFormulaType::AND); // conjunct C
                     for (unsigned i = 0; i < subst_vars.size(); ++i) {
-                        const BasicTerm& subst_var = subst_vars[i];
-                        mata::Word word_of_subst_var = one_case[i];
+                        const BasicTerm& subst_var = subst_vars[i]; // var s_i
+                        mata::Word word_of_subst_var = one_case[i]; // word w_i
 
-                        // |subst_var| = |word_of_subst_var|
+                        // creating formula
+                        //   |s_i| == |w_i| && s_i!to_int = to_int('1'.w_i) [ && s_i!to_code = to_code(w_i) ]
+
+                        // |s_i| = |w_i|
                         formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ subst_var, word_of_subst_var.size() });
 
-                        // subst_var!to_int = 1to_int(word_of_subst_var)
-                        // we add 1 at the beginning for the cases with 0s at the beginning of word_of_subst_var,
-                        // so that for example if word_of_subst_var="00013", it does not turn into 13 but into 100013
+                        // s_i!to_int = to_int('1'.w_i)
+                        // we add 1 at the beginning for the cases with 0s at the beginning of w_i,
+                        // so that for example if w_i="00013", it does not turn it into 13 but into 100013
                         formula_for_case.succ.push_back(word_to_int(word_of_subst_var, to_int_var(subst_var), true, false));
 
-                        // in the case that subst_var is also one of code vars, we need to force the exact value of code var here
                         if (code_vars.contains(subst_var)) {
+                            // in the case that s_i is also one of the code vars, we need to force the exact value of code var, i.e., we add the optional part
+                            //      s_i!to_code = to_code(w_i)
                             if (word_of_subst_var.size() == 1) {
                                 mata::Symbol code_point = word_of_subst_var[0];
                                 if (48 <= code_point && code_point <= 57) {
                                     // code point for a digit -> we need the exact value
+                                    //      s_i!to_code == w_i[0]
                                     formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ to_code_var(subst_var), code_point });
                                 } else {
-                                    // code point for something else (could be even a dummy symbol, but we assume digits are not represented by dummy symbol, see final_check_eh)
-                                    // -> we can just say that code var should not be equal to code point of digit, because it has the same semantics for all cases where we do not have digit
+                                    // code point for something else (could be even a dummy symbol, but we assume digits are not represented by dummy symbol, see the assumptions)
+                                    // -> we can just say that code var should be valid and not be equal to code point of digit, because it has the same semantics for all cases where we do not have digit
+                                    
+                                    // s_i!to_code is valid...
+                                    //      0 <= s_i!to_code <= max_char
+                                    formula_for_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{ 0, to_code_var(subst_var) });
+                                    formula_for_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{ to_code_var(subst_var), zstring::max_char() });
+                                    // ...but not a digit
+                                    //      s_i!to_code < 48 && 57 < s_i!to_code
                                     formula_for_case.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{ to_code_var(subst_var), 48 });
                                     formula_for_case.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{ 57, to_code_var(subst_var) });
                                 }
@@ -836,18 +907,19 @@ namespace smt::noodler {
                             }
                         }
 
-                        // add word_of_subst_var to full_word
+                        // add w_i to the end of w
                         full_word.insert(full_word.end(), word_of_subst_var.begin(), word_of_subst_var.end());
                     }
 
-                    // int_var = to_int(word_of_subst_var1 word_of_subst_var2 ... word_of_subst_varN)
+                    // add "|s| == |w| && i == to_int(w)" to C
+                    formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LeNNode>{ string_var, full_word.size() });
                     formula_for_case.succ.push_back(word_to_int(full_word, int_var, false, conv.type == ConversionType::FROM_INT));
 
                     cases_as_formula.succ.push_back(formula_for_case);
 
                 }
 
-                result_conjuncts.push_back(cases_as_formula);
+                result.succ.push_back(cases_as_formula);
 
                 break;
             }
@@ -857,9 +929,9 @@ namespace smt::noodler {
         }
 
         STRACE("str-conversion",
-            tout << "Formula for conversions: " << LenNode(LenFormulaType::AND, result_conjuncts) << std::endl;
+            tout << "Formula for conversions: " << result << std::endl;
         );
-        return LenNode(LenFormulaType::AND, result_conjuncts);
+        return result;
     }
 
     /**

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -719,7 +719,7 @@ namespace smt::noodler {
             return LenNode(LenFormulaType::EQ, std::vector<LenNode>{var, -1});
         } else {
             // var < 0
-            return LenNode(LenFormulaType::LESS, std::vector<LenNode>{var, 0});
+            return LenNode(LenFormulaType::LT, std::vector<LenNode>{var, 0});
         }
     };
 
@@ -738,8 +738,8 @@ namespace smt::noodler {
             // (|s| == 0 && c is not a valid code point)
             invalid_value.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{s, 0});
             // non-valid code point means that 'c < 0 || c > max_char'
-            invalid_value.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{c, 0});
-            invalid_value.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{zstring::max_char(), c});
+            invalid_value.succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{c, 0});
+            invalid_value.succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{zstring::max_char(), c});
         }
 
         // Now we create the second disjunct of (1):
@@ -830,8 +830,8 @@ namespace smt::noodler {
                             formula_for_case.succ.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{ code_version_of(subst_var), zstring::max_char() });
                             // ...but not a digit
                             //      code_version_of(s_i) < 48 && 57 < code_version_of(s_i)
-                            formula_for_case.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{ code_version_of(subst_var), 48 });
-                            formula_for_case.succ.emplace_back(LenFormulaType::LESS, std::vector<LenNode>{ 57, code_version_of(subst_var) });
+                            formula_for_case.succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{ code_version_of(subst_var), 48 });
+                            formula_for_case.succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{ 57, code_version_of(subst_var) });
                         }
                     } else {
                         formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ code_version_of(subst_var), -1 });

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -646,6 +646,8 @@ namespace smt::noodler {
                     }
                     break;
                 }
+                default:
+                    break;
             }
         }
 
@@ -788,15 +790,16 @@ namespace smt::noodler {
                     if (!aut->is_acyclic()) {
                         util::throw_error("cannot process to_int/from_int for automaton with infinite language");
                     }
+
+                    std::vector<std::vector<mata::Word>> new_cases;
                     for (auto word : mata::nfa::get_words(*aut, aut->num_of_states())) {
-                        std::vector<std::vector<mata::Word>> new_cases;
                         for (const auto& old_case : cases) {
                             std::vector<mata::Word> new_case = old_case;
                             new_case.push_back(word);
                             new_cases.push_back(new_case);
                         }
-                        cases = new_cases;
                     }
+                    cases = new_cases;
                 }
 
                 LenNode cases_as_formula(LenFormulaType::OR);

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -788,6 +788,7 @@ namespace smt::noodler {
                     // TODO split automaton to only-digit and not-only-digit part and do some smarter way with not-only-digit part
                     auto aut = solution.aut_ass.at(subst_var);
                     if (!aut->is_acyclic()) {
+                        STRACE("str-conversion", tout << "failing NFA:" << *aut << std::endl;);
                         util::throw_error("cannot process to_int/from_int for automaton with infinite language");
                     }
 

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -22,35 +22,6 @@ namespace smt::noodler {
         UNDERAPPROX
     };
 
-    // Conversions of strings to ints/code values and vice versa
-    enum class ConversionType {
-        TO_CODE,
-        FROM_CODE,
-        TO_INT,
-        FROM_INT,
-    };
-
-    // Term conversion: to_int/from_int ...
-    using TermConversion = std::tuple<BasicTerm,BasicTerm,ConversionType>;
-
-    inline std::string get_conversion_name(ConversionType type) {
-        switch (type)
-        {
-        case ConversionType::TO_CODE:
-            return "to_code";
-        case ConversionType::FROM_CODE:
-            return "from_code";
-        case ConversionType::TO_INT:
-            return "to_int";
-        case ConversionType::FROM_INT:
-            return "from_int";
-        
-        default:
-            UNREACHABLE();
-            return "";
-        }
-    }
-
     /**
      * @brief Get the value of the symbol representing all symbols not ocurring in the formula (i.e. a minterm)
      * 

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -299,11 +299,57 @@ namespace smt::noodler {
         std::vector<Predicate> replace_disequality(Predicate diseq);
 
         /**
-         * @brief Gets length constraint that represent to/from_code/int conversions
-         * 
-         * TODO: from_int, to_int not implemented yet
+         * @brief Gets the formula encoding to_code/from_code/to_int/from_int conversions
          */
         LenNode get_formula_for_conversions();
+
+        /**
+         * Returns the code var version of @p var used to encode to_code/from_code in get_formula_for_conversions
+         */
+        BasicTerm code_version_of(const BasicTerm& var) {
+            return BasicTerm(BasicTermType::Variable, var.get_name() + "!to_code");
+        }
+
+        /**
+         * Returns the int var version of @p var used to encode to_int/from_int in get_formula_for_conversions
+         */
+        BasicTerm int_version_of(const BasicTerm& var) {
+            return BasicTerm(BasicTermType::Variable, var.get_name() + "!to_int");
+        }
+
+        /**
+         * Gets all vars s_i, such that there exists `c = to_code(s)` or `s = from_code(c)`
+         * in conversions where s is substituted by s_1 ... s_i ... s_n in the solution.
+         */
+        std::set<BasicTerm> get_vars_substituted_in_code_conversions();
+
+        /**
+         * @brief Get the formula for code substituting variables
+         * 
+         * It basically encodes `code_version_of(c) = to_code(c)` for each c in @p code_subst_vars
+         */
+        LenNode get_formula_for_code_subst_vars(const std::set<BasicTerm>& code_subst_vars);
+
+        /**
+         * @brief Returns formula encoding `var = to_int(word)`.
+         * 
+         * Based on handle_invalid_as_from_int, invalid inputs (word is empty/contains non-digits) are either
+         *    - (false) handled normally, i.e., to_int(word) = -1, or
+         *    - (true) handled as if we had `word = from_int(var)`, i.e., var < 0.
+         * 
+         * @param start_with_one if true, encode instead `var = to_int('1'.word)`
+         */
+        LenNode word_to_int(const mata::Word& word, const BasicTerm &var, bool start_with_one, bool handle_invalid_as_from_int);
+
+        /**
+         * @brief Get the formula encoding to_code/from_code conversion
+         */
+        LenNode get_formula_for_code_conversion(const TermConversion& conv);
+
+        /**
+         * @brief Get the formula encoding to_int/from_int conversion
+         */
+        LenNode get_formula_for_int_conversion(const TermConversion& conv, const std::set<BasicTerm>& code_subst_vars);
 
         /**
          * Formula containing all not_contains predicate (nothing else)

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -134,7 +134,7 @@ namespace smt::noodler {
         NEQ, // not equal
         NOT,
         LEQ, // <=
-        LESS, // <
+        LT, // <
         LEAF, // int or variable (use LenNode(int) or LenNode(BasicTerm) constructors)
         AND,
         OR,
@@ -166,7 +166,7 @@ namespace smt::noodler {
             return os << "(not" << node.succ.at(0) << ")";
         case LenFormulaType::LEQ:
             return os << "(<= " << node.succ.at(0) << " " << node.succ.at(1) << ")";
-        case LenFormulaType::LESS:
+        case LenFormulaType::LT:
             return os << "(< " << node.succ.at(0) << " " << node.succ.at(1) << ")";
         case LenFormulaType::EQ:
             return os << "(= " << node.succ.at(0) << " " << node.succ.at(1) << ")";

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -147,8 +147,8 @@ namespace smt::noodler {
         BasicTerm atom_val;
         std::vector<struct LenNode> succ;
 
-        LenNode(int k) : type(LenFormulaType::LEAF), atom_val(BasicTermType::Length, std::to_string(k)), succ() { };
-        LenNode(rational k) : type(LenFormulaType::LEAF), atom_val(BasicTermType::Length, k.to_string()), succ() { };
+        LenNode(rational k) : type(LenFormulaType::LEAF), atom_val(BasicTermType::Length, zstring(k)), succ() { };
+        LenNode(int k) : LenNode(rational(k)) { };
         LenNode(BasicTerm val) : type(LenFormulaType::LEAF), atom_val(val), succ() { };
         LenNode(LenFormulaType tp, std::vector<struct LenNode> s = {}) : type(tp), atom_val(BasicTerm(BasicTermType::Length)), succ(s) { };
     };

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -646,6 +646,41 @@ namespace smt::noodler {
     }
     static bool operator>(const Formula& lhs, const Formula& rhs) { return !(lhs < rhs); }
 
+    // Conversions of strings to ints/code values and vice versa
+    enum class ConversionType {
+        TO_CODE,
+        FROM_CODE,
+        TO_INT,
+        FROM_INT,
+    };
+
+    // Term conversion: to_int/from_int/to_code/from_code
+    struct TermConversion {
+        ConversionType type;
+        BasicTerm string_var;
+        BasicTerm int_var;
+
+        TermConversion(ConversionType type, BasicTerm string_var, BasicTerm int_var) : type(type), string_var(std::move(string_var)), int_var(std::move(int_var)) {}
+    };
+
+    inline std::string get_conversion_name(ConversionType type) {
+        switch (type)
+        {
+        case ConversionType::TO_CODE:
+            return "to_code";
+        case ConversionType::FROM_CODE:
+            return "from_code";
+        case ConversionType::TO_INT:
+            return "to_int";
+        case ConversionType::FROM_INT:
+            return "from_int";
+        
+        default:
+            UNREACHABLE();
+            return "";
+        }
+    }
+
 } // Namespace smt::noodler.
 
 namespace std {

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -134,6 +134,7 @@ namespace smt::noodler {
         NEQ, // not equal
         NOT,
         LEQ, // <=
+        LESS, // <
         LEAF, // int or variable (use LenNode(int) or LenNode(BasicTerm) constructors)
         AND,
         OR,
@@ -147,6 +148,7 @@ namespace smt::noodler {
         std::vector<struct LenNode> succ;
 
         LenNode(int k) : type(LenFormulaType::LEAF), atom_val(BasicTermType::Length, std::to_string(k)), succ() { };
+        LenNode(rational k) : type(LenFormulaType::LEAF), atom_val(BasicTermType::Length, k.to_string()), succ() { };
         LenNode(BasicTerm val) : type(LenFormulaType::LEAF), atom_val(val), succ() { };
         LenNode(LenFormulaType tp, std::vector<struct LenNode> s = {}) : type(tp), atom_val(BasicTerm(BasicTermType::Length)), succ(s) { };
     };
@@ -164,6 +166,8 @@ namespace smt::noodler {
             return os << "(not" << node.succ.at(0) << ")";
         case LenFormulaType::LEQ:
             return os << "(<= " << node.succ.at(0) << " " << node.succ.at(1) << ")";
+        case LenFormulaType::LESS:
+            return os << "(< " << node.succ.at(0) << " " << node.succ.at(1) << ")";
         case LenFormulaType::EQ:
             return os << "(= " << node.succ.at(0) << " " << node.succ.at(1) << ")";
         case LenFormulaType::NEQ:

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -397,14 +397,7 @@ namespace smt::noodler {
             handle_is_digit(n);
         } else if (
             m_util_s.str.is_stoi(n) || // str.to_int
-            m_util_s.str.is_itos(n) // str.from_int
-        ) {
-            // handle_conversion can handle to/from_int, but decision procedure cannot.
-            // We throw error here so that we get to unknown faster. After decision
-            // procedure gets support for it, remove this and let it fall trough with
-            // is/from_code to handle_conversion
-            util::throw_error("str.to_int and str.from_int is not supported (yet)");
-        } else if (
+            m_util_s.str.is_itos(n) || // str.from_int
             m_util_s.str.is_to_code(n) || // str.to_code
             m_util_s.str.is_from_code(n) // str.from_code
         ) {
@@ -815,6 +808,12 @@ namespace smt::noodler {
 
         // Gather symbols from relevant (dis)equations and from regular expressions of relevant memberships
         std::set<mata::Symbol> symbols_in_formula = get_symbols_from_relevant();
+        // For the case that it is possible we have to_int/from_int, we keep digits (0-9) as explicit symbols, so that they are not represented by dummy_symbol and it is easier to handle to_int/from_int
+        if (!m_conversion_todo.empty()) {
+            for (mata::Symbol s = 48; s <= 57; ++s) {
+                symbols_in_formula.insert(s);
+            }
+        }
 
         // Create automata assignment for the formula
         AutAssignment aut_assignment{create_aut_assignment_for_formula(instance, symbols_in_formula)};

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -320,7 +320,7 @@ namespace smt::noodler {
          */
         lbool solve_underapprox(const Formula& instance, const AutAssignment& aut_ass,
                                 const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
-                                std::vector<std::tuple<BasicTerm,BasicTerm,ConversionType>> conversions);
+                                std::vector<TermConversion> conversions);
 
         /**
          * @brief Check if the length formula @p len_formula is satisfiable with the existing length constraints.
@@ -395,7 +395,7 @@ namespace smt::noodler {
          */
         lbool run_length_sat(const Formula& instance, const AutAssignment& aut_ass,
                                 const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
-                                std::vector<std::tuple<BasicTerm,BasicTerm,ConversionType>> conversions);
+                                std::vector<TermConversion> conversions);
 
         /***************** FINAL_CHECK_EH HELPING FUNCTIONS END *******************/
     };

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -236,7 +236,7 @@ namespace smt::noodler::util {
             return expr_ref(m_util_a.mk_le(left, right), m);
         }
 
-        case LenFormulaType::LESS: {
+        case LenFormulaType::LT: {
             assert(node.succ.size() == 2);
             expr_ref left = len_to_expr(node.succ[0], variable_map, m, m_util_s, m_util_a);
             expr_ref right = len_to_expr(node.succ[1], variable_map, m, m_util_s, m_util_a);

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -172,7 +172,7 @@ namespace smt::noodler::util {
         switch(node.type) {
         case LenFormulaType::LEAF:
             if(node.atom_val.get_type() == BasicTermType::Length)
-                return expr_ref(m_util_a.mk_int(std::stoi(node.atom_val.get_name().encode())), m);
+                return expr_ref(m_util_a.mk_int(rational(node.atom_val.get_name().encode().c_str())), m);
             else if (node.atom_val.get_type() == BasicTermType::Literal) {
                 // for literal, get the exact length of it
                 return expr_ref(m_util_a.mk_int(node.atom_val.get_name().length()), m);
@@ -234,6 +234,13 @@ namespace smt::noodler::util {
             expr_ref left = len_to_expr(node.succ[0], variable_map, m, m_util_s, m_util_a);
             expr_ref right = len_to_expr(node.succ[1], variable_map, m, m_util_s, m_util_a);
             return expr_ref(m_util_a.mk_le(left, right), m);
+        }
+
+        case LenFormulaType::LESS: {
+            assert(node.succ.size() == 2);
+            expr_ref left = len_to_expr(node.succ[0], variable_map, m, m_util_s, m_util_a);
+            expr_ref right = len_to_expr(node.succ[1], variable_map, m, m_util_s, m_util_a);
+            return expr_ref(m_util_a.mk_lt(left, right), m);
         }
 
         case LenFormulaType::NOT: {


### PR DESCRIPTION
Adds a (basic) handling of `from_int` and `to_int`.
It should be able to handle cases where they lead to solutions with finite languages in the automata for the string variables used in `from_int` and `to_int`.
I had to also rewrite the way `to_code`/`from_code` was handled.