### PR TITLE
Bug fixing: length unsat formula in preprocessing

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -575,7 +575,7 @@ namespace smt::noodler {
         return l_false;
     }
 
-    LenNode DecisionProcedure::get_initial_lengths() {
+    LenNode DecisionProcedure::get_initial_lengths(bool all_vars) {
         if (init_length_sensitive_vars.empty()) {
             // there are no length sensitive vars, so we can immediately say true
             return LenNode(LenFormulaType::TRUE);
@@ -585,9 +585,16 @@ namespace smt::noodler {
         std::vector<LenNode> conjuncts = {preprocessing_len_formula};
 
         // for each initial length variable get the lengths of all its possible words for automaton in init_aut_ass
-        for (const BasicTerm &var : init_length_sensitive_vars) {
-            conjuncts.push_back(init_aut_ass.get_lengths(var));
+        if(all_vars) {
+            for (const BasicTerm &var : this->formula.get_vars()) {
+                conjuncts.push_back(init_aut_ass.get_lengths(var));
+            }
+        } else {
+            for (const BasicTerm &var : this->init_length_sensitive_vars) {
+                conjuncts.push_back(init_aut_ass.get_lengths(var));
+            }
         }
+        
 
         return LenNode(LenFormulaType::AND, conjuncts);
     }

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -82,7 +82,7 @@ namespace smt::noodler {
          * Get length constraints for the initial assignment (possibly modified by preprocessing).
          * If it is unsatisfiable, it means that there is no possible solution.
          */
-        virtual LenNode get_initial_lengths() {
+        virtual LenNode get_initial_lengths(bool all_vars = false) {
             throw std::runtime_error("Unimplemented");
         }
 
@@ -443,7 +443,7 @@ namespace smt::noodler {
         void init_computation() override;
         lbool compute_next_solution() override;
 
-        LenNode get_initial_lengths() override;
+        LenNode get_initial_lengths(bool all_vars = false) override;
 
         std::pair<LenNode, LenNodePrecision> get_lengths() override;
     };

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.h
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.h
@@ -367,7 +367,7 @@ namespace smt::noodler {
         }
 
         lbool compute_next_solution() override;
-        LenNode get_initial_lengths() override {
+        LenNode get_initial_lengths(bool all_vars = false) override {
             return LenNode(LenFormulaType::TRUE);
         }
         std::pair<LenNode, LenNodePrecision> get_lengths() override;

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -867,6 +867,8 @@ namespace smt::noodler {
         }
 
         DecisionProcedure dec_proc = DecisionProcedure{ instance, aut_assignment, init_length_sensitive_vars, m_params, conversions };
+        // is formula length unsatisfiable?
+        bool length_unsat = false;
 
         // the skip_len_sat preprocessing rule requires that the input formula is length satisfiable
         // --> before we apply the preprocessing, we need to be sure that it is indeed true.
@@ -877,13 +879,15 @@ namespace smt::noodler {
         expr_ref lengths = len_node_to_z3_formula(dec_proc.get_initial_lengths(true));
         if(check_len_sat(lengths) == l_false) {
             STRACE("str", tout << "Unsat from initial lengths" << std::endl);
-            block_curr_len(lengths, true, true);
-            return FC_CONTINUE;
+            // we postpone the decision. If the instance is both length unsatisfiable and 
+            // unsatisfiable from preprocessing, we want to kill it after preprocessing as it
+            //  generates stronger theory lemma (negation of the string part).
+            length_unsat = true;
         }
 
         // now we know that the initial formula is length-satisfiable
         // try underapproximation (if enabled) to solve
-        if(m_params.m_underapproximation && is_underapprox_suitable(instance, aut_assignment, conversions)) {
+        if(!length_unsat && m_params.m_underapproximation && is_underapprox_suitable(instance, aut_assignment, conversions)) {
             STRACE("str", tout << "Try underapproximation" << std::endl);
             if (solve_underapprox(instance, aut_assignment, init_length_sensitive_vars, conversions) == l_true) {
                 STRACE("str", tout << "Sat from underapproximation" << std::endl;);
@@ -899,6 +903,11 @@ namespace smt::noodler {
             return FC_CONTINUE;
         } // we do not check for l_true, because we will get it in get_another_solution() anyway TODO: should we check?
 
+        // instance is length unsat --> generate theory lemma
+        if(length_unsat) {
+            block_curr_len(lengths, true, true);
+            return FC_CONTINUE;
+        }
         // it is possible that the arithmetic formula becomes unsatisfiable already by adding the (underapproximating)
         // length constraints from initial assignment
         lengths = len_node_to_z3_formula(dec_proc.get_initial_lengths());

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -876,8 +876,8 @@ namespace smt::noodler {
         // we want to include all variables from the formula --> e.g.
         // s.t = u where u \in ab, |s| > 100. The only length variable is s, but we need 
         // to include also length of |u| to propagate the value to |s|
-        expr_ref lengths = len_node_to_z3_formula(dec_proc.get_initial_lengths(true));
-        if(check_len_sat(lengths) == l_false) {
+        expr_ref lengths_pre = len_node_to_z3_formula(dec_proc.get_initial_lengths(true));
+        if(check_len_sat(lengths_pre) == l_false) {
             STRACE("str", tout << "Unsat from initial lengths" << std::endl);
             // we postpone the decision. If the instance is both length unsatisfiable and 
             // unsatisfiable from preprocessing, we want to kill it after preprocessing as it
@@ -903,17 +903,18 @@ namespace smt::noodler {
             return FC_CONTINUE;
         } // we do not check for l_true, because we will get it in get_another_solution() anyway TODO: should we check?
 
-        // instance is length unsat --> generate theory lemma
-        if(length_unsat) {
-            block_curr_len(lengths, true, true);
-            return FC_CONTINUE;
-        }
         // it is possible that the arithmetic formula becomes unsatisfiable already by adding the (underapproximating)
         // length constraints from initial assignment
-        lengths = len_node_to_z3_formula(dec_proc.get_initial_lengths());
+        expr_ref lengths = len_node_to_z3_formula(dec_proc.get_initial_lengths());
         if(check_len_sat(lengths) == l_false) {
             STRACE("str", tout << "Unsat from initial lengths" << std::endl);
             block_curr_len(lengths, true, true);
+            return FC_CONTINUE;
+        }
+
+        // instance is length unsat --> generate theory lemma
+        if(length_unsat) {
+            block_curr_len(lengths_pre, true, true);
             return FC_CONTINUE;
         }
 

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -876,8 +876,8 @@ namespace smt::noodler {
         // we want to include all variables from the formula --> e.g.
         // s.t = u where u \in ab, |s| > 100. The only length variable is s, but we need 
         // to include also length of |u| to propagate the value to |s|
-        expr_ref lengths_pre = len_node_to_z3_formula(dec_proc.get_initial_lengths(true));
-        if(check_len_sat(lengths_pre) == l_false) {
+        expr_ref lengths = len_node_to_z3_formula(dec_proc.get_initial_lengths(true));
+        if(check_len_sat(lengths) == l_false) {
             STRACE("str", tout << "Unsat from initial lengths" << std::endl);
             // we postpone the decision. If the instance is both length unsatisfiable and 
             // unsatisfiable from preprocessing, we want to kill it after preprocessing as it
@@ -903,18 +903,17 @@ namespace smt::noodler {
             return FC_CONTINUE;
         } // we do not check for l_true, because we will get it in get_another_solution() anyway TODO: should we check?
 
-        // it is possible that the arithmetic formula becomes unsatisfiable already by adding the (underapproximating)
-        // length constraints from initial assignment
-        expr_ref lengths = len_node_to_z3_formula(dec_proc.get_initial_lengths());
-        if(check_len_sat(lengths) == l_false) {
-            STRACE("str", tout << "Unsat from initial lengths" << std::endl);
+        // instance is length unsat --> generate theory lemma
+        if(length_unsat) {
             block_curr_len(lengths, true, true);
             return FC_CONTINUE;
         }
-
-        // instance is length unsat --> generate theory lemma
-        if(length_unsat) {
-            block_curr_len(lengths_pre, true, true);
+        // it is possible that the arithmetic formula becomes unsatisfiable already by adding the (underapproximating)
+        // length constraints from initial assignment
+        lengths = len_node_to_z3_formula(dec_proc.get_initial_lengths());
+        if(check_len_sat(lengths) == l_false) {
+            STRACE("str", tout << "Unsat from initial lengths" << std::endl);
+            block_curr_len(lengths, true, true);
             return FC_CONTINUE;
         }
 


### PR DESCRIPTION
This PR fixes bug in preprocessing. The preprocessing rule `skip_len_sat` requires to be the initial formula length satisfiable. Therefore, I moved the initial length check before the preprocessing itself to ensure that the formula meets the preprocessing requirements.