### PR TITLE
Length based conversion encoding of int conversions

### DIFF
--- a/src/smt/theory_str_noodler/aut_assignment.cpp
+++ b/src/smt/theory_str_noodler/aut_assignment.cpp
@@ -67,7 +67,7 @@ namespace smt::noodler {
         // maps all states q reachable in n steps (starting with n=0), into the vector of interval words with which we can reach the given state from the inital state
         std::map<mata::nfa::State,std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>> cur_level = { {*(aut.initial.begin()), {{}}} };
 
-        while (!cur_level.empty()) {
+        while (true) {
             // we will compute the mapping for states reachable in n+1 steps
             std::map<mata::nfa::State,std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>> next_level;
 

--- a/src/smt/theory_str_noodler/aut_assignment.cpp
+++ b/src/smt/theory_str_noodler/aut_assignment.cpp
@@ -50,4 +50,99 @@ namespace smt::noodler {
         nfa.final.insert(state);
         return nfa;
     }
+
+    std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>> AutAssignment::get_interval_words(const mata::nfa::Nfa& aut) {
+        assert(aut.initial.size() == 1); // is deterministic and accepts a non-empty language
+        assert(aut.is_acyclic()); // accepts a finite language
+
+        // Because aut is minimized (i.e., deterministic) and finite, the automaton aut has a specific structure
+        //      - there is exactly one initial and final state
+        //      - there are no loops
+        // Therefore, each state can be reached exactly after some specific number of steps (and we can never reach it after), so for each step n, starting with 0,
+        // we compute the reachable interval words for each state that can be reached in n steps
+
+        // maps all states q reachable in n steps (starting with n=0), into the vector of interval words with which we can reach the given state from the inital state
+        std::map<mata::nfa::State,std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>> cur_level = { {*(aut.initial.begin()), {{}}} };
+
+        while (!cur_level.empty()) {
+            // we will compute the mapping for states reachable in n+1 steps
+            std::map<mata::nfa::State,std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>> next_level;
+
+            for (auto const& [st, interval_words] : cur_level) {
+                // st - state reachable in n steps
+                // interval_words - interval words with whose we can reach st from the initial state
+
+                auto trans_from_st_it = aut.delta[st].begin();
+
+                if (trans_from_st_it == aut.delta[st].end()) {
+                    // if there are no transitions, st must be final state (and there is no other state that can be reached in n number of steps)
+                    assert(aut.final.contains(st));
+                    assert(cur_level.size() == 1);
+                    // interval_words should therefore be the accepted interval words by aut
+                    return interval_words;
+                }
+
+                // From mata representation, symbols are ordered in aut.delta[st], so we can easily compute the intervals by checking
+                // for "change" of target of the next transition (aut is deterministic, so we always have just one target).
+                // For example, if we have transitions
+                //      st -5-> t1
+                //      st -6-> t1
+                //      st -8-> t1
+                //      st -9-> t2
+                //      st -10-> t2
+                //      st -11-> t2
+                //      st -12-> t3
+                // we get intervals
+                //      st -[5-6]-> t1
+                //      st -[8-8]-> t1
+                //      st -[6-11]-> t2
+                //      st -[12-12]-> t3
+
+                assert(trans_from_st_it->targets.size() == 1); // should be deterministic
+
+                // target of previous transition
+                mata::nfa::State last_target = *trans_from_st_it->targets.begin();
+                // symbol of previous transition
+                mata::Symbol last_symbol = trans_from_st_it->symbol;
+                // starting symbol of the interval we are currently computing
+                mata::Symbol last_starting_symbol = trans_from_st_it->symbol;
+
+                ++trans_from_st_it;
+
+                while (trans_from_st_it != aut.delta[st].end()) {
+                    assert(trans_from_st_it->targets.size() == 1); // should be deterministic
+
+                    mata::nfa::State cur_target = *trans_from_st_it->targets.begin();
+                    mata::nfa::State cur_symbol = trans_from_st_it->symbol;
+                    
+                    if (cur_target != last_target || cur_symbol != last_symbol+1) {
+                        // we should end the current interval, as the target changed, or there is a gap between symbols
+                        std::pair<mata::Symbol,mata::Symbol> cur_interval = {last_starting_symbol, last_symbol};
+                        
+                        // add the interval to all interval words with whose we reached st and add these interval words to state last_target
+                        for (auto vec_of_intervals : interval_words) {
+                            vec_of_intervals.push_back(cur_interval);
+                            next_level[last_target].push_back(vec_of_intervals);
+                        }
+
+                        // start new interval
+                        last_starting_symbol = cur_symbol;
+                    }
+                    
+                    last_target = cur_target;
+                    last_symbol = cur_symbol;
+                    ++trans_from_st_it;
+                }
+
+                // we need to also handle the last interval
+                std::pair<mata::Symbol,mata::Symbol> cur_interval = {last_starting_symbol, last_symbol};
+                for (auto vec_of_intervals : interval_words) {
+                    vec_of_intervals.push_back(cur_interval);
+                    next_level[last_target].push_back(vec_of_intervals);
+                }
+            }
+            
+            cur_level = next_level;
+        }
+    }
 }

--- a/src/smt/theory_str_noodler/aut_assignment.cpp
+++ b/src/smt/theory_str_noodler/aut_assignment.cpp
@@ -108,7 +108,7 @@ namespace smt::noodler {
                 // we get intervals
                 //      st -[5-6]-> t1
                 //      st -[8-8]-> t1
-                //      st -[6-11]-> t2
+                //      st -[9-11]-> t2
                 //      st -[12-12]-> t3
 
                 assert(trans_from_st_it->targets.size() == 1); // should be deterministic

--- a/src/smt/theory_str_noodler/aut_assignment.cpp
+++ b/src/smt/theory_str_noodler/aut_assignment.cpp
@@ -55,6 +55,9 @@ namespace smt::noodler {
         assert(aut.initial.size() == 1); // is deterministic and accepts a non-empty language
         assert(aut.is_acyclic()); // accepts a finite language
 
+
+        STRACE("str-interval-words", tout << "NFA for which we compute interval words:" << std::endl << aut << std::endl;);
+
         // Because aut is minimized (i.e., deterministic) and finite, the automaton aut has a specific structure
         //      - there is exactly one initial and final state
         //      - there are no loops
@@ -79,6 +82,16 @@ namespace smt::noodler {
                     assert(aut.final.contains(st));
                     assert(cur_level.size() == 1);
                     // interval_words should therefore be the accepted interval words by aut
+                    STRACE("str-interval-words",
+                        tout << "interval words:" << std::endl;
+                        for (const auto& interval_word : interval_words) {
+                            tout << "   ";
+                            for (const auto& interv : interval_word) {
+                                tout << "[" << interv.first << "-" << interv.second << "]";
+                            }
+                            tout << std::endl;
+                        }
+                    );
                     return interval_words;
                 }
 

--- a/src/smt/theory_str_noodler/aut_assignment.cpp
+++ b/src/smt/theory_str_noodler/aut_assignment.cpp
@@ -51,7 +51,7 @@ namespace smt::noodler {
         return nfa;
     }
 
-    std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>> AutAssignment::get_interval_words(const mata::nfa::Nfa& aut) {
+    std::vector<interval_word> AutAssignment::get_interval_words(const mata::nfa::Nfa& aut) {
         assert(aut.initial.size() == 1); // is deterministic and accepts a non-empty language
         assert(aut.is_acyclic()); // accepts a finite language
 
@@ -65,11 +65,11 @@ namespace smt::noodler {
         // we compute the reachable interval words for each state that can be reached in n steps
 
         // maps all states q reachable in n steps (starting with n=0), into the vector of interval words with which we can reach the given state from the inital state
-        std::map<mata::nfa::State,std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>> cur_level = { {*(aut.initial.begin()), {{}}} };
+        std::map<mata::nfa::State, std::vector<interval_word>> cur_level = { {*(aut.initial.begin()), {{}}} };
 
         while (true) {
             // we will compute the mapping for states reachable in n+1 steps
-            std::map<mata::nfa::State,std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>> next_level;
+            std::map<mata::nfa::State,std::vector<interval_word>> next_level;
 
             for (auto const& [st, interval_words] : cur_level) {
                 // st - state reachable in n steps

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -17,6 +17,8 @@
 
 namespace smt::noodler {
 
+    using interval_word = std::vector<std::pair<mata::Symbol,mata::Symbol>>;
+
     /**
      * hints for using AutAssignment:
      *   - use at() instead of [] operator for getting the value, use [] only for assigning
@@ -134,7 +136,7 @@ namespace smt::noodler {
          * 
          * @param aut - minimized automaton that accepts finite language
          */
-        static std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>> get_interval_words(const mata::nfa::Nfa& aut);
+        static std::vector<interval_word> get_interval_words(const mata::nfa::Nfa& aut);
 
         mata::nfa::Nfa get_automaton_concat(const std::vector<BasicTerm>& concat) const {
             mata::nfa::Nfa ret = mata::nfa::builder::create_empty_string_nfa();

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -94,6 +94,48 @@ namespace smt::noodler {
             return only_digits_aut;
         }
 
+        /**
+         * @brief Returns automaton that accept (possibly empty) words containing only symbols encoding digits (symbols from 48 to 57)
+         */
+        static mata::nfa::Nfa digit_automaton_with_epsilon() {
+            mata::nfa::Nfa only_digits_and_epsilon(1, {0}, {0});
+            for (mata::Symbol digit = AutAssignment::DIGIT_SYMBOL_START; digit <= AutAssignment::DIGIT_SYMBOL_END; ++digit) {
+                only_digits_and_epsilon.delta.add(0, digit, 0);
+            }
+            return only_digits_and_epsilon;
+        }
+
+        /**
+         * @brief Returns automaton that accept words of length @p length containing only symbols encoding digits (symbols from 48 to 57)
+         */
+        static mata::nfa::Nfa digit_automaton_of_length(unsigned length) {
+            mata::nfa::Nfa only_digits_of_length(length+1, {0}, {length});
+            for (unsigned i = 0; i < length; ++i) {
+                for (mata::Symbol digit = AutAssignment::DIGIT_SYMBOL_START; digit <= AutAssignment::DIGIT_SYMBOL_END; ++digit) {
+                    only_digits_of_length.delta.add(i, digit, i+1);
+                }
+            }
+            return only_digits_of_length;
+        }
+
+        /**
+         * @brief Get the vector of "interval" words accepted by @p aut
+         * 
+         * Interval word is a vector of mata::Symbol intervals (pairs), for example
+         *      {[4-10], [11-20], [0-100]}
+         * represents all words
+         *      {4, 11, 0}
+         *      {4, 11, 1}
+         *          ...
+         *      {4, 12, 2}
+         *          ...
+         * 
+         * Assumes that @p aut is minimized and accepts a non-empty finite language
+         * 
+         * @param aut - minimized automaton that accepts finite language
+         */
+        static std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>> get_interval_words(const mata::nfa::Nfa& aut);
+
         mata::nfa::Nfa get_automaton_concat(const std::vector<BasicTerm>& concat) const {
             mata::nfa::Nfa ret = mata::nfa::builder::create_empty_string_nfa();
             for(const BasicTerm& t : concat) {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -841,6 +841,11 @@ namespace smt::noodler {
             // and add l to int_subst_vars_to_possible_valid_lengths[int_subst_var].
             // For l=0 we need to do something else with the second conjunct, and for l=1, we also need to add something about code_version_of(int_subt_var).
 
+            if (aut_valid_part.is_lang_empty()) {
+                result.succ.push_back(formula_for_int_subst_var);
+                continue;
+            }
+
             // Handle l=0 as a special case.
             if (aut_valid_part.is_in_lang({})) {
                 // Even though it is invalid and it seems that we should set int_version_of(int_subst_var) = -1, we cannot do that

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -717,16 +717,16 @@ namespace smt::noodler {
                 rational interval_end(interval_it->second - AutAssignment::DIGIT_SYMBOL_START);
 
                 if (need_to_split) {
+                    std::vector<std::pair<rational,rational>> new_interval_cases;
                     for (rational possible_digit = interval_start; possible_digit <= interval_end; ++possible_digit) {
-                        std::vector<std::pair<rational,rational>> new_interval_cases;
                         for (std::pair<rational,rational>& interval_case : interval_cases) {
                             new_interval_cases.push_back({
-                                possible_digit*decimal + interval_cases[0].first,
-                                possible_digit*decimal + interval_cases[0].second
+                                possible_digit*decimal + interval_case.first,
+                                possible_digit*decimal + interval_case.second
                             });
                         }
-                        interval_cases = new_interval_cases;
                     }
+                    interval_cases = new_interval_cases;
                 } else {
                     assert(interval_cases.size() == 1);
                     interval_cases[0].first += interval_start*decimal;
@@ -795,8 +795,10 @@ namespace smt::noodler {
                     // int_subst_var is used in some to_code/from_code
                     // => we need to add to the previous formula also the fact, that int_subst_var cannot encode code point of a digit
                     //      .. && !(AutAssignment::DIGIT_SYMBOL_START <= code_version_of(int_subst_var) <= AutAssignment::DIGIT_SYMBOL_END)
-                    formula_for_int_subst_var.succ.back().succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{ code_version_of(int_subst_var), AutAssignment::DIGIT_SYMBOL_START });
-                    formula_for_int_subst_var.succ.back().succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{ AutAssignment::DIGIT_SYMBOL_END, code_version_of(int_subst_var) });
+                    formula_for_int_subst_var.succ.back().succ.emplace_back(LenFormulaType::OR, std::vector<LenNode>{
+                        LenNode(LenFormulaType::LT, { code_version_of(int_subst_var), AutAssignment::DIGIT_SYMBOL_START }),
+                        LenNode(LenFormulaType::LT, { AutAssignment::DIGIT_SYMBOL_END, code_version_of(int_subst_var) })
+                    });
                 }
             }
 

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -705,7 +705,7 @@ namespace smt::noodler {
         return result;
     }
 
-    LenNode DecisionProcedure::encode_interval_words(const BasicTerm& var, const std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>& interval_words) {
+    LenNode DecisionProcedure::encode_interval_words(const BasicTerm& var, const std::vector<interval_word>& interval_words) {
         LenNode result(LenFormulaType::OR);
         for (const auto& interval_word : interval_words) {
             // How this works on an example:

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -831,7 +831,7 @@ namespace smt::noodler {
                 }
 
                 //       |int_subst_var| = length && ...
-                formula_for_int_subst_var.succ.emplace_back(LenFormulaType::AND, LenNode(LenFormulaType::EQ, { int_subst_var, length }));
+                formula_for_int_subst_var.succ.emplace_back(LenFormulaType::AND, std::vector<LenNode>{LenNode(LenFormulaType::EQ, { int_subst_var, length })});
                 // remember that there are some valid words of given length
                 int_subst_vars_to_possible_valid_lengths[int_subst_var].push_back(length);
 

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -713,14 +713,17 @@ namespace smt::noodler {
             // We need to encode, as succintcly as possible, that var is any number from the interval word.
             // It is easy to see, that because last two positions can use all digits, we can create following inequations:
             //      ..200 <= var <= ..599
-            // where the first two digits are any of [4-5] and [0-9] respectively, i.e., we get:
+            // where the first two digits are any of [4-5] and [0-9] respectively, i.e., the full encoding should be the
+            // following disjunct:
             //      40200 <= var <= 40599 ||
             //      41200 <= var <= 41599 ||
             //               ...
             //      49200 <= var <= 49599 ||
             //      50200 <= var <= 50599 ||
+            //      51200 <= var <= 51599 ||
             //               ...
             //      59200 <= var <= 59599
+
             // We first compute the vector interval_cases of all the intervals [40200-40599], [41200-41599], ...
             // by going backwards in the interval_word, first by computing the main interval [..200-..599] which
             // ends after hitting first digit interval that does not contain all digits (in the exmaple it is [2-5])

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -907,8 +907,10 @@ namespace smt::noodler {
             // (|s| == 0 && c is not a valid code point)
             invalid_value.succ.emplace_back(LenFormulaType::EQ, std::vector<LenNode>{s, 0});
             // non-valid code point means that 'c < 0 || c > max_char'
-            invalid_value.succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{c, 0});
-            invalid_value.succ.emplace_back(LenFormulaType::LT, std::vector<LenNode>{zstring::max_char(), c});
+            invalid_value.succ.emplace_back(LenFormulaType::OR, std::vector<LenNode>{
+                LenNode(LenFormulaType::LT, {c, 0}),
+                LenNode(LenFormulaType::LT, {zstring::max_char(), c})
+            });
         }
 
         // Now we create the second disjunct of (1):
@@ -955,7 +957,7 @@ namespace smt::noodler {
         } else {
             // for FROM_INT only empty string (as we assume that language of s was set to only possible results of from_int)
             result.succ.emplace_back(LenFormulaType::AND, std::vector<LenNode>{
-                LenNode(LenFormulaType::LT, {0, i}), // from_int(i) = "" only if i < 0
+                LenNode(LenFormulaType::LT, {i, 0}), // from_int(i) = "" only if i < 0
                 LenNode(LenFormulaType::EQ, {s, 0})
             });
         }

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -330,10 +330,13 @@ namespace smt::noodler {
         }
 
         /**
-         * Gets all vars s_i, such that there exists `c = to_code(s)` or `s = from_code(c)`
+         * Gets the pair of variable sets (code_subst_vars, int_subst_vars) where code_subst_vars
+         * contains all vars s_i, such that there exists "c = to_code(s)" or "s = from_code(c)"
          * in conversions where s is substituted by s_1 ... s_i ... s_n in the solution.
+         * The set int_subst_vars is defined similarly, but for "i = to_int(s)" or "s = from_int(i)"
+         * conversions.
          */
-        std::set<BasicTerm> get_vars_substituted_in_code_conversions();
+        std::pair<std::set<BasicTerm>,std::set<BasicTerm>> get_vars_substituted_in_conversions();
 
         /**
          * @brief Get the formula for code substituting variables
@@ -341,6 +344,19 @@ namespace smt::noodler {
          * It basically encodes `code_version_of(c) = to_code(c)` for each c in @p code_subst_vars
          */
         LenNode get_formula_for_code_subst_vars(const std::set<BasicTerm>& code_subst_vars);
+
+        /**
+         * @brief Get the formula for int substituting variables
+         * 
+         * It basically encodes `int_version_of(c) = to_int(c)` for each c in @p int_subst_vars
+         * 
+         * @param int_subst_vars 
+         * @param code_subst_vars 
+         * @param int_subst_vars_to_possible_valid_lengths 
+         * @param underapproximating_length For the case that we need to underapproximate, this variable sets the length up to which we underapproximate
+         * @return std::pair<LenNode, LenNodePrecision> 
+         */
+        std::pair<LenNode, LenNodePrecision> get_formula_for_int_subst_vars(const std::set<BasicTerm>& int_subst_vars, const std::set<BasicTerm>& code_subst_vars, std::map<BasicTerm,std::vector<unsigned>>& int_subst_vars_to_possible_valid_lengths, const unsigned underapproximating_length = 3);
 
         /**
          * @brief Returns formula encoding `var = to_int(word)`.
@@ -353,6 +369,8 @@ namespace smt::noodler {
          */
         LenNode word_to_int(const mata::Word& word, const BasicTerm &var, bool start_with_one, bool handle_invalid_as_from_int);
 
+        LenNode encode_interval_words(const BasicTerm& var, const std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>& interval_words);
+
         /**
          * @brief Get the formula encoding to_code/from_code conversion
          */
@@ -364,7 +382,7 @@ namespace smt::noodler {
          * @param underapproximating_length For the case that we need to underapproximate, this variable sets
          * the length up to which we underapproximate
          */
-        std::pair<LenNode, LenNodePrecision> get_formula_for_int_conversion(const TermConversion& conv, const std::set<BasicTerm>& code_subst_vars, const unsigned underapproximating_length = 3);
+        LenNode get_formula_for_int_conversion(const TermConversion& conv, const std::map<BasicTerm,std::vector<unsigned>>& int_subst_vars_to_possible_valid_lengths);
 
         /**
          * Formula containing all not_contains predicate (nothing else)

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -349,7 +349,7 @@ namespace smt::noodler {
         /**
          * @brief Get the formula encoding that arithmetic variable @p var is any of the numbers encoded by some interval word from @p interval_words
          */
-        LenNode encode_interval_words(const BasicTerm& var, const std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>& interval_words);
+        LenNode encode_interval_words(const BasicTerm& var, const std::vector<interval_word>& interval_words);
 
         /**
          * @brief Get the formula for to_int/from_int substituting variables

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -339,37 +339,33 @@ namespace smt::noodler {
         std::pair<std::set<BasicTerm>,std::set<BasicTerm>> get_vars_substituted_in_conversions();
 
         /**
-         * @brief Get the formula for code substituting variables
+         * @brief Get the formula for to_code/from_code substituting variables
          * 
-         * It basically encodes `code_version_of(c) = to_code(c)` for each c in @p code_subst_vars
+         * It basically succinctly encodes `code_version_of(s) = to_code(w_s)` for each s in @p code_subst_vars and w_c \in solution.aut_ass.at(s) while
+         * keeping the correspondence between |s| and |w_s|
          */
         LenNode get_formula_for_code_subst_vars(const std::set<BasicTerm>& code_subst_vars);
 
         /**
-         * @brief Get the formula for int substituting variables
-         * 
-         * It basically encodes `int_version_of(c) = to_int(c)` for each c in @p int_subst_vars
-         * 
-         * @param int_subst_vars 
-         * @param code_subst_vars 
-         * @param int_subst_vars_to_possible_valid_lengths 
-         * @param underapproximating_length For the case that we need to underapproximate, this variable sets the length up to which we underapproximate
-         * @return std::pair<LenNode, LenNodePrecision> 
+         * @brief Get the formula encoding that arithmetic variable @p var is any of the numbers encoded by some interval word from @p interval_words
          */
-        std::pair<LenNode, LenNodePrecision> get_formula_for_int_subst_vars(const std::set<BasicTerm>& int_subst_vars, const std::set<BasicTerm>& code_subst_vars, std::map<BasicTerm,std::vector<unsigned>>& int_subst_vars_to_possible_valid_lengths, const unsigned underapproximating_length = 6);
+        LenNode encode_interval_words(const BasicTerm& var, const std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>& interval_words);
 
         /**
-         * @brief Returns formula encoding `var = to_int(word)`.
+         * @brief Get the formula for to_int/from_int substituting variables
          * 
-         * Based on handle_invalid_as_from_int, invalid inputs (word is empty/contains non-digits) are either
-         *    - (false) handled normally, i.e., to_int(word) = -1, or
-         *    - (true) handled as if we had `word = from_int(var)`, i.e., var < 0.
+         * It basically succinctly encodes `int_version_of(s) = to_int(w_s)` for each s in @p int_subst_vars and w_s \in solution.aut_ass.at(s) while
+         * keeping the correspondence between |s|, |w_s|, and code_version_of(s).
+         * Note that for w_s = "", we do not put int_version_of(s) = -1 but we instead force that it is NOT -1 (so that get_formula_for_int_conversion
+         * can handle this case correctly).
          * 
-         * @param start_with_one if true, encode instead `var = to_int('1'.word)`
+         * @param int_subst_vars to_int/from_int substituting variables for which we create formulae
+         * @param code_subst_vars to_code/from_code substituting variables (needed only if int_subst_vars and code_subst_vars are not disjoint)
+         * @param[out] int_subst_vars_to_possible_valid_lengths will map each var from int_subst_vars into a vector of lengths of all possible numbers for var (also 0 if there is empty string)
+         * @param underapproximating_length For the case that we need to underapproximate, this variable sets the length up to which we underapproximate
+         * @return The formula + precision of the formula (can be precise or underapproximation)
          */
-        LenNode word_to_int(const mata::Word& word, const BasicTerm &var, bool start_with_one, bool handle_invalid_as_from_int);
-
-        LenNode encode_interval_words(const BasicTerm& var, const std::vector<std::vector<std::pair<mata::Symbol,mata::Symbol>>>& interval_words);
+        std::pair<LenNode, LenNodePrecision> get_formula_for_int_subst_vars(const std::set<BasicTerm>& int_subst_vars, const std::set<BasicTerm>& code_subst_vars, std::map<BasicTerm,std::vector<unsigned>>& int_subst_vars_to_possible_valid_lengths, const unsigned underapproximating_length = 5);
 
         /**
          * @brief Get the formula encoding to_code/from_code conversion
@@ -379,8 +375,7 @@ namespace smt::noodler {
         /**
          * @brief Get the formula encoding to_int/from_int conversion
          * 
-         * @param underapproximating_length For the case that we need to underapproximate, this variable sets
-         * the length up to which we underapproximate
+         * @param int_subst_vars_to_possible_valid_lengths maps each var from int_subst_vars into a vector of lengths of all possible numbers for var (also 0 if there is empty string)
          */
         LenNode get_formula_for_int_conversion(const TermConversion& conv, const std::map<BasicTerm,std::vector<unsigned>>& int_subst_vars_to_possible_valid_lengths);
 

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -356,7 +356,7 @@ namespace smt::noodler {
          * @param underapproximating_length For the case that we need to underapproximate, this variable sets the length up to which we underapproximate
          * @return std::pair<LenNode, LenNodePrecision> 
          */
-        std::pair<LenNode, LenNodePrecision> get_formula_for_int_subst_vars(const std::set<BasicTerm>& int_subst_vars, const std::set<BasicTerm>& code_subst_vars, std::map<BasicTerm,std::vector<unsigned>>& int_subst_vars_to_possible_valid_lengths, const unsigned underapproximating_length = 3);
+        std::pair<LenNode, LenNodePrecision> get_formula_for_int_subst_vars(const std::set<BasicTerm>& int_subst_vars, const std::set<BasicTerm>& code_subst_vars, std::map<BasicTerm,std::vector<unsigned>>& int_subst_vars_to_possible_valid_lengths, const unsigned underapproximating_length = 6);
 
         /**
          * @brief Returns formula encoding `var = to_int(word)`.

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -240,7 +240,8 @@ namespace smt::noodler::util {
             assert(node.succ.size() == 2);
             expr_ref left = len_to_expr(node.succ[0], variable_map, m, m_util_s, m_util_a);
             expr_ref right = len_to_expr(node.succ[1], variable_map, m, m_util_s, m_util_a);
-            return expr_ref(m_util_a.mk_lt(left, right), m);
+            // LIA solver fails if we use "L < R" for some reason (it cannot be internalized in smt::theory_lra::imp::internalize_atom, as it expects only <= or >=); we use "!(R <= L)" instead
+            return expr_ref(m.mk_not(m_util_a.mk_le(right, left)), m);
         }
 
         case LenFormulaType::NOT: {


### PR DESCRIPTION
Instead of creating each case while creating LIA formula encoding int conversions, we now handle them by legnths, so for example if we have
`i = to_int(s_1 s_2)` with `s_1 \in [4-8][0-9][0-9]` and `s_2 \in [2-3][5-9]`
instead of putting `i = 40025 || i = 40026 || ....` we now create `400 <= s_1^i <= 899`, `25 <= s_2^i <= 29 || 35 <= s_2^i <= 39` and `i = s_1^i*100 + s_2^i`.