### PR TITLE
Fix invalid link to SMTLIB theory of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ cd build/
 ```
 
 ## Limitations
-The following functions/predicates of the [SMTLIB Strings theory](https://smtlib.cs.uiowa.edu/theories-UnicodeStrings.shtml) are not supported at the moment:
+The following functions/predicates of the [SMTLIB Strings theory](https://smt-lib.org/theories-UnicodeStrings.shtml) are not supported at the moment:
 ```
 str.replace_all
 str.replace_re_all


### PR DESCRIPTION
This PR fixes an invalid link to the theory of strings in SMTLIB in project `README.md`.