### PR TITLE
Fix axiomitizing conversions

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -2119,10 +2119,6 @@ namespace smt::noodler {
      * of the term and puts them in m_conversion_todo.
      */
     void theory_str_noodler::handle_conversion(expr *conversion) {
-        if(axiomatized_persist_terms.contains(conversion))
-            return;
-        axiomatized_persist_terms.insert(conversion);
-
         expr *arg = nullptr;
 
         ConversionType type;


### PR DESCRIPTION
This PR (probably) fixes #135. There was a problem that conversion could be axiomitized on higher level and after popping, it would not be axiomitized again, as it was saved in `axiomatized_persist_terms`.