### PR TITLE
Basic handling of uninterpreted string functions

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -453,11 +453,15 @@ namespace smt::noodler {
             // we do not need to handle these, concatenation is handled differently (TODO: explain better?)
             // and everything else will be handled during final_check_eh
         } else {
-            std::stringstream error_msg;
-            error_msg << "Unknown predicate/function " << mk_pp(n, get_manager()) << " in relevant_eh()";
-            util::throw_error(error_msg.str());
+            // if we got here it means that we got some uninterpreted string function (i.e. probably user declared), we just replace it with a fresh string variable
+            expr* e = n;
+            if (!axiomatized_persist_terms.contains(e)) {
+                axiomatized_persist_terms.insert(e);
+                expr_ref fresh = mk_str_var_fresh("uninter");
+                predicate_replace.insert(e, fresh.get());
+                add_axiom({mk_eq(fresh, e, false)});
+            }
         }
-
     }
 
     /*


### PR DESCRIPTION
This PR adds basic handling of uninterpreted functions, so we can handle formulas such as:
```
(declare-fun domain-site (String) String)
(declare-fun x () String)

(assert (str.in_re (domain-site "4567") (re.* (str.to_re "a"))))
(assert (str.in_re x (re.* (str.to_re "a"))))
(assert (< 5 (str.len (domain-site "11"))))
(assert (= (domain-site "4567") (domain-site "11")))
(assert (= (domain-site "111")  "11"))
(assert (= (domain-site "14311")  "12341"))
(check-sat)
``` 
or
```
(declare-fun x () String)
(declare-fun y () String)
(declare-fun sb (String) Int)

(assert (> (sb x) (str.len y)))
(assert (= x (str.substr y (- (str.len y) (sb y)) (sb y))))
(check-sat)
```