### PR TITLE
Update instructions to install Mata to use 'sudo'

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For a brief overview of the architecture, see [SMT-COMP'23 Z3-Noodler descriptio
     git clone 'https://github.com/VeriFIT/mata.git'
     cd mata
     make release
-    make install
+    sudo make install
     ```
 
 ### Building Z3-Noodler


### PR DESCRIPTION
This PR updates instructions on installing Mata by advising to use `sudo` when running `make install`.