### PR TITLE
not-contains: implement not-contains > LIA reduction 

### DIFF
--- a/src/smt/theory_str_noodler/ca_str_constr.h
+++ b/src/smt/theory_str_noodler/ca_str_constr.h
@@ -26,18 +26,18 @@ namespace smt::noodler::ca {
     using AutMatrix = std::vector<std::vector<mata::nfa::Nfa>>;
 
     /**
-     * @brief Class representing copies of automata for each variable. 
-     * X axis = variables 
+     * @brief Class representing copies of automata for each variable.
+     * X axis = variables
      * Y axis = copy
      */
     class DiseqAutMatrix {
-    
+
     private:
         AutMatrix aut_matrix {};
         // order of variables
         std::vector<BasicTerm> var_order {};
         // starting state of each automaton
-        std::vector<size_t> offsets {};
+        std::vector<size_t> var_aut_init_states_in_copy {};
 
     protected:
         void create_aut_matrix(const Predicate& diseq, const AutAssignment& aut_ass);
@@ -45,39 +45,43 @@ namespace smt::noodler::ca {
         /**
          * @brief Recompute offsets.
          */
-        void recompute_offset();
+        void recompute_var_aut_init_state_positions();
 
         /**
          * @brief Get offset in the Big unified NFA (i.e., starting state of the particular NFA [ @p copy, @p var ] in the Big NFA)
-         * 
+         *
          * @param copy Copy index
          * @param var Variable index
          * @return size_t Smallest/starting state
          */
-        size_t get_offset(size_t copy, size_t var) const {
-            return this->offsets[copy*this->var_order.size() + var];
-        } 
+        size_t get_var_aut_init_state_pos(size_t copy, size_t var) const {
+            return this->var_aut_init_states_in_copy[copy*this->var_order.size() + var];
+        }
 
-    public: 
-        DiseqAutMatrix(const Predicate& diseq, const AutAssignment& aut_ass) : aut_matrix(), var_order(), offsets() {
+    public:
+        DiseqAutMatrix(const Predicate& diseq, const AutAssignment& aut_ass) : aut_matrix(), var_order(), var_aut_init_states_in_copy() {
             create_aut_matrix(diseq, aut_ass);
         }
 
         /**
          * @brief Get state in unified automaton (where all automata in matrix are unioned).
-         * 
+         *
          * @param copy Index of the copy
          * @param var Index of the variable (index in @p var_order)
          * @param state State of the particular automaton at [ @p copy, @p var ]
          * @return mata::nfa::State State in the big NFA
          */
         mata::nfa::State get_union_state(size_t copy, size_t var, mata::nfa::State state) const {
-            return get_offset(copy, var) + state;
+            return get_var_aut_init_state_pos(copy, var) + state;
+        }
+
+        std::vector<size_t> get_var_init_states_pos_in_copies() const {
+            return this->var_aut_init_states_in_copy;
         }
 
         /**
          * @brief Unify all particular automata into a single NFA.
-         * 
+         *
          * @return mata::nfa::Nfa Big NFA
          */
         mata::nfa::Nfa union_matrix() const;
@@ -89,8 +93,12 @@ namespace smt::noodler::ca {
         void set_aut(size_t copy, size_t var, const mata::nfa::Nfa& aut, bool recomp_offset = false) {
             this->aut_matrix[copy][var] = aut;
             if(recomp_offset) {
-                recompute_offset();
+                recompute_var_aut_init_state_positions();
             }
+        }
+
+        const std::vector<mata::nfa::Nfa>& get_matrix_row(size_t row_idx) const {
+            return this->aut_matrix[row_idx];
         }
 
         const mata::nfa::Nfa& get_aut(size_t copy, size_t var) const {
@@ -110,22 +118,22 @@ namespace smt::noodler::ca {
         ca::CounterAlphabet alph {};
 
     public:
-        TagDiseqGen(const Predicate& diseq, const AutAssignment& aut_ass) : aut_matrix(diseq, aut_ass), 
+        TagDiseqGen(const Predicate& diseq, const AutAssignment& aut_ass) : aut_matrix(diseq, aut_ass),
             aut_ass(aut_ass), diseq(diseq), alph() { }
 
     protected:
         /**
-         * @brief Replace symbols in a particular variable automaton. Replace original symbols with 
+         * @brief Replace symbols in a particular variable automaton. Replace original symbols with
          * the AtomicSymbols of the form <L,x> ...
-         * 
+         *
          * @param copy Copy identifying particular variable automaton
          * @param var Variable of the automaton
          */
         void replace_symbols(char copy, size_t var);
 
         /**
-         * @brief Add connections between copies. 
-         * 
+         * @brief Add connections between copies.
+         *
          * @param copy_start Starting copy (transitions source)
          * @param var Variable
          * @param aut_union Union automaton contains all copies in a single automaton.
@@ -135,7 +143,7 @@ namespace smt::noodler::ca {
     public:
         /**
          * @brief Construct tagged automaton for a single disequation.
-         * 
+         *
          * @return ca::CA Tagged automaton.
          */
         ca::TagAut construct_tag_aut();
@@ -144,14 +152,19 @@ namespace smt::noodler::ca {
             return this->aut_matrix;
         }
 
+
+        const Predicate& get_underlying_predicate() const {
+            return this->diseq;
+        };
+
     };
 
     /**
-     * @brief Get LIA formula for disequations. The LIA formula describes all length 
-     * models of the diseqation. 
-     * 
-     * TODO: So-far it supports only one disequation. 
-     * 
+     * @brief Get LIA formula for disequations. The LIA formula describes all length
+     * models of the diseqation.
+     *
+     * TODO: So-far it supports only one disequation.
+     *
      * @param diseqs Disequations
      * @param autass Automata assignmnent after stabilization
      * @return LenNode LIA formula describing lengths of string models
@@ -159,8 +172,18 @@ namespace smt::noodler::ca {
     LenNode get_lia_for_disequations(const Formula& diseqs, const AutAssignment& autass);
 
     /**
+     * @brief Construct a LIA formula that is true iff the RHS of the given @p not_contains is longer
+     *        than its LHS given a model of @p parikh_image
+     *
+     * @param not_contains A not-contains predicate whose RHS should be longer than its LHS
+     * @param autass Automata assignmnent after stabilization
+     * @return LenNode LIA formula that is true iff the RHS of the given not_contains is longer than its LHS
+    */
+    LenNode make_lia_rhs_longer_than_lhs(const Predicate& not_contains, const DiseqAutMatrix& automaton_matrix, const parikh::ParikhImage& parikh_image);
+
+    /**
      * @brief Get LIA formula for not contains. So-far it performs only simple checks.
-     * 
+     *
      * @param not_conts Not contains
      * @param autass Automata assignmnent after stabilization
      * @return std::pair<LenNode, LenNodePrecision> LIA formula describing lengths of string models together with the precision.

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -146,8 +146,8 @@ namespace smt::noodler::util {
 
         if(!m_util_s.str.is_length(len, str) || str->hash() != s->hash()) {
             return false;
-        } 
-        
+        }
+
         return true;
     }
 
@@ -183,7 +183,7 @@ namespace smt::noodler::util {
             words.pop_back();
             is_backtracked = true;
         };
-        
+
         while (current_automaton != NUM_OF_AUTOMATA || index_in_word != LENGTH_OF_WORD) {
             STRACE("str-split-word-to-automata", tout << "Current automaton and index in word: " << current_automaton << " " << index_in_word << "\n";);
 
@@ -219,7 +219,7 @@ namespace smt::noodler::util {
                 backtrack();
                 continue;
             }
-            
+
             // we move by one in word and compute the new set of states
             mata::Symbol current_symbol = word[index_in_word];
             mata::nfa::StateSet new_current_states; // we save here post over current symbol from the set of current states
@@ -257,4 +257,30 @@ namespace smt::noodler::util {
 
         return true;
     }
+}
+
+template <typename T>
+size_t rec_bin_search_leftmost(const std::vector<T>& haystack, T needle, size_t start_idx, size_t end_idx) {
+
+    if (start_idx == end_idx) {
+        if (haystack.at(start_idx) >= needle) return start_idx;
+        return -1;
+    }
+
+    size_t midpoint = start_idx + (end_idx - start_idx) / 2;
+    if (needle < midpoint) {
+        return rec_bin_search_leftmost(haystack, needle, start_idx, midpoint);
+    }
+
+    size_t match = rec_bin_search_leftmost(haystack, needle, midpoint+1, end_idx);
+    if (match == -1) {
+        // We have not found the the in [midpoint+1 ... end_idx], therefore, the leftmost smaller is midpoint
+        return midpoint;
+    }
+    return match;
+}
+
+template <typename T>
+size_t bin_search_leftmost(const std::vector<T>& haystack, T needle) {
+    return rec_bin_search_leftmost(haystack, needle, 0, haystack.size());
 }

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -35,7 +35,7 @@ namespace smt::noodler::util {
 
     /**
      * @brief Get the value of the symbol representing all symbols not ocurring in the formula (i.e. a minterm)
-     * 
+     *
      * Dummy symbol represents all symbols not occuring in the problem. It is needed,
      * because if we have for example disequation x != y and nothing else, we would
      * have no symbols and incorrectly say it is unsat. Similarly, for 'x not in "aaa"
@@ -50,7 +50,7 @@ namespace smt::noodler::util {
      * Throws error and select which class to throw based on debug (if we are
      * debugging, we do not want z3 to catch our error, if we are not debugging
      * we want z3 to catch it and return unknown).
-     * 
+     *
      * @param errMsg Error message
      */
     void throw_error(std::string errMsg);
@@ -118,9 +118,9 @@ namespace smt::noodler::util {
 
     /**
      * @brief Create a fresh noodler (BasicTerm) variable with a given @p name followed by a unique suffix.
-     * 
+     *
      * The suffix contains a number which is incremented for each use of this function for a given @p name
-     * 
+     *
      * @param name Infix of the name (rest is added to get a unique name)
      */
     inline BasicTerm mk_noodler_var_fresh(const std::string& name) {
@@ -132,7 +132,7 @@ namespace smt::noodler::util {
 
     /**
      * @brief Check whether the expression @p val is of the form ( @p num_res ) + (len @p s ).
-     * 
+     *
      * @param val Expression to be checked
      * @param s String term with length
      * @param m ast manager
@@ -145,10 +145,12 @@ namespace smt::noodler::util {
 
     /**
      * @brief Assuming that concatenation of automata in @p automata accepts @p word, returns in @p words splitted @p word, where @p word[i] is accepted by @p automata[i]
-     * 
+     *
      * @return boolean indicating whether we can split the @p word to @p automata (true if we can)
      */
     bool split_word_to_automata(const zstring& word, const std::vector<std::shared_ptr<mata::nfa::Nfa>>& automata, std::vector<zstring>& words);
 }
+
+size_t bin_search_leftmost(const std::vector<mata::nfa::State>& haystack, mata::nfa::State needle);
 
 #endif


### PR DESCRIPTION
This PR implements a reduction of a single `not-contains` predicate into a LIA formula when the languages of the underlying variables are flat, building on #150.