### PR TITLE
Fast models

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1552,7 +1552,7 @@ namespace smt::noodler {
         }
         inclusions_from_preprocessing.clear();
 
-        // Restrict the languages in solution of length variables and code/int conversion variables by their words
+        // Restrict the languages in solution of length variables and code/int conversion variables by their models
         for (auto& [var, nfa] : solution.aut_ass) {
             if (var.is_literal() || !solution.length_sensitive_vars.contains(var)) { continue; } // literals should have the correct language + we restrict only length vars
 

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1707,7 +1707,7 @@ namespace smt::noodler {
         // we always need (for initialization) all len_vars that are in aut_ass, so we ignore str_var
         std::vector<BasicTerm> needed_vars;
         for (const BasicTerm& len_var : solution.length_sensitive_vars) {
-            if (solution.aut_ass.contains(len_var)) {
+            if (!len_var.is_literal() && solution.aut_ass.contains(len_var)) {
                 needed_vars.push_back(len_var);
 
                 if (int_subst_vars.contains(len_var)) {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1691,7 +1691,6 @@ namespace smt::noodler {
                 return model_of_var.at(var);
             } else {
                 // var is only on the left side in the inclusion graph => we can return whatever
-                zstring result;
                 const auto& nfa = solution.aut_ass.at(var);
                 STRACE("str-model-nfa", tout << "NFA for var " << var << " before getting some word:\n" << *nfa;);
                 mata::Word accepted_word = nfa->get_word().value();

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1552,7 +1552,7 @@ namespace smt::noodler {
         }
         inclusions_from_preprocessing.clear();
 
-        // Restrict the languages in solution of length variables and code/int conversion variables by their models
+        // Restrict the languages in solution of length variables and code/int conversion variables by their words
         for (auto& [var, nfa] : solution.aut_ass) {
             if (var.is_literal() || !solution.length_sensitive_vars.contains(var)) { continue; } // literals should have the correct language + we restrict only length vars
 
@@ -1659,7 +1659,7 @@ namespace smt::noodler {
 
                 // We need to compute the vars on the right side from the vars on the left
                 //  - first we get the string model of the left side
-                //  - we then do "opposite" noodlification to get the values on the right side
+                //  - we then do "opposite noodlification" to get the values on the right side
 
                 zstring left_side_string;
                 for (const auto& var_on_left_side : inclusion_with_var_on_right_side.get_left_side()) {
@@ -1674,60 +1674,18 @@ namespace smt::noodler {
                         update_model_and_aut_ass(right_side_var, zstring());
                     }
                 } else {
-                    std::vector<std::shared_ptr<mata::nfa::Nfa>>left_side_string_aut{std::make_shared<mata::nfa::Nfa>(solution.aut_ass.create_word_nfa(left_side_string))};
-
-                    const auto& vars_on_right_side = inclusion_with_var_on_right_side.get_right_side(); // becase inclusion is not on cycle, all variables on the right side must be different
+                    const auto& vars_on_right_side = inclusion_with_var_on_right_side.get_right_side(); // because inclusion is not on cycle, all variables on the right side must be different
                     std::vector<std::shared_ptr<mata::nfa::Nfa>> automata_on_right_side;
                     for (const auto &right_side_var : vars_on_right_side) {
                         automata_on_right_side.push_back(solution.aut_ass.at(right_side_var));
                     }
                     SASSERT(vars_on_right_side.size() == automata_on_right_side.size());
 
-                    auto noodles = mata::strings::seg_nfa::noodlify_for_equation(automata_on_right_side, 
-                                                                                left_side_string_aut,
-                                                                                false, 
-                                                                                {{"reduce", "forward"}});
-                    SASSERT(!noodles.empty());
-                    STRACE("str-model-noodlification",
-                        tout << "Noodlification before and after in model generation:" << std::endl;
-                        tout << "Left side automaton for concatenation ";
-                        for (const auto& var_on_left_side : inclusion_with_var_on_right_side.get_left_side()) {
-                            tout << " " << var_on_left_side;
-                        }
-                        tout << ":\n" << *left_side_string_aut[0];
-                        tout << "Right side automata:" << std::endl;
-                        for (unsigned i = 0; i < vars_on_right_side.size(); ++i) {
-                            tout << "Variable " << vars_on_right_side[i] << ":\n" << *automata_on_right_side[i];
-                        }
-                        tout << "Noodle:\n";
-                        for (const auto &noodle_aut : noodles[0]) {
-                            tout << "Automaton for right var with index " << noodle_aut.second[0] << ":\n";
-                            tout << *noodle_aut.first;
-                        }
-                    );
-                    unsigned index_of_right_var_that_is_not_yet_processed = 0;
-                    for (const auto &noodle_aut : noodles[0]) { // we can take any noodle, so we take the first one
-                        // noodle_aut.second[0] is the index of the right var whose automaton is noodle_aut.first (see compute_next_solution() for better explanation)
-                        unsigned index_of_right_var_that_belongs_to_noodle_aut = noodle_aut.second[0];
-                        while (index_of_right_var_that_is_not_yet_processed < index_of_right_var_that_belongs_to_noodle_aut) {
-                            // skipped vars means that they are empty strings
-                            BasicTerm right_var_that_is_not_yet_processed = vars_on_right_side[index_of_right_var_that_is_not_yet_processed];
-                            update_model_and_aut_ass(right_var_that_is_not_yet_processed, zstring());
-                            ++index_of_right_var_that_is_not_yet_processed;
-                        }
-                        // update model based on noodle_aut
-                        BasicTerm right_var_that_belongs_to_noodle_aut = vars_on_right_side[index_of_right_var_that_belongs_to_noodle_aut];
-                        if (!right_var_that_belongs_to_noodle_aut.is_literal()) {
-                            zstring right_side_var_string = alph.get_string_from_mata_word(noodle_aut.first->get_word().value());
-                            SASSERT(index_of_right_var_that_is_not_yet_processed == index_of_right_var_that_belongs_to_noodle_aut);
-                            update_model_and_aut_ass(right_var_that_belongs_to_noodle_aut, right_side_var_string);
-                        }
-                        ++index_of_right_var_that_is_not_yet_processed;
-                    }
-                    while (index_of_right_var_that_is_not_yet_processed < vars_on_right_side.size()) {
-                        BasicTerm right_var_that_is_not_yet_processed = vars_on_right_side[index_of_right_var_that_is_not_yet_processed];
-                        update_model_and_aut_ass(right_var_that_is_not_yet_processed, zstring());
-                        ++index_of_right_var_that_is_not_yet_processed;
+                    std::vector<zstring> models_of_the_right_side;
+                    VERIFY(util::split_word_to_automata(left_side_string, automata_on_right_side, models_of_the_right_side));
+                    SASSERT(vars_on_right_side.size() == models_of_the_right_side.size());
+                    for (unsigned i = 0; i < vars_on_right_side.size(); ++i) {
+                        update_model_and_aut_ass(vars_on_right_side[i], models_of_the_right_side[i]);
                     }
                 }
                 return model_of_var.at(var);

--- a/src/smt/theory_str_noodler/memb_heuristics_procedures.cpp
+++ b/src/smt/theory_str_noodler/memb_heuristics_procedures.cpp
@@ -63,6 +63,7 @@ namespace smt::noodler {
         } else {
             word = reg_nfa->get_word_from_complement(&alph->mata_alphabet).value();
         }
+        return alph->get_string_from_mata_word(word);
     }
 
     lbool MultMembHeuristicProcedure::compute_next_solution() {

--- a/src/smt/theory_str_noodler/memb_heuristics_procedures.cpp
+++ b/src/smt/theory_str_noodler/memb_heuristics_procedures.cpp
@@ -48,12 +48,21 @@ namespace smt::noodler {
         SASSERT(var == this->var);
 
         if (!reg_nfa) {
-            // TODO: compute model directly from regex instead of creating nfa
+            if (is_regex_positive) {
+                try {
+                    return regex::get_model_from_regex(to_app(regex), m_util_s);
+                } catch (const regex::regex_model_fail& exc) {
+                    // fall trough, we need to create nfa
+                }
+            }
+
+            // TODO try handling also complement of regex directly
             
             // create alphabet (start with minterm representing symbols not ocurring in the regex)
             std::set<mata::Symbol> symbols_in_regex{util::get_dummy_symbol()};
             regex::extract_symbols(regex, m_util_s, symbols_in_regex);
             alph = std::make_unique<regex::Alphabet>(symbols_in_regex);
+
             reg_nfa = std::make_unique<mata::nfa::Nfa>(regex::conv_to_nfa(to_app(regex), m_util_s, m, *alph, false, false));
         }
         

--- a/src/smt/theory_str_noodler/memb_heuristics_procedures.cpp
+++ b/src/smt/theory_str_noodler/memb_heuristics_procedures.cpp
@@ -21,7 +21,7 @@ namespace smt::noodler {
                 // but we won't complement it, instead we will compare it with
                 // the universal automaton (as complementation can blow up)
 
-                // start with minterm representing symbols not ocurring in the regex
+                // create alphabet (start with minterm representing symbols not ocurring in the regex)
                 std::set<mata::Symbol> symbols_in_regex{util::get_dummy_symbol()};
                 regex::extract_symbols(regex, m_util_s, symbols_in_regex);
                 alph = std::make_unique<regex::Alphabet>(symbols_in_regex);
@@ -48,14 +48,20 @@ namespace smt::noodler {
         SASSERT(var == this->var);
 
         if (!reg_nfa) {
-            // TODO: compute model from regex
-            util::throw_error("Cannot compute model from regex directly");
-            return zstring();
+            // TODO: compute model directly from regex instead of creating nfa
+            
+            // create alphabet (start with minterm representing symbols not ocurring in the regex)
+            std::set<mata::Symbol> symbols_in_regex{util::get_dummy_symbol()};
+            regex::extract_symbols(regex, m_util_s, symbols_in_regex);
+            alph = std::make_unique<regex::Alphabet>(symbols_in_regex);
+            reg_nfa = std::make_unique<mata::nfa::Nfa>(regex::conv_to_nfa(to_app(regex), m_util_s, m, *alph, false, false));
+        }
+        
+        mata::Word word;
+        if (is_regex_positive) {
+            word = reg_nfa->get_word().value();
         } else {
-            SASSERT(!is_regex_positive);
-            // TODO: get word that is NOT in reg_nfa (do not forget dummy symbol, use alph->get_string_from_mata_word)
-            util::throw_error("Unsupported for now");
-            return zstring();
+            word = reg_nfa->get_word_from_complement(&alph->mata_alphabet).value();
         }
     }
 

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -611,4 +611,94 @@ namespace smt::noodler::regex {
             return sum;
         }
     }
+
+    zstring get_model_from_regex(const app *regex, const seq_util& m_util_s) {
+        if (m_util_s.re.is_to_re(regex)) { // Handle conversion of to regex function call.
+            SASSERT(regex->get_num_args() == 1);
+            const auto arg{ regex->get_arg(0) };
+            // Assume that regex inside re.to_re() function is a string of characters.
+            if (!m_util_s.str.is_string(arg)) { // if to_re has something other than string literal
+                throw regex_model_fail();
+            }
+            return get_model_from_regex(to_app(arg), m_util_s);
+        } else if (m_util_s.re.is_concat(regex)) { // Handle regex concatenation.
+            SASSERT(regex->get_num_args() > 0);
+            zstring result;
+            for (unsigned int i = 0; i < regex->get_num_args(); ++i) {
+                result = result + get_model_from_regex(to_app(regex->get_arg(i)), m_util_s);
+            }
+            return result;
+        } else if (m_util_s.re.is_complement(regex)) { // Handle complement.
+            SASSERT(regex->get_num_args() == 1);
+            throw regex_model_fail();
+        } else if (m_util_s.re.is_diff(regex)) { // Handle diff.
+            throw regex_model_fail();
+        } else if (m_util_s.re.is_dot_plus(regex)) { // Handle dot plus.
+            return zstring("a"); // return one iteration, i.e., arbitrary char
+        } else if (m_util_s.re.is_empty(regex)) { // Handle empty language.
+            throw regex_model_fail();
+        } else if (m_util_s.re.is_epsilon(regex)) { // Handle epsilon.
+            return zstring();
+        } else if (m_util_s.re.is_full_char(regex)) { // Handle full char (single occurrence of any string symbol, '.').
+            return zstring("a"); // return arbitrary char
+        } else if (m_util_s.re.is_full_seq(regex)) {
+            return zstring(); // return arbitrary word
+        } else if (m_util_s.re.is_intersection(regex)) { // Handle intersection.
+            SASSERT(regex->get_num_args() > 0);
+            // TODO we could possibly handle this by creating automata, their intersection and returning their model
+            throw regex_model_fail();
+        } else if (m_util_s.re.is_loop(regex)) { // Handle loop.
+            unsigned low, high;
+            expr *body;
+            VERIFY(m_util_s.re.is_loop(regex, body, low, high) || m_util_s.re.is_loop(regex, body, low));
+
+            // return model from body iterated low times
+            if (low == 0 || low > high) {
+                return zstring();
+            } else {
+                const zstring inside = get_model_from_regex(to_app(body), m_util_s);
+                std::vector<unsigned> result; // to make it more effecient, we use vector instead of zstring, using only zstring concatenation was very slow
+                result.reserve(inside.length()*low);
+                for (unsigned i = 0; i < low; ++i) {
+                    for (unsigned j = 0; j < inside.length(); ++j) {
+                        result.push_back(inside[j]);
+                    }
+                }
+                return zstring(result.size(), result.data());
+            }
+        } else if (m_util_s.re.is_opt(regex)) { // Handle optional.
+            return zstring(); // we can ignore inside and just return empty string, 
+        } else if (m_util_s.re.is_range(regex)) { // Handle range.
+            SASSERT(regex->get_num_args() == 2);
+            const auto range_begin{ regex->get_arg(0) };
+            const auto range_end{ regex->get_arg(1) };
+            SASSERT(is_app(range_begin));
+            SASSERT(is_app(range_end));
+            const auto range_begin_value{ to_app(range_begin)->get_parameter(0).get_zstring()[0] };
+            const auto range_end_value{ to_app(range_end)->get_parameter(0).get_zstring()[0] };
+            if (range_begin_value > range_end_value) {
+                return zstring(); // if range is invalid, according to standart, it means empty string
+            } else {
+                return to_app(range_begin)->get_parameter(0).get_zstring(); // we return the start of the range
+            }
+        } else if (m_util_s.re.is_union(regex)) { // Handle union (= or; A|B).
+            SASSERT(regex->get_num_args() == 2);
+            const auto left{ regex->get_arg(0) };
+            SASSERT(is_app(left));
+            // TODO we should maybe catch error, left might not accept anything and then we should return model from right
+            return get_model_from_regex(to_app(left), m_util_s); // we can return model from any of the arguments
+        } else if (m_util_s.re.is_star(regex)) { // Handle star iteration.
+            return zstring(); // empty string is always accepted by star
+        } else if (m_util_s.re.is_plus(regex)) { // Handle positive iteration.
+            SASSERT(regex->get_num_args() == 1);
+            const auto child{ regex->get_arg(0) };
+            SASSERT(is_app(child));
+            return get_model_from_regex(to_app(child), m_util_s); // we just return one iteration
+        } else if(m_util_s.str.is_string(regex)) { // Handle string literal.
+            SASSERT(regex->get_num_parameters() == 1);
+            return regex->get_parameter(0).get_zstring();
+        } else {
+            throw regex_model_fail();
+        }
+    }
 }

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -89,14 +89,9 @@ namespace smt::noodler::regex {
         zstring get_string_from_mata_word(const mata::Word& word) const {
             zstring res;
             mata::Symbol unused_symbol = get_unused_symbol();
-            for (mata::Symbol s : word) {
-                if (util::is_dummy_symbol(s)) {
-                    res = res + zstring(unsigned(unused_symbol));
-                } else {
-                    res = res + zstring(unsigned(s));
-                }
-            }
-            return res;
+            mata::Word new_word{ word };
+            std::replace(new_word.begin(), new_word.end(), util::get_dummy_symbol(), unused_symbol);
+            return zstring(new_word.size(), new_word.data());
         }
     };
 

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -148,6 +148,21 @@ namespace smt::noodler::regex {
      * @return sum of loops inside @p regex, with nested loops multiplied 
      */
     unsigned get_loop_sum(const app* reg, const seq_util& m_util_s);
+
+    class regex_model_fail : public default_exception {
+    public:
+        regex_model_fail() : default_exception("Failed to find model of a regex") {}
+    };
+
+    /**
+     * @brief Get some word accepted by @p regex (assumes that regex accepts something)
+     * 
+     * @param regex Regex to be checked
+     * @param m_util_s string ast util
+     * @return word accepted by @p regex
+     * @throws regex_model_fail if the model cannot be found (it does not mean it does not exists, regex might contain for example complement which this function ignores)
+     */
+    zstring get_model_from_regex(const app *regex, const seq_util& m_util_s);
 }
 
 #endif

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -150,12 +150,14 @@ namespace smt::noodler::regex {
     };
 
     /**
-     * @brief Get some word accepted by @p regex (assumes that regex accepts something)
+     * @brief Try to g et some word accepted by @p regex
+     * 
+     * It currently cannot handle intersection, complement, or string variables inside regex.
      * 
      * @param regex Regex to be checked
      * @param m_util_s string ast util
      * @return word accepted by @p regex
-     * @throws regex_model_fail if the model cannot be found (it does not mean it does not exists, regex might contain for example complement which this function ignores)
+     * @throws regex_model_fail if the model cannot be found (either regex represents empty language, or it contains intersection/complement/string variables, which this function currently cannot handle)
      */
     zstring get_model_from_regex(const app *regex, const seq_util& m_util_s);
 }

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -473,7 +473,9 @@ namespace smt::noodler {
                                 std::vector<TermConversion> conversions);
 
         /**
-         * @brief This function should always be called after decision procedure decides SAT
+         * @brief This function should always be called after decision procedure decides SAT with non-trivial length formula
+         * 
+         * It pushes the length formula into Z3, so that we can generate correct model.
          * 
          * @param length_formula - formula with which we got sat
          */

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -963,12 +963,14 @@ namespace smt::noodler {
         last_run_was_sat = true;
         if (m_params.m_produce_models) {
             // If we want to produce models, we would like to constraint the lengths more significantly,
-            // so that Z3 arith solver does not give us some large numbers.
-            // We therefore check if we can still get a model if we constraint all lengths by some number (right now 100).
+            // so that Z3 arith solver does not give us some large numbers (for example it can give 60000
+            // and returning such a long model can take a long time).
+            // We therefore check if we can still get a model if we constraint all lengths by some number.
+            const int LENGTH_LIMIT = 100; // this seems a small enough number so that model generation is easy, while allowing model to pass trough for most benchmarks
             expr_ref_vector len_constraints(m);
             for (expr* len_var : len_vars) {
-                // |len_var| <= 100
-                len_constraints.push_back(expr_ref(m_util_a.mk_le(m_util_s.str.mk_length(len_var), m_util_a.mk_int(100)), m));
+                // |len_var| <= LENGTH_LIMIT
+                len_constraints.push_back(expr_ref(m_util_a.mk_le(m_util_s.str.mk_length(len_var), m_util_a.mk_int(LENGTH_LIMIT)), m));
             }
             expr_ref length_formula_underapprox(m.mk_and(length_formula, m.mk_and(len_constraints)), m);
             STRACE("str-sat-handling", tout << "Checking if we can put stronger limits on lengths with formula " << mk_pp(length_formula_underapprox, m) << " which is ";);

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -962,10 +962,10 @@ namespace smt::noodler {
     void theory_str_noodler::sat_handling(expr_ref length_formula) {
         last_run_was_sat = true;
         if (m_params.m_produce_models) {
-            // If we want to produce models, we would like to constraint the lengths more significantly,
+            // If we want to produce models, we would like to limit the lengths more significantly,
             // so that Z3 arith solver does not give us some large numbers (for example it can give 60000
             // and returning such a long model can take a long time).
-            // We therefore check if we can still get a model if we constraint all lengths by some number.
+            // We therefore check if we can still get a model if we limit all lengths by some number.
             const int LENGTH_LIMIT = 100; // this seems a small enough number so that model generation is easy, while allowing model to pass trough for most benchmarks
             expr_ref_vector len_constraints(m);
             for (expr* len_var : len_vars) {
@@ -975,7 +975,7 @@ namespace smt::noodler {
             expr_ref length_formula_underapprox(m.mk_and(length_formula, m.mk_and(len_constraints)), m);
             STRACE("str-sat-handling", tout << "Checking if we can put stronger limits on lengths with formula " << mk_pp(length_formula_underapprox, m) << " which is ";);
             if (check_len_sat(length_formula_underapprox) == lbool::l_true) {
-                // we can constraint the lengths => add it to the resulting length formula
+                // we can limit the lengths => add it to the resulting length formula
                 STRACE("str-sat-handling", tout << "sat\n");
                 length_formula = length_formula_underapprox;
             } else {

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -971,9 +971,13 @@ namespace smt::noodler {
                 len_constraints.push_back(expr_ref(m_util_a.mk_le(m_util_s.str.mk_length(len_var), m_util_a.mk_int(100)), m));
             }
             expr_ref length_formula_underapprox(m.mk_and(length_formula, m.mk_and(len_constraints)), m);
-            if (check_len_sat(length_formula_underapprox)) {
+            STRACE("str-sat-handling", tout << "Checking if we can put stronger limits on lengths with formula " << mk_pp(length_formula_underapprox, m) << " which is ";);
+            if (check_len_sat(length_formula_underapprox) == lbool::l_true) {
                 // we can constraint the lengths => add it to the resulting length formula
+                STRACE("str-sat-handling", tout << "sat\n");
                 length_formula = length_formula_underapprox;
+            } else {
+                STRACE("str-sat-handling", tout << "unsat\n");
             }
         }
         sat_length_formula = length_formula;

--- a/src/smt/theory_str_noodler/theory_str_noodler_model.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_model.cpp
@@ -75,11 +75,8 @@ namespace smt::noodler {
             rational val(0);
             SASSERT(values.size() == 1);
             VERIFY(m_util_a.is_numeral(values[0], val, is_int) && is_int);
-            zstring res;
-            while (res.length() != val.get_unsigned()) {
-                res = res + zstring("a"); // we can return anything, so we will just fill it with 'a'
-            }
-            return m_util_s.str.mk_string(res);
+            std::vector<unsigned> res(val.get_unsigned(), 'a'); // we can return anything, so we will just fill it with 'a'
+            return m_util_s.str.mk_string(zstring(res.size(), res.data()));
         }
     };
 

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -142,6 +142,13 @@ namespace smt::noodler::util {
      * @return Is of the form.
      */
     bool is_len_sub(expr* val, expr* s, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& num_res);
+
+    /**
+     * @brief Assuming that concatenation of automata in @p automata accepts @p word, returns in @p words splitted @p word, where @p word[i] is accepted by @p automata[i]
+     * 
+     * @return boolean indicating whether we can split the @p word to @p automata (true if we can)
+     */
+    bool split_word_to_automata(const zstring& word, const std::vector<std::shared_ptr<mata::nfa::Nfa>>& automata, std::vector<zstring>& words);
 }
 
 #endif


### PR DESCRIPTION
This PR adds model generation from regex directly in membership heuristic (and if not possible, try to create NFA and get model from that) +  multiple optimization: 
- added function for getting model from automata on the right side of inclusion from the left side string (instead of using noodlification)
- if we get `sat`, check if we can limit arith model of lengths by some number (currently 100), so that we do not get some large models for which generating model is hard
- replace `zstring` concatenations in a loop by a vector from which a resulting `zstring` is computed (for large loop bounds, `zstring` concatenation is very slow, it constantly creates new vectors)