### PR TITLE
Move rewriter rule

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -4544,19 +4544,8 @@ br_status seq_rewriter::mk_str_in_regexp(expr* a, expr* b, expr_ref& result) {
     }
     expr_ref b_s(m());
     if (lift_str_from_to_re(b, b_s)) {
-        // NOODLER we do not apply
-        //   a in (str.to_re a') -> (a == a')
-        // always, because replacing regexes to equalities
-        // can then lead to disequalities (if there is negation before),
-        // however, that is not beneficial for noodler.
-        // Instead, we replace only if there is a variable (noodler cannot handle var in regex)
-        m_lhs.reset();
-        str().get_concat(b_s, m_lhs);
-        remove_empty_and_concats(m_lhs);
-        if (has_var(m_lhs)) {
-            result = m_br.mk_eq_rw(a, b_s);
-            return BR_REWRITE_FULL;
-        }
+        result = m_br.mk_eq_rw(a, b_s);
+        return BR_REWRITE_FULL;
     }
     expr* b1 = nullptr;
     expr* eps = nullptr;

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -346,6 +346,10 @@ class seq_rewriter {
     void remove_empty_and_concats(expr_ref_vector& es);
     void remove_leading(unsigned n, expr_ref_vector& es);
 
+    // for NOODLER, used for str.len == numeral, str.len <= numeral and str.to_int == numeral (see mk_le_core, mk_eq_core)
+    bool reduce_length_eq_leq(expr *l, expr *r, bool is_equality, expr_ref& result);
+    bool reduce_stoi_eq(expr *l, expr *r, expr_ref& result);
+
     class seq_util::rex& re() { return u().re; }
     class seq_util::rex const& re() const { return u().re; }
     class seq_util::str& str() { return u().str; }

--- a/src/smt/CMakeLists.txt
+++ b/src/smt/CMakeLists.txt
@@ -79,6 +79,7 @@ z3_add_component(smt
     theory_str_noodler/expr_cases.cpp
     theory_str_noodler/regex.cpp
     theory_str_noodler/aut_assignment.cpp
+    theory_str_noodler/ugly_global_variables.cpp
     theory_str_mc.cpp
     theory_str_regex.cpp
     theory_user_propagator.cpp

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -140,8 +140,9 @@ namespace smt::noodler {
             string_theory_propagation(ex, true, false);
             
         }
-        add_conversion_num_axioms();
-        add_len_num_axioms();
+        // not needed anymore, as we do this in rewriter
+        // add_conversion_num_axioms();
+        // add_len_num_axioms();
         STRACE("str", tout << __LINE__ << " leave " << __FUNCTION__ << std::endl;);
 
     }

--- a/src/smt/theory_str_noodler/ugly_global_variables.cpp
+++ b/src/smt/theory_str_noodler/ugly_global_variables.cpp
@@ -1,0 +1,3 @@
+namespace smt::noodler {
+    bool rewrite_shitty_things = true;
+}

--- a/src/smt/theory_str_noodler/ugly_global_variables.h
+++ b/src/smt/theory_str_noodler/ugly_global_variables.h
@@ -1,0 +1,8 @@
+#ifndef _UGLY_GLOBAL_VARIABLES_H_
+#define _UGLY_GLOBAL_VARIABLES_H_
+
+namespace smt::noodler {
+    extern bool rewrite_shitty_things;
+}
+
+#endif


### PR DESCRIPTION
This PR moves the axioms (assuming `N` is a numeral)
- from `(str.len s) = N` create `(str.len s) = N => s \in \Sigma^N`
- from `(str.len s) <= N` create `(str.len s) <= N => s \in \Sigma^(0..N)`
- from `(str.to_int s) = N` create `(str.to_int s) = N => s \in 0*N`
from `theory_str_noodler` into the rewriter. I already tried doing this in #120, but I forgot that I tried this.

Does not work correctly for `full_str_int` + there is performance degradation (see `z3-noodler-43f4868-d95fe13`).