### PR TITLE
Concatenation model fix

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler_model.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_model.cpp
@@ -88,11 +88,17 @@ namespace smt::noodler {
         concat_var_value_proc(expr* str_concat, ast_manager& m, context& ctx, seq_util& m_util_s) : m_util_s(m_util_s) {
             // for concatenation, we just recursively get the models for arguments and then concatenate them
             expr_ref_vector concats(m);
-            STRACE("str-model-concat", tout << "Dependencies for concat " << mk_pp(str_concat, m) << " (#" << ctx.get_enode(str_concat)->get_owner_id() << "):";);
+            enode* str_concat_enode = ctx.get_enode(str_concat);
+            STRACE("str-model-concat", tout << "Dependencies for concat " << mk_pp(str_concat, m) << " (#" << str_concat_enode->get_owner_id() << "):";);
             m_util_s.str.get_concat(str_concat, concats);
             for (auto concat : concats) {
-                STRACE("str-model-concat", tout << " " << mk_pp(concat, m) << " (#" << ctx.get_enode(concat)->get_root()->get_owner_id() << ")";);
-                m_dependencies.push_back(model_value_dependency(ctx.get_enode(concat)));
+                enode* concat_enode = ctx.get_enode(concat);
+                STRACE("str-model-concat", tout << " " << mk_pp(concat, m) << " (#" << concat_enode->get_root()->get_owner_id() << ")";);
+                if (concat_enode->get_root() == str_concat_enode) {
+                    // this should not happen
+                    util::throw_error("Enode for some concatenation is the representant of enode of one of its arguments");
+                }
+                m_dependencies.push_back(model_value_dependency(concat_enode));
             }
             STRACE("str-model-concat", tout << "\n";);
         }

--- a/src/smt/theory_str_noodler/theory_str_noodler_model.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_model.cpp
@@ -159,7 +159,7 @@ namespace smt::noodler {
         } else if (m_util_s.str.is_concat(tgt)) {
             // check if tgt is not in a class of enodes that contain some string literal (see PR #174)
             enode* tgt_enode = ctx.get_enode(tgt);
-            for (auto tgt_enode_it = tgt_enode->begin(); i != tgt_enode->end(); ++tgt_enode_it) {
+            for (auto tgt_enode_it = tgt_enode->begin(); tgt_enode_it != tgt_enode->end(); ++tgt_enode_it) {
                 app* cur_app = (*tgt_enode_it)->get_expr();
                 if (m_util_s.str.is_string(cur_app)) {
                     // if the class contains string literal, return it directly

--- a/src/smt/theory_str_noodler/theory_str_noodler_model.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_model.cpp
@@ -88,10 +88,13 @@ namespace smt::noodler {
         concat_var_value_proc(expr* str_concat, ast_manager& m, context& ctx, seq_util& m_util_s) : m_util_s(m_util_s) {
             // for concatenation, we just recursively get the models for arguments and then concatenate them
             expr_ref_vector concats(m);
+            STRACE("str-model-concat", tout << "Dependencies for concat " << mk_pp(str_concat, m) << " (#" << ctx.get_enode(str_concat)->get_owner_id() << "):";);
             m_util_s.str.get_concat(str_concat, concats);
             for (auto concat : concats) {
+                STRACE("str-model-concat", tout << " " << mk_pp(concat, m) << " (#" << ctx.get_enode(concat)->get_root()->get_owner_id() << ")";);
                 m_dependencies.push_back(model_value_dependency(ctx.get_enode(concat)));
             }
+            STRACE("str-model-concat", tout << "\n";);
         }
 
         void get_dependencies(buffer<model_value_dependency> & result) override {
@@ -148,6 +151,13 @@ namespace smt::noodler {
         } else if (util::is_str_variable(tgt, m_util_s)) {
             return model_of_string_var(tgt);
         } else if (m_util_s.str.is_concat(tgt)) {
+            enode* e = ctx.get_enode(tgt);
+            for (auto i = e->begin(); i != e->end(); ++i) {
+                app* asef = (*i)->get_expr();
+                if (m_util_s.str.is_string(asef)) {
+                    return alloc(expr_wrapper_proc, asef);
+                }
+            }
             return alloc(concat_var_value_proc, tgt, m, ctx, m_util_s);
         } else {
             // for complex string functions (nothing else should be able to come into mk_value), we should be able to find vars that replace them in predicate_replace

--- a/src/smt/theory_str_noodler/theory_str_noodler_model.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_model.cpp
@@ -157,11 +157,13 @@ namespace smt::noodler {
         } else if (util::is_str_variable(tgt, m_util_s)) {
             return model_of_string_var(tgt);
         } else if (m_util_s.str.is_concat(tgt)) {
-            enode* e = ctx.get_enode(tgt);
-            for (auto i = e->begin(); i != e->end(); ++i) {
-                app* asef = (*i)->get_expr();
-                if (m_util_s.str.is_string(asef)) {
-                    return alloc(expr_wrapper_proc, asef);
+            // check if tgt is not in a class of enodes that contain some string literal (see PR #174)
+            enode* tgt_enode = ctx.get_enode(tgt);
+            for (auto tgt_enode_it = tgt_enode->begin(); i != tgt_enode->end(); ++tgt_enode_it) {
+                app* cur_app = (*tgt_enode_it)->get_expr();
+                if (m_util_s.str.is_string(cur_app)) {
+                    // if the class contains string literal, return it directly
+                    return alloc(expr_wrapper_proc, cur_app);
                 }
             }
             return alloc(concat_var_value_proc, tgt, m, ctx, m_util_s);


### PR DESCRIPTION
During model generation, we add the arguments of concatenation as its dependencies to create the model of the concatenation. However, sometimes (in `Leetcode`, for example for `QF_SLIA/2019-Leetcode/findLadders/40e8819fff4fee9d50e90f6b69865ac6e7c40c0699830176df703c6e.smt2`) it could happen that one of its argument belonged to the same equivalence class as the concatenation, which resulted in problems during dependency evaluation. I think the problem is that the equivalence class contains a literal, but it is not the representative. This PR adds a check, which looks at all enodes belonging to the same equivalence class as concatenation, and if one of them is literal, immediately returns this literal as a model instead of adding dependencies.