### PR TITLE
Small cleaning in `final_check_eh`

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -909,7 +909,7 @@ namespace smt::noodler {
                 if (is_lengths_sat == l_true && precision != LenNodePrecision::OVERAPPROX) {
                     STRACE("str", tout << "len sat " << mk_pp(lengths, m) << std::endl;);
                     // save the current assignment to catch it during the loop protection
-                    block_curr_len(lengths, true, false);
+                    // block_curr_len(lengths, true, false);
                     return FC_DONE;
                 } else if (is_lengths_sat == l_false /*&& precision != LenNodePrecision::UNDERAPPROX*/) {
                     // TODO is handling underapprox correct here? is it even safe to underapproximate? we do not have a case where we underapproximate, but for the future

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -745,6 +745,10 @@ namespace smt::noodler {
     final_check_status theory_str_noodler::final_check_eh() {
         TRACE("str", tout << "final_check starts" << std::endl;);
 
+        if (last_run_was_sat) {
+            return FC_DONE;
+        }
+
         remove_irrelevant_constr();
 
         STRACE("str",
@@ -909,6 +913,7 @@ namespace smt::noodler {
                 
                 if (is_lengths_sat == l_true) {
                     STRACE("str", tout << "len sat " << mk_pp(lengths, m) << std::endl;);
+                    last_run_was_sat = true;
                     return FC_DONE;
                 } else if (is_lengths_sat == l_false) {
                     STRACE("str", tout << "len unsat " <<  mk_pp(lengths, m) << std::endl;);

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -898,7 +898,6 @@ namespace smt::noodler {
         dec_proc.init_computation();
 
         expr_ref block_len(m.mk_false(), m);
-        bool was_something_approximated = false;
         while (true) {
             result = dec_proc.compute_next_solution();
             if (result == l_true) {
@@ -924,12 +923,6 @@ namespace smt::noodler {
                 // we did not find a solution (with satisfiable length constraints)
                 // we need to block current assignment
                 STRACE("str", tout << "assignment unsat " << mk_pp(block_len, m) << std::endl;);
-
-                if (was_something_approximated) {
-                    // if some length formula was an approximation and it did not lead to solution, we have to give up
-                    STRACE("str", tout << "there was approximating - giving up" << std::endl);
-                    return FC_GIVEUP;
-                }
 
                 if(m.is_false(block_len)) {
                     block_curr_len(block_len, false, true);

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -746,6 +746,7 @@ namespace smt::noodler {
         TRACE("str", tout << "final_check starts" << std::endl;);
 
         if (last_run_was_sat) {
+            // if we returned previously sat, then we should always return sat (final_check_eh should not be called again, but for some reason Z3 calls it)
             return FC_DONE;
         }
 

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -904,14 +904,13 @@ namespace smt::noodler {
                 auto [noodler_lengths, precision] = dec_proc.get_lengths();
                 lengths = len_node_to_z3_formula(noodler_lengths);
                 lbool is_lengths_sat = check_len_sat(lengths);
+
+                // we assume that precision != LenNodePrecision::OVERAPPROX
                 
-                if (is_lengths_sat == l_true && precision != LenNodePrecision::OVERAPPROX) {
+                if (is_lengths_sat == l_true) {
                     STRACE("str", tout << "len sat " << mk_pp(lengths, m) << std::endl;);
-                    // save the current assignment to catch it during the loop protection
-                    // block_curr_len(lengths, true, false);
                     return FC_DONE;
-                } else if (is_lengths_sat == l_false /*&& precision != LenNodePrecision::UNDERAPPROX*/) {
-                    // TODO is handling underapprox correct here? is it even safe to underapproximate? we do not have a case where we underapproximate, but for the future
+                } else if (is_lengths_sat == l_false) {
                     STRACE("str", tout << "len unsat " <<  mk_pp(lengths, m) << std::endl;);
                     block_len = m.mk_or(block_len, lengths);
 

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -112,6 +112,8 @@ namespace smt::noodler {
         vector<expr_pair_flag> m_membership_todo_rel; // contains the variable and reg. lang. + flag telling us if it is negated (false -> negated)
         // we cannot decide relevancy of to_code, from_code, to_int and from_int, so we assume everything in m_conversion_todo is relevant => no _todo_rel version
 
+        bool last_run_was_sat = false;
+
     public:
         char const * get_name() const override { return "noodler"; }
         theory_str_noodler(context& ctx, ast_manager & m, theory_str_noodler_params const & params);

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -112,6 +112,7 @@ namespace smt::noodler {
         vector<expr_pair_flag> m_membership_todo_rel; // contains the variable and reg. lang. + flag telling us if it is negated (false -> negated)
         // we cannot decide relevancy of to_code, from_code, to_int and from_int, so we assume everything in m_conversion_todo is relevant => no _todo_rel version
 
+        // true if last run of final_check_eh was sat (if it is true, then final_check_eh always return sat)
         bool last_run_was_sat = false;
 
     public:


### PR DESCRIPTION
This PR
- cleans up the handling of approximated length formula
- removes calling `block_cur_len` for sat instances, because for sat instances, `Z3` should immediately return sat too