### PR TITLE
Underapproximating `to_int`/`from_int`

### DIFF
--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -77,6 +77,18 @@ namespace smt::noodler {
             return nfa;
         }
 
+        /**
+         * @brief Returns automaton that accept non-empty words containing only symbols encoding digits (symbols from 48 to 57)
+         */
+        static mata::nfa::Nfa digit_automaton() {
+            mata::nfa::Nfa only_digits_aut(2, {0}, {1});
+            for (mata::Symbol digit = 48; digit <= 57; ++digit) {
+                only_digits_aut.delta.add(0, digit, 1);
+                only_digits_aut.delta.add(1, digit, 1);
+            }
+            return only_digits_aut;
+        }
+
         mata::nfa::Nfa get_automaton_concat(const std::vector<BasicTerm>& concat) const {
             mata::nfa::Nfa ret = mata::nfa::builder::create_empty_string_nfa();
             for(const BasicTerm& t : concat) {

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -77,12 +77,17 @@ namespace smt::noodler {
             return nfa;
         }
 
+        // represents code point of digit 0
+        static const mata::Symbol DIGIT_SYMBOL_START = 48;
+        // represents code point of digit 9
+        static const mata::Symbol DIGIT_SYMBOL_END = 57;
+
         /**
          * @brief Returns automaton that accept non-empty words containing only symbols encoding digits (symbols from 48 to 57)
          */
         static mata::nfa::Nfa digit_automaton() {
             mata::nfa::Nfa only_digits_aut(2, {0}, {1});
-            for (mata::Symbol digit = 48; digit <= 57; ++digit) {
+            for (mata::Symbol digit = DIGIT_SYMBOL_START; digit <= DIGIT_SYMBOL_END; ++digit) {
                 only_digits_aut.delta.add(0, digit, 1);
                 only_digits_aut.delta.add(1, digit, 1);
             }

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -77,17 +77,6 @@ namespace smt::noodler {
             return nfa;
         }
 
-        /**
-         * @brief Get NFA that accepts strings with only digits (also empty string)
-         */
-        mata::nfa::Nfa digit_automaton() const {
-            mata::nfa::Nfa only_digits(1, {0}, {0});
-            for (mata::Symbol digit = 48; digit <= 57; ++digit) {
-                only_digits.delta.add(0, digit, 0);
-            }
-            return only_digits;
-        }
-
         mata::nfa::Nfa get_automaton_concat(const std::vector<BasicTerm>& concat) const {
             mata::nfa::Nfa ret = mata::nfa::builder::create_empty_string_nfa();
             for(const BasicTerm& t : concat) {

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -77,6 +77,17 @@ namespace smt::noodler {
             return nfa;
         }
 
+        /**
+         * @brief Get NFA that accepts strings with only digits (also empty string)
+         */
+        mata::nfa::Nfa digit_automaton() const {
+            mata::nfa::Nfa only_digits(1, {0}, {0});
+            for (mata::Symbol digit = 48; digit <= 57; ++digit) {
+                only_digits.delta.add(0, digit, 0);
+            }
+            return only_digits;
+        }
+
         mata::nfa::Nfa get_automaton_concat(const std::vector<BasicTerm>& concat) const {
             mata::nfa::Nfa ret = mata::nfa::builder::create_empty_string_nfa();
             for(const BasicTerm& t : concat) {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -772,7 +772,10 @@ namespace smt::noodler {
 
         // automaton representing all valid inputs (only digits)
         // - we also keep empty word, because we will use it for substituted vars, and one of them can be empty, while other has only digits (for example s1="12", s2="" but s="12" is valid)
-        mata::nfa::Nfa only_digits = solution.aut_ass.digit_automaton();
+        mata::nfa::Nfa only_digits(1, {0}, {0});
+        for (mata::Symbol digit = 48; digit <= 57; ++digit) {
+            only_digits.delta.add(0, digit, 0);
+        }
         STRACE("str-conversion-int", tout << "only-digit NFA:" << std::endl << only_digits << std::endl;);
         // automaton representing all non-valid inputs (contain non-digit)
         mata::nfa::Nfa contain_non_digit = solution.aut_ass.complement_aut(only_digits);
@@ -825,7 +828,9 @@ namespace smt::noodler {
                 // util::throw_error("cannot process to_int/from_int for automaton with infinite language");
                 is_underapproximation = true;
                 if (max_length_of_words > 3) {
-                    max_length_of_words = 3; // there are 10^max_length_if_words possible cases, we put limit so there is not MEMOUT
+                    // there are 10^max_length_of_words possible cases, we put limit so there is not MEMOUT
+                    // but (experimentally) it seems to be better to reduce it even more if the automaton has less states
+                    max_length_of_words = 3;
                 }
             }
 
@@ -1093,7 +1098,7 @@ namespace smt::noodler {
         prep_handler.reduce_regular_sequence(1);
         prep_handler.remove_regular();
 
-        prep_handler.check_conversions_validity(conversions);
+        prep_handler.conversions_validity(conversions);
 
         // Refresh the instance
         this->formula = prep_handler.get_modified_formula();

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1046,7 +1046,7 @@ namespace smt::noodler {
         FormulaPreprocessor prep_handler{std::move(this->formula), std::move(this->init_aut_ass), std::move(this->init_length_sensitive_vars), m_params};
 
         // we collect variables used in conversions, some preprocessing rules cannot be applied for them
-        std::set<BasicTerm> conv_vars;
+        std::unordered_set<BasicTerm> conv_vars;
         for (const auto &conv : conversions) {
             conv_vars.insert(conv.string_var);
         }

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -772,10 +772,7 @@ namespace smt::noodler {
 
         // automaton representing all valid inputs (only digits)
         // - we also keep empty word, because we will use it for substituted vars, and one of them can be empty, while other has only digits (for example s1="12", s2="" but s="12" is valid)
-        mata::nfa::Nfa only_digits(1, {0}, {0});
-        for (mata::Symbol digit = 48; digit <= 57; ++digit) {
-            only_digits.delta.add(0, digit, 0);
-        }
+        mata::nfa::Nfa only_digits = solution.aut_ass.digit_automaton();
         STRACE("str-conversion-int", tout << "only-digit NFA:" << std::endl << only_digits << std::endl;);
         // automaton representing all non-valid inputs (contain non-digit)
         mata::nfa::Nfa contain_non_digit = solution.aut_ass.complement_aut(only_digits);
@@ -1095,6 +1092,8 @@ namespace smt::noodler {
         }
         prep_handler.reduce_regular_sequence(1);
         prep_handler.remove_regular();
+
+        prep_handler.check_conversions_validity(conversions);
 
         // Refresh the instance
         this->formula = prep_handler.get_modified_formula();

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -798,8 +798,8 @@ namespace smt::noodler {
                 aut_valid_part = aut;
             }
 
-            STRACE("str-conversion-int", tout << "only-digit NFA:" << std::endl << aut_valid_part << std::endl;);
-            STRACE("str-conversion-int", tout << "contains-non-digit NFA:" << std::endl << aut_non_valid_part << std::endl;);
+            STRACE("str-conversion-int", tout << "only-digit NFA:" << std::endl << *aut_valid_part << std::endl;);
+            STRACE("str-conversion-int", tout << "contains-non-digit NFA:" << std::endl << *aut_non_valid_part << std::endl;);
 
             if (!aut_non_valid_part->is_lang_empty()) {
                 // aut_non_valid_part is language of words that contain at least one non-digit
@@ -821,7 +821,7 @@ namespace smt::noodler {
 
             // we want to enumerate all words containing digits -> cannot be infinite language
             if (!aut_valid_part->is_acyclic()) {
-                STRACE("str-conversion", tout << "failing NFA:" << std::endl << aut_valid_part << std::endl;);
+                STRACE("str-conversion", tout << "failing NFA:" << std::endl << *aut_valid_part << std::endl;);
                 // util::throw_error("cannot process to_int/from_int for automaton with infinite language");
                 is_underapproximation = true;
                 if (max_length_of_words > 3) {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -813,7 +813,8 @@ namespace smt::noodler {
             // we want to enumerate all words containing digits -> cannot be infinite language
             if (!aut_valid_part.is_acyclic()) {
                 STRACE("str-conversion", tout << "failing NFA:" << std::endl << aut_valid_part << std::endl;);
-                util::throw_error("cannot process to_int/from_int for automaton with infinite language");
+                // util::throw_error("cannot process to_int/from_int for automaton with infinite language");
+                is_underapproximation = true;
             }
 
             std::vector<std::vector<mata::Word>> new_cases;

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -866,7 +866,7 @@ namespace smt::noodler {
                     if (word_of_subst_var.size() == 1) { // |w_i| = 1
                         mata::Symbol code_point = word_of_subst_var[0]; // this must be a code point of a digit, as w_i can only contain digits
                         formula_for_case.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{ code_version_of(subst_var), code_point });
-                    } // "else" part is not needed, that should be solved by setting "|s_i| = |w_i|" and by using the forula from function get_formula_for_code_subst_vars()
+                    } // "else" part is not needed, that should be solved by setting "|s_i| = |w_i|" and by using the formula from function get_formula_for_code_subst_vars()
                 }
 
                 // add w_i to the end of w

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -705,8 +705,8 @@ namespace smt::noodler {
 
         for (mata::Symbol s : word) {
             is_invalid = false; // word is not empty, it might not be invalid
-            if (48 <= s && s <= 57) { // s is a code point of digit
-                rational real_digit(s - 48);
+            if (AutAssignment::DIGIT_SYMBOL_START <= s && s <= AutAssignment::DIGIT_SYMBOL_END) { // s is a code point of digit
+                rational real_digit(s - AutAssignment::DIGIT_SYMBOL_START);
                 resulting_int = resulting_int*10 + real_digit;
             } else {
                 // it is possible that s is a dummy symbol, but we assume that all digits are explicitly in the alphabet, see the assumptions
@@ -778,7 +778,7 @@ namespace smt::noodler {
         // automaton representing all valid inputs (only digits)
         // - we also keep empty word, because we will use it for substituted vars, and one of them can be empty, while other has only digits (for example s1="12", s2="" but s="12" is valid)
         mata::nfa::Nfa only_digits(1, {0}, {0});
-        for (mata::Symbol digit = 48; digit <= 57; ++digit) {
+        for (mata::Symbol digit = AutAssignment::DIGIT_SYMBOL_START; digit <= AutAssignment::DIGIT_SYMBOL_END; ++digit) {
             only_digits.delta.add(0, digit, 0);
         }
         STRACE("str-conversion-int", tout << "only-digit NFA:" << std::endl << only_digits << std::endl;);
@@ -812,9 +812,9 @@ namespace smt::noodler {
                     if (code_subst_vars.contains(subst_var)) {
                         // s_i is used in some to_code/from_code
                         // => we need to add to the previous formula also the fact, that s_i cannot encode code point of a digit
-                        //      .. && !(48 <= code_version_of(s_i) <= 57)
-                        result.succ.back().succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{ code_version_of(subst_var), 48 });
-                        result.succ.back().succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{ 57, code_version_of(subst_var) });
+                        //      .. && !(AutAssignment::DIGIT_SYMBOL_START <= code_version_of(s_i) <= AutAssignment::DIGIT_SYMBOL_END)
+                        result.succ.back().succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{ code_version_of(subst_var), AutAssignment::DIGIT_SYMBOL_START });
+                        result.succ.back().succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{ AutAssignment::DIGIT_SYMBOL_END, code_version_of(subst_var) });
                     }
                 }
             } else {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -817,7 +817,9 @@ namespace smt::noodler {
                 STRACE("str-conversion", tout << "failing NFA:" << std::endl << aut_valid_part << std::endl;);
                 // util::throw_error("cannot process to_int/from_int for automaton with infinite language");
                 is_underapproximation = true;
-                max_length_of_words = 3; // there are 10^max_length_if_words possible cases, we put limit so there is not MEMOUT
+                if (max_length_of_words > 3) {
+                    max_length_of_words = 3; // there are 10^max_length_if_words possible cases, we put limit so there is not MEMOUT
+                }
             }
 
             std::vector<std::vector<mata::Word>> new_cases;

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -810,15 +810,18 @@ namespace smt::noodler {
                 }
             }
 
+            unsigned max_length_of_words = aut_valid_part.num_of_states();
+
             // we want to enumerate all words containing digits -> cannot be infinite language
             if (!aut_valid_part.is_acyclic()) {
                 STRACE("str-conversion", tout << "failing NFA:" << std::endl << aut_valid_part << std::endl;);
                 // util::throw_error("cannot process to_int/from_int for automaton with infinite language");
                 is_underapproximation = true;
+                max_length_of_words = 3; // there are 10^max_length_if_words possible cases, we put limit so there is not MEMOUT
             }
 
             std::vector<std::vector<mata::Word>> new_cases;
-            for (auto word : aut_valid_part.get_words(aut_valid_part.num_of_states())) {
+            for (auto word : aut_valid_part.get_words(max_length_of_words)) {
                 for (const auto& old_case : cases) {
                     std::vector<mata::Word> new_case = old_case;
                     new_case.push_back(word);

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -765,7 +765,7 @@ namespace smt::noodler {
     }
 
     // see the comment of get_formula_for_conversions for explanation
-    std::pair<LenNode, LenNodePrecision> DecisionProcedure::get_formula_for_int_conversion(const TermConversion& conv, const std::set<BasicTerm>& code_subst_vars) {
+    std::pair<LenNode, LenNodePrecision> DecisionProcedure::get_formula_for_int_conversion(const TermConversion& conv, const std::set<BasicTerm>& code_subst_vars, const unsigned underapproximating_length) {
         const BasicTerm& s = conv.string_var;
         const BasicTerm& i = conv.int_var;
 
@@ -829,12 +829,11 @@ namespace smt::noodler {
             // we want to enumerate all words containing digits -> cannot be infinite language
             if (!aut_valid_part->is_acyclic()) {
                 STRACE("str-conversion", tout << "failing NFA:" << std::endl << *aut_valid_part << std::endl;);
-                // util::throw_error("cannot process to_int/from_int for automaton with infinite language");
                 res_precision = LenNodePrecision::UNDERAPPROX;
-                if (max_length_of_words > 3) {
+                if (max_length_of_words > underapproximating_length) {
                     // there are 10^max_length_of_words possible cases, we put limit so there is not MEMOUT
                     // but (experimentally) it seems to be better to reduce it even more if the automaton has less states
-                    max_length_of_words = 3;
+                    max_length_of_words = underapproximating_length;
                 }
             }
 

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -23,6 +23,15 @@ namespace smt::noodler {
     };
 
     /**
+     * @brief Length formula precision
+     */
+    enum struct LenNodePrecisionType {
+        PRECISE,
+        UNDERAPPROX,
+        OVERAPPROX,
+    };
+
+    /**
      * @brief Get the value of the symbol representing all symbols not ocurring in the formula (i.e. a minterm)
      * 
      * Dummy symbol represents all symbols not occuring in the problem. It is needed,
@@ -81,8 +90,10 @@ namespace smt::noodler {
          * Get length constraints for the solution. Assumes that we have some solution from
          * running compute_next_solution(), the solution is actually solution if the length
          * constraints hold.
+         * 
+         * 
          */
-        virtual LenNode get_lengths() {
+        virtual std::tuple<LenNode, LenNodePrecisionType> get_lengths() {
             throw std::runtime_error("Unimplemented");
         }
 
@@ -374,7 +385,7 @@ namespace smt::noodler {
     public:
         
         bool is_underapproximation = false;
-        
+
         /**
          * Initialize a new decision procedure that can solve word equations
          * (equalities of concatenations of string variables) with regular constraints

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -373,6 +373,8 @@ namespace smt::noodler {
 
     public:
         
+        bool is_underapproximation = false;
+        
         /**
          * Initialize a new decision procedure that can solve word equations
          * (equalities of concatenations of string variables) with regular constraints

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -360,8 +360,11 @@ namespace smt::noodler {
 
         /**
          * @brief Get the formula encoding to_int/from_int conversion
+         * 
+         * @param underapproximating_length For the case that we need to underapproximate, this variable sets
+         * the length up to which we underapproximate
          */
-        std::pair<LenNode, LenNodePrecision> get_formula_for_int_conversion(const TermConversion& conv, const std::set<BasicTerm>& code_subst_vars);
+        std::pair<LenNode, LenNodePrecision> get_formula_for_int_conversion(const TermConversion& conv, const std::set<BasicTerm>& code_subst_vars, const unsigned underapproximating_length = 3);
 
         /**
          * Formula containing all not_contains predicate (nothing else)

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -25,7 +25,7 @@ namespace smt::noodler {
     /**
      * @brief Length formula precision
      */
-    enum struct LenNodePrecisionType {
+    enum struct LenNodePrecision {
         PRECISE,
         UNDERAPPROX,
         OVERAPPROX,
@@ -91,9 +91,10 @@ namespace smt::noodler {
          * running compute_next_solution(), the solution is actually solution if the length
          * constraints hold.
          * 
-         * 
+         * The second elemnt of the resulting pair marks whether the lennode is precise or
+         * over/underapproximation.
          */
-        virtual std::tuple<LenNode, LenNodePrecisionType> get_lengths() {
+        virtual std::pair<LenNode, LenNodePrecision> get_lengths() {
             throw std::runtime_error("Unimplemented");
         }
 
@@ -312,7 +313,7 @@ namespace smt::noodler {
         /**
          * @brief Gets the formula encoding to_code/from_code/to_int/from_int conversions
          */
-        LenNode get_formula_for_conversions();
+        std::pair<LenNode, LenNodePrecision> get_formula_for_conversions();
 
         /**
          * Returns the code var version of @p var used to encode to_code/from_code in get_formula_for_conversions
@@ -360,7 +361,7 @@ namespace smt::noodler {
         /**
          * @brief Get the formula encoding to_int/from_int conversion
          */
-        LenNode get_formula_for_int_conversion(const TermConversion& conv, const std::set<BasicTerm>& code_subst_vars);
+        std::pair<LenNode, LenNodePrecision> get_formula_for_int_conversion(const TermConversion& conv, const std::set<BasicTerm>& code_subst_vars);
 
         /**
          * Formula containing all not_contains predicate (nothing else)
@@ -383,8 +384,6 @@ namespace smt::noodler {
         lbool can_unify_not_contains(const FormulaPreprocessor& prep);
 
     public:
-        
-        bool is_underapproximation = false;
 
         /**
          * Initialize a new decision procedure that can solve word equations
@@ -430,7 +429,7 @@ namespace smt::noodler {
 
         LenNode get_initial_lengths() override;
 
-        LenNode get_lengths() override;
+        std::pair<LenNode, LenNodePrecision> get_lengths() override;
     };
 }
 

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1520,4 +1520,18 @@ namespace smt::noodler {
         return can_unify(left, right, check);
     }
 
+
+    void FormulaPreprocessor::check_conversions_validity(std::vector<TermConversion>& conversions) {
+        mata::nfa::Nfa sigma_aut = aut_ass.sigma_automaton();
+        mata::nfa::Nfa only_digits_aut = aut_ass.digit_automaton();
+
+        for (const auto& conv : conversions) {
+            if ((conv.type == ConversionType::TO_CODE && mata::nfa::reduce(mata::nfa::intersection(sigma_aut,       *aut_ass.at(conv.string_var))).is_lang_empty()) ||
+                (conv.type == ConversionType::TO_INT  && mata::nfa::reduce(mata::nfa::intersection(only_digits_aut, *aut_ass.at(conv.string_var))).is_lang_empty()))
+                {
+                    len_formula.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{conv.int_var, -1});
+                }
+        }
+    }
+
 } // Namespace smt::noodler.

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -1541,11 +1541,7 @@ namespace smt::noodler {
      */
     void FormulaPreprocessor::conversions_validity(std::vector<TermConversion>& conversions) {
         mata::nfa::Nfa sigma_aut = aut_ass.sigma_automaton();
-        mata::nfa::Nfa only_digits_aut(2, {0}, {1});
-        for (mata::Symbol digit = 48; digit <= 57; ++digit) {
-            only_digits_aut.delta.add(0, digit, 1);
-            only_digits_aut.delta.add(1, digit, 1);
-        }
+        mata::nfa::Nfa only_digits_aut = AutAssignment::digit_automaton();
 
         for (const auto& conv : conversions) {
             if ((conv.type == ConversionType::TO_CODE && mata::nfa::reduce(mata::nfa::intersection(sigma_aut,       *aut_ass.at(conv.string_var))).is_lang_empty()) ||

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -298,12 +298,14 @@ namespace smt::noodler {
     }
 
     /**
-     * @brief Iteratively remove regular predicates. A regular predicate is of the form X = X_1 X_2 ... X_n where
+     * Iteratively remove regular predicates. A regular predicate is of the form X = X_1 X_2 ... X_n where
      * X_1 ... X_n does not occurr elsewhere in the system. Formally, L = R is regular if |L| = 1 and each variable
      * from Vars(R) has a single occurrence in the system only. Regular predicates can be removed from the system
      * provided A(X) = A(X) \cap A(X_1).A(X_2)...A(X_n) where A(X) is the automaton assigned to variable X.
+     * 
+     * @param disallowed_vars - if any of these var occurs in equation, it cannot be removed
      */
-    void FormulaPreprocessor::remove_regular() {
+    void FormulaPreprocessor::remove_regular(const std::set<BasicTerm>& disallowed_vars) {
         std::vector<std::pair<size_t, Predicate>> regs;
         this->formula.get_side_regulars(regs);
         std::deque<std::pair<size_t, Predicate>> worklist(regs.begin(), regs.end());
@@ -312,7 +314,14 @@ namespace smt::noodler {
             std::pair<size_t, Predicate> pr = worklist.front();
             worklist.pop_front();
 
+            STRACE("str-prep-remove_regular", tout << "Remove regular:" << pr.second << std::endl;);
+
             assert(pr.second.get_left_side().size() == 1);
+
+            bool contains_disallowed = !set_disjoint(this->len_variables, pr.second.get_vars());
+            if (contains_disallowed) {
+                continue;
+            }
 
             // if right side contains len vars (except when we have X = Y), we must do splitting => cannot remove
             bool is_right_side_len = !set_disjoint(this->len_variables, pr.second.get_side_vars(Predicate::EquationSideType::Right));
@@ -332,6 +341,7 @@ namespace smt::noodler {
             }
 
             this->formula.remove_predicate(pr.first);
+            STRACE("str-prep-remove_regular", tout << "removed" << std::endl;);
 
             // check if by removing the regular equation, some other equations did not become regular
             // we only need to check this for left_var, as the variables from the right side do not occur

--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -305,7 +305,7 @@ namespace smt::noodler {
      * 
      * @param disallowed_vars - if any of these var occurs in equation, it cannot be removed
      */
-    void FormulaPreprocessor::remove_regular(const std::set<BasicTerm>& disallowed_vars) {
+    void FormulaPreprocessor::remove_regular(const std::unordered_set<BasicTerm>& disallowed_vars) {
         std::vector<std::pair<size_t, Predicate>> regs;
         this->formula.get_side_regulars(regs);
         std::deque<std::pair<size_t, Predicate>> worklist(regs.begin(), regs.end());
@@ -318,7 +318,7 @@ namespace smt::noodler {
 
             assert(pr.second.get_left_side().size() == 1);
 
-            bool contains_disallowed = !set_disjoint(this->len_variables, pr.second.get_vars());
+            bool contains_disallowed = !set_disjoint(disallowed_vars, pr.second.get_vars());
             if (contains_disallowed) {
                 continue;
             }

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -58,10 +58,16 @@ namespace smt::noodler {
 
     template<typename T>
     bool set_disjoint(const std::unordered_set<T>& t1, const std::set<T>& t2) {
-        std::set<T> inter;
-        for(const auto& t : t2) {
-            if(t1.find(t) != t1.end())
-                return false;
+        if (t1.size() < t2.size()) {
+            for(const auto& t : t1) {
+                if(t2.contains(t))
+                    return false;
+            }
+        } else {
+            for(const auto& t : t2) {
+                if(t1.contains(t))
+                    return false;
+            }
         }
         return true;
     }
@@ -357,7 +363,7 @@ namespace smt::noodler {
 
         Formula get_modified_formula() const;
 
-        void remove_regular(const std::set<BasicTerm>& disallowed_vars);
+        void remove_regular(const std::unordered_set<BasicTerm>& disallowed_vars);
         void propagate_variables();
         void propagate_eps();
         void generate_identities();

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -377,6 +377,8 @@ namespace smt::noodler {
         bool contains_unsat_eqs_or_diseqs();
         bool can_unify_contain(const Concat& left, const Concat& right) const;
 
+        void check_conversions_validity(std::vector<TermConversion>& conversions);
+
         /**
          * @brief Replace all occurrences of find with replace. Warning: do not modify the automata assignment.
          *

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -357,7 +357,7 @@ namespace smt::noodler {
 
         Formula get_modified_formula() const;
 
-        void remove_regular();
+        void remove_regular(const std::set<BasicTerm>& disallowed_vars);
         void propagate_variables();
         void propagate_eps();
         void generate_identities();

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -377,7 +377,7 @@ namespace smt::noodler {
         bool contains_unsat_eqs_or_diseqs();
         bool can_unify_contain(const Concat& left, const Concat& right) const;
 
-        void check_conversions_validity(std::vector<TermConversion>& conversions);
+        void conversions_validity(std::vector<TermConversion>& conversions);
 
         /**
          * @brief Replace all occurrences of find with replace. Warning: do not modify the automata assignment.

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.cpp
@@ -10,9 +10,9 @@
 
 namespace smt::noodler {
 
-    LenNode NielsenDecisionProcedure::get_lengths() {
+    std::pair<LenNode, LenNodePrecision> NielsenDecisionProcedure::get_lengths() {
         STRACE("str", tout << "Nielsen lengths: " << length_formula_for_solution << std::endl;);
-        return std::move(length_formula_for_solution);
+        return {std::move(length_formula_for_solution), LenNodePrecision::PRECISE};
     }
 
     /**

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.h
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.h
@@ -344,7 +344,7 @@ namespace smt::noodler {
         LenNode get_initial_lengths() override {
             return LenNode(LenFormulaType::TRUE);
         }
-        LenNode get_lengths() override;
+        std::pair<LenNode, LenNodePrecision> get_lengths() override;
         void init_computation() override;
 
         lbool preprocess(PreprocessType opt = PreprocessType::PLAIN, const BasicTermEqiv &len_eq_vars = {}) override;

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -492,6 +492,8 @@ namespace smt::noodler {
         expr_ref l{get_enode(x)->get_expr(), m};
         expr_ref r{get_enode(y)->get_expr(), m};
 
+        STRACE("str", tout << "new_eq: " << l <<  " = " << r << std::endl;);
+
         app* equation = m.mk_eq(l, r);
 
         // TODO explain what is happening here
@@ -526,8 +528,6 @@ namespace smt::noodler {
                 }
             }
         }
-
-        STRACE("str", tout << "new_eq: " << l <<  " = " << r << std::endl;);
     }
 
     void theory_str_noodler::new_diseq_eh(theory_var x, theory_var y) {

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -878,27 +878,37 @@ namespace smt::noodler {
         dec_proc.init_computation();
 
         expr_ref block_len(m.mk_false(), m);
+        bool was_something_approximated = false;
         while (true) {
             result = dec_proc.compute_next_solution();
             if (result == l_true) {
-                lengths = len_node_to_z3_formula(dec_proc.get_lengths());
-                if (check_len_sat(lengths) == l_true) {
+                auto [noodler_lengths, precision] = dec_proc.get_lengths();
+                lengths = len_node_to_z3_formula(noodler_lengths);
+                lbool is_lengths_sat = check_len_sat(lengths);
+                
+                if (is_lengths_sat == l_true && precision != LenNodePrecision::OVERAPPROX) {
                     STRACE("str", tout << "len sat " << mk_pp(lengths, m) << std::endl;);
                     // save the current assignment to catch it during the loop protection
                     block_curr_len(lengths, true, false);
                     return FC_DONE;
-                } else {
+                } else if (is_lengths_sat == l_false && precision != LenNodePrecision::UNDERAPPROX) {
+                    // TODO is handling underapprox correct here? is it even safe to underapproximate? we do not have a case where we underapproximate, but for the future
                     STRACE("str", tout << "len unsat " <<  mk_pp(lengths, m) << std::endl;);
                     block_len = m.mk_or(block_len, lengths);
+                } else {
+                    was_something_approximated = true;
                 }
             } else if (result == l_false) {
                 // we did not find a solution (with satisfiable length constraints)
                 // we need to block current assignment
                 STRACE("str", tout << "assignment unsat " << mk_pp(block_len, m) << std::endl;);
-                if (dec_proc.is_underapproximation) {
-                    STRACE("str", tout << "there was underapproximating - giving up" << std::endl);
+
+                if (was_something_approximated) {
+                    // if some length formula was an approximation and it did not lead to solution, we have to give up
+                    STRACE("str", tout << "there was approximating - giving up" << std::endl);
                     return FC_GIVEUP;
                 }
+
                 if(m.is_false(block_len)) {
                     block_curr_len(block_len, false, true);
                 } else {

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -590,6 +590,7 @@ namespace smt::noodler {
         m_word_diseq_todo.push_scope();
         m_membership_todo.push_scope();
         m_not_contains_todo.push_scope();
+        m_conversion_todo.push_scope();
         STRACE("str", tout << "push_scope: " << m_scope_level << '\n';);
     }
 
@@ -603,6 +604,7 @@ namespace smt::noodler {
         m_word_diseq_todo.pop_scope(num_scopes);
         m_membership_todo.pop_scope(num_scopes);
         m_not_contains_todo.pop_scope(num_scopes);
+        m_conversion_todo.pop_scope(num_scopes);
         m_rewrite.reset();
         STRACE("str",
             tout << "pop_scope: " << num_scopes << " (back to level " << m_scope_level << ")\n";);
@@ -894,6 +896,7 @@ namespace smt::noodler {
                 // we need to block current assignment
                 STRACE("str", tout << "assignment unsat " << mk_pp(block_len, m) << std::endl;);
                 if (dec_proc.is_underapproximation) {
+                    STRACE("str", tout << "there was underapproximating - giving up" << std::endl);
                     return FC_GIVEUP;
                 }
                 if(m.is_false(block_len)) {

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -893,6 +893,9 @@ namespace smt::noodler {
                 // we did not find a solution (with satisfiable length constraints)
                 // we need to block current assignment
                 STRACE("str", tout << "assignment unsat " << mk_pp(block_len, m) << std::endl;);
+                if (dec_proc.is_underapproximation) {
+                    return FC_GIVEUP;
+                }
                 if(m.is_false(block_len)) {
                     block_curr_len(block_len, false, true);
                 } else {

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -235,7 +235,7 @@ namespace smt::noodler {
 
         dec_proc.init_computation();
         while(dec_proc.compute_next_solution() == l_true) {
-            expr_ref lengths = len_node_to_z3_formula(dec_proc.get_lengths());
+            expr_ref lengths = len_node_to_z3_formula(dec_proc.get_lengths().first);
             if(check_len_sat(lengths) == l_true) {
                 return l_true;
             }
@@ -475,7 +475,7 @@ namespace smt::noodler {
         while (true) {
             lbool result = nproc.compute_next_solution();
             if (result == l_true) {
-                expr_ref lengths = len_node_to_z3_formula(nproc.get_lengths());
+                expr_ref lengths = len_node_to_z3_formula(nproc.get_lengths().first);
                 if (check_len_sat(lengths) == l_true) {
                     return l_true;
                 } else {


### PR DESCRIPTION
This PR is mostly for `stringfuzz` benchmark.

It adds a possibility to generate underapproximating LIA formula for `to_int`/`from_int`, so that if we end up with non-finite language for the string variable of these two predicates, we still generate "something": we check all the words up to some length (right now 3).
It can lead to SAT in most of the cases.

For the UNSAT formulae,  I added a new preprocessing step (`conversions_validity`), that can immediately tell that there are no valid inputs for `to_int` (i.e., its result is `-1`). This can also help in a lot of cases.

It seems that what would really help (and probably would solve nearly everything in stringfuzz), is to get information about input equations such as `5 = str.to_int(x)`.
We could then generate `x ∈ 0*5` which would in most cases lead to UNSAT.
However, I did not find a way to get this information into noodler.