### PR TITLE
Multiple membership heuristic improvement

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -375,6 +375,12 @@ namespace smt::noodler {
          * We then only need to compute intersection from the regular languages and check if it is not empty.
          * The heuristics sorts the regexes by expected complexity of computing nfa, and iteratively computes
          * the intersection, so that if the formula is unsat, we do not need to build all automata.
+         * Furthermore, for all regexes that should be complemented, we compute their union and then check
+         * the inclusion with the intersection from the previous step, i.e., we have:
+         * L_1 \cap ... \cap L_m \cap \neg L_{m+1} \cap ... \cap \neg L_n = L \cap \neg (L_{m+1} \cup ... \cup L_n)
+         *                                                                = L \cap \neg L'
+         * where L = L_1 \cap ... \cap L_m, and L' = L_{m+1} \cup ... \cup L_n.
+         * We then want to check if L \cap \neg L' is empty (unsat), which is the same as asking if L is subset of L'.
          */
         bool is_mult_membership_suitable();
 

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -678,7 +678,7 @@ namespace smt::noodler {
             }
 
 
-            std::shared_ptr<mata::nfa::Nfa> intersection = nullptr; // we save the intersected automata here
+            intersection = nullptr; // we save the intersected automata here
             for (auto& [is_complement, reg] : list_of_regexes) {
                 STRACE("str", tout << "building intersection for var " << var << " and regex " << mk_pp(reg, m) << (is_complement ? " that needs to be first complemented" : " that does not need to be first complemented") << std::endl;);
 


### PR DESCRIPTION
This PR changes the way that multiple membership heuristic work.
We have
`L_1 ∩ ... ∩ L_m ∩ ¬L_{m+1} ∩ ... ∩ ¬L_n`
and we want to know if this intersection is empty (unsat).
We did it by sorting the regexes by their expected complexity (with negated regexes at the end), and then iteratively computing the NFAs and intersection, which could help with unsat instances, as the intersection could become empty and the more complex regexes would not be transformed to NFA (see #139).

The bottleneck is usually computing complement. We can however use de Morgan to get
`L_1 ∩ ... ∩ L_m ∩ ¬L_{m+1} ∩ ... ∩ ¬L_n =  L_1 ∩ ... ∩ L_m ∩ ¬(L_{m+1} ∪ ... ∪ L_n)`
and then compute two NFAs:
`L = L_1 ∩ ... ∩ L_m` (if `m=0`, we set `L` to be universal automaton)
`L' = L_{m+1} ∪ ... ∪ L_n` (if `m=n`, we set `L' = ∅`)
We are now asking whether `L ∩ ¬L' = ∅` which is the same as asking if `L ⊆ L'`. Therefore we only compute the inclusion, which is usually easier than complement.

