### PR TITLE
Model of singleton automata

### DIFF
--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -216,10 +216,11 @@ namespace smt::noodler {
         }
 
         /**
-         * @brief Check if the automaton accepts only a single word. It is only underapproximation,
-         * as is_singleton is false for the NFA p1 -a-> p2, q1 -a-> q2 where p1, q1 are initial and p2, q2 are final.
-         * To get a precise information, the determinization+minimization might be necessary, which is often 
-         * expensive. 
+         * @brief Check if the automaton for @p t accepts only a single word.
+         * 
+         * It is only underapproximation, as is_singleton is false for the NFA p1 -a-> p2, q1 -a-> q2 where
+         * p1, q1 are initial and p2, q2 are final. To get precise information, you determinization+minimization
+         * might be necessary, which is often expensive.
          * 
          * @param t Variable
          * @return True -> is surely singleton, False -> inconclusive

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1651,6 +1651,12 @@ namespace smt::noodler {
             }
             return update_model_and_aut_ass(var, result);
         } else if (solution.aut_ass.contains(var)) {
+            // as a heuristic, we check if the automaton for var is a singleton (this can sometimes help if there is a cycle in inclusions)
+            if (solution.aut_ass.is_singleton(var)) {
+                mata::Word accepted_word = solution.aut_ass.at(var)->get_word().value();
+                return update_model_and_aut_ass(var, alph.get_string_from_mata_word(accepted_word));
+            }
+
             Predicate inclusion_with_var_on_right_side;
             if (solution.get_inclusion_with_var_on_right_side(var, inclusion_with_var_on_right_side)) {
                 // TODO check if inclusion_with_var_on_right_side lays on a cycle.

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1632,13 +1632,13 @@ namespace smt::noodler {
             return model_of_var.at(var);
         }
 
-        if (vars_whose_model_we_are_computing.contains(var)) {
-            util::throw_error("There is cycle in inclusion graph, cannot produce model");
-        }
-
         STRACE("str-model",
             tout << "Generating model for var " << var << "\n";
         );
+
+        if (vars_whose_model_we_are_computing.contains(var)) {
+            util::throw_error("There is cycle in inclusion graph, cannot produce model");
+        }
 
         vars_whose_model_we_are_computing.insert(var);
 

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1651,7 +1651,7 @@ namespace smt::noodler {
             }
             return update_model_and_aut_ass(var, result);
         } else if (solution.aut_ass.contains(var)) {
-            // as a heuristic, we check if the automaton for var is a singleton (this can sometimes help if there is a cycle in inclusions)
+            // as a heuristic, we check if the automaton for var contains exactly one word, if yes, we immediately return this word instead of going trough inclusions (this can sometimes help if there is a cycle in inclusions)
             if (solution.aut_ass.is_singleton(var)) {
                 mata::Word accepted_word = solution.aut_ass.at(var)->get_word().value();
                 return update_model_and_aut_ass(var, alph.get_string_from_mata_word(accepted_word));


### PR DESCRIPTION
If the language of an automaton for a variable contains only one word, we return it immediately instead of looking trough incusions. This can help for cyclic inclusions, we can now generate model for two of the three mentioned formulas in #179 (it cannot generate model for `QF_SLIA/20230329-woorpje-lu/track05/05_track_169.smt2`).