### PR TITLE
Nielsen optimizations

### DIFF
--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.cpp
@@ -218,6 +218,7 @@ namespace smt::noodler {
 
         // use priority queue to prefer smaller formulae (higher probability to reach a final node)
         auto cmp = [](const auto& pr1, const auto& pr2) { return NielsenDecisionProcedure::get_formula_cost(pr1.second) > NielsenDecisionProcedure::get_formula_cost(pr2.second); };
+        // priority queue sorted by the cost of formula
         std::priority_queue<std::pair<size_t, Formula>, std::vector<std::pair<size_t, Formula>>, decltype(cmp)> worklist(cmp);
         worklist.push({0, trim_formula(init)}); 
         graph.set_init(init);

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.cpp
@@ -51,7 +51,7 @@ namespace smt::noodler {
             // sort predicates from smallest to largest
             std::vector<Predicate>& preds = this->formula.get_predicates();
             std::sort(preds.begin(), preds.end(), [](const Predicate& p1, const Predicate& p2) {
-                return (p1.get_left_side().size() + p1.get_right_side().size()) < (p2.get_left_side().size() + p2.get_right_side().size());
+                return NielsenDecisionProcedure::get_predicate_cost(p1) < NielsenDecisionProcedure::get_predicate_cost(p2);
             });
 
             std::vector<Formula> instances = divide_independent_formula(this->formula);

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.h
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.h
@@ -316,6 +316,21 @@ namespace smt::noodler {
         bool get_label_sl_formula(const CounterLabel& lab, const std::map<BasicTerm, BasicTerm>& in_vars, BasicTerm& out_var, std::vector<LenNode>& conjuncts);
         bool generate_len_connection(const std::map<BasicTerm, BasicTerm>& actual_var_map, std::vector<LenNode>& conjuncts);
 
+        /**
+         * @brief Get a cost of the given formula. Implemented as a sum of literals/variables 
+         * occurring inside the formula.
+         * 
+         * @param fl Formula 
+         * @return unsigned Cost
+         */
+        static unsigned get_formula_cost(const Formula& fl) { 
+            unsigned ret = 0;
+            for(const Predicate& pr : fl.get_predicates()) {
+                ret += pr.get_left_side().size() + pr.get_right_side().size();
+            }
+            return ret;
+        }
+
     public:
         
         /**

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.h
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.h
@@ -326,9 +326,20 @@ namespace smt::noodler {
         static unsigned get_formula_cost(const Formula& fl) { 
             unsigned ret = 0;
             for(const Predicate& pr : fl.get_predicates()) {
-                ret += pr.get_left_side().size() + pr.get_right_side().size();
+                ret += get_predicate_cost(pr);
             }
             return ret;
+        }
+
+        /**
+         * @brief Get predicate cost. It is computed as a number of literals/variables 
+         * occurrences in the predicate.
+         * 
+         * @param pr Preicate
+         * @return unsigned Cost
+         */
+        static unsigned get_predicate_cost(const Predicate& pr) {
+            return pr.get_left_side().size() + pr.get_right_side().size();
         }
 
     public:


### PR DESCRIPTION
This PR optimizes the Nielsen transformation with a priority queue instead of dequeue as a datastructure for storing nodes of a proof graph. Now we prefer nodes with smaller formulae as they more likely reach a final node.