### PR TITLE
Remove useless int variables for conversions

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -100,7 +100,7 @@ namespace smt::noodler {
         scoped_vector<expr_pair_flag> m_membership_todo; // contains the variable and reg. lang. + flag telling us if it is negated (false -> negated)
         // contains pair of variables (e,s), where we have one of e = str.to_code(s), e = str.from_code(s),
         // e = str.to_int(s), or e = str.from_int(s), based on the conversion type
-        scoped_vector<std::tuple<expr_ref,expr_ref,ConversionType>> m_conversion_todo;
+        scoped_vector<TermConversion> m_conversion_todo;
 
         // during final_check_eh, we call remove_irrelevant_constr which chooses from previous sets of
         // todo constraints and check if they are relevant for current SAT assignment => if they are

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -169,6 +169,7 @@ namespace smt::noodler {
         std::vector<TermConversion> conversions;
         for (const auto& transf : m_conversion_todo) {
             ass.insert({transf.string_var, nfa_sigma_star});
+            conversions.push_back(transf);
         }
         return conversions;
     }

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -168,19 +168,7 @@ namespace smt::noodler {
         
         std::vector<TermConversion> conversions;
         for (const auto& transf : m_conversion_todo) {
-            BasicTerm result(BasicTermType::Variable, to_app(std::get<0>(transf))->get_decl()->get_name().str());
-            BasicTerm argument(BasicTermType::Variable, to_app(std::get<1>(transf))->get_decl()->get_name().str());
-            ConversionType type = std::get<2>(transf);
-
-            if (type == ConversionType::FROM_CODE || type == ConversionType::FROM_INT) {
-                conversions.emplace_back(type, result, argument);
-                var_name.insert({result, expr_ref(std::get<0>(transf), m)});
-                ass.insert({result, nfa_sigma_star});
-            } else {
-                conversions.emplace_back(type, argument, result);
-                var_name.insert({argument, expr_ref(std::get<1>(transf), m)});
-                ass.insert({argument, nfa_sigma_star});
-            }
+            ass.insert({transf.string_var, nfa_sigma_star});
         }
         return conversions;
     }


### PR DESCRIPTION
In handling conversions `to/from_int/code` we created int variables that were not really used. For example for `from_int(arg)`, we created a new variable `i` for `arg`, where we wanted to put `arg=i`. However, this did not work for some reason, so it was "fixed" by just remembering that `i` stands for `arg` during the decision procedure.

This PR then removes these int variables (i.e., they are not created as z3 variables, just as noodler ones, using them internally in the decision procedure) + these variables were used in axioms, however, as they were not connected, these axioms had no impact. They should have an impact now.