### PR TITLE
Do not remove the same equation twice in `remove_regular` preprocessing rule

### DIFF
--- a/src/smt/theory_str_noodler/formula_preprocess.cpp
+++ b/src/smt/theory_str_noodler/formula_preprocess.cpp
@@ -310,10 +310,14 @@ namespace smt::noodler {
         std::vector<std::pair<size_t, Predicate>> regs;
         this->formula.get_side_regulars(regs);
         std::deque<std::pair<size_t, Predicate>> worklist(regs.begin(), regs.end());
+        // keeps the ids of removed equations
+        std::set<size_t> removed;
 
         while(!worklist.empty()) {
             std::pair<size_t, Predicate> pr = worklist.front();
             worklist.pop_front();
+
+            if (removed.contains(pr.first)) continue; // if the equation was already removed, we do not remove it again
 
             STRACE("str-prep-remove_regular", tout << "Remove regular:" << pr.second << std::endl;);
 
@@ -354,6 +358,7 @@ namespace smt::noodler {
             }
 
             this->formula.remove_predicate(pr.first);
+            removed.insert(pr.first);
             STRACE("str-prep-remove_regular", tout << "removed" << std::endl;);
 
             // check if by removing the regular equation, some other equations did not become regular


### PR DESCRIPTION
The same equation but with different sides could be removed by `remove_regular` (for equation with one var on both sides) which would cause a cycle in the inclusion graph for model generation.