### PR TITLE
Print computation tree of decision procedure in DOT format

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -356,7 +356,7 @@ namespace smt::noodler {
         };
 
         std::ostringstream res;
-        res << DOT_name << "[label=\"" << print_predicate_container_to_DOT(inclusions);
+        res << DOT_name << "[shape=record,label=\"" << print_predicate_container_to_DOT(inclusions);
         if (!inclusions.empty() && !transducers.empty()) {
             res << "\\n";
         }
@@ -404,8 +404,7 @@ namespace smt::noodler {
                            << "------------------------" << std::endl;);
 
         while (!worklist.empty()) {
-            SolvingState element_to_process = std::move(worklist.front());
-            worklist.pop_front();
+            SolvingState element_to_process = pop_from_worklist();
 
             if (element_to_process.predicates_to_process.empty()) {
                 // we found another solution, element_to_process contain the automata
@@ -428,6 +427,7 @@ namespace smt::noodler {
                         }
                     }
                 );
+                STRACE("str-noodle-dot", tout << solution.DOT_name << " [style=filled,fillcolor=\"aqua\"];\n";);
                 return l_true;
             }
 
@@ -445,6 +445,7 @@ namespace smt::noodler {
         }
 
         // there are no solving states left, which means nothing led to solution -> it must be unsatisfiable
+        STRACE("str-noodle-dot", tout << "}\n";);
         return l_false;
     }
 
@@ -502,13 +503,10 @@ namespace smt::noodler {
             // it is possible that some transducer become non-simple (one of its side becomes empty), we want to process these again
             solving_state.push_non_simple_transducers_to_processing();
 
-            if (!is_inclusion_to_process_on_cycle) {
-                // we push to front when the inclusion is not on cycle, because we want to get to the result as fast as possible
-                // and if there is no cycle, we do not need to do BFS, the algorithm should end
-                worklist.push_front(solving_state);
-            } else {
-                worklist.push_back(solving_state);
-            }
+            // we push to front when the inclusion is not on cycle, because we want to get to the result as fast as possible
+            // and if there is no cycle, we do not need to do BFS, the algorithm should end
+            push_to_worklist(std::move(solving_state), is_inclusion_to_process_on_cycle);
+
             return;
         }
         /********************************************************************************************************/
@@ -544,7 +542,7 @@ namespace smt::noodler {
                 // the inclusion holds, therefore we do not need to do noodlification and we can continue with this
                 // solving_state (we push to front and not back because we can just directly continue with next inclusion
                 // and we can possibly get to the result on the next step)
-                worklist.push_front(solving_state);
+                push_to_worklist(std::move(solving_state), false);
                 return;
             }
         }
@@ -646,14 +644,9 @@ namespace smt::noodler {
              */
             new_element.process_substituting_inclusions_from_left(left_side_inclusions, is_inclusion_to_process_on_cycle);
 
-            if (!is_inclusion_to_process_on_cycle) {
-                // we push to front when the inclusion is not on cycle, because we want to get to the result as fast as possible
-                // and if there is no cycle, we do not need to do BFS, the algorithm should end
-                worklist.push_front(new_element);
-            } else {
-                worklist.push_back(new_element);
-            }
-
+            // we push to front when the inclusion is not on cycle, because we want to get to the result as fast as possible
+            // and if there is no cycle, we do not need to do BFS, the algorithm should end
+            push_to_worklist(std::move(new_element), is_inclusion_to_process_on_cycle);
         }
 
         ++noodlification_no; // TODO: when to do this increment?? maybe noodlification_no should be part of SolvingState?
@@ -710,7 +703,7 @@ namespace smt::noodler {
                 // if the non-empty side is actually also empty, then we can just check if the result of application contains epsilon
                 if (application_to_empty_string.is_in_lang({})) {
                     // if it does, we can continue with this solving_state, otherwise we keep it out of worklist as it will not lead to solution
-                    worklist.push_front(solving_state);
+                    push_to_worklist(std::move(solving_state), false);
                 }
                 return;
             }
@@ -729,7 +722,7 @@ namespace smt::noodler {
             }
             solving_state.add_predicate(new_inclusion, false);
             solving_state.push_front_unique(new_inclusion);
-            worklist.push_front(solving_state);
+            push_to_worklist(std::move(solving_state), false);
             return;
         }
 
@@ -798,7 +791,7 @@ namespace smt::noodler {
             std::vector<Predicate> output_inclusions = util::create_inclusions_from_multiple_sides(output_vars_divisions, output_vars_to_new_output_vars);
             new_element.process_substituting_inclusions_from_left(output_inclusions, false);
 
-            worklist.push_front(new_element);
+            push_to_worklist(std::move(new_element), false);
         }
         ++noodlification_no; // TODO: when to do this increment?? maybe noodlification_no should be part of SolvingState?
     }
@@ -1648,7 +1641,9 @@ namespace smt::noodler {
             }
         }
 
-        worklist.push_back(init_solving_state);
+
+        STRACE("str-noodle-dot", tout << "digraph Procedure {\ninit[shape=none, label=\"\"]\n";);
+        push_to_worklist(std::move(init_solving_state), true);
     }
 
     lbool DecisionProcedure::preprocess(PreprocessType opt, const BasicTermEqiv &len_eq_vars) {

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -227,7 +227,7 @@ namespace smt::noodler {
          * Checks whether @p predicate would be on cycle in the inclusion graph (can overapproximate
          * and say that predicate is on cycle even if it is not).
          */
-        bool is_predicate_on_cycle(const Predicate &predicate) {
+        bool is_predicate_on_cycle(const Predicate &predicate) const {
             return !predicates_not_on_cycle.contains(predicate);
         }
 
@@ -459,6 +459,9 @@ namespace smt::noodler {
          * If @p replacements is empty, it only deletes dummy symbols from transducers.
          */
         void replace_dummy_symbol_in_transducers_with(std::set<mata::Symbol> replacements);
+
+        std::string DOT_name;
+        std::string print_to_DOT() const;
     };
 
     class DecisionProcedure : public AbstractDecisionProcedure {

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -237,15 +237,15 @@ namespace smt::noodler {
          * @param predicate Predicate to add
          * @param is_on_cycle Whether the predicate would be on cycle in the inclusion graph (if not sure, set to true)
          */
-        void add_predicate(const Predicate &predicate, bool is_on_cycle = true) {
-            if (predicate.is_equation()) { // inclusion
-                inclusions.insert(predicate);
-            } else {
-                SASSERT(predicate.is_transducer());
-                transducers.insert(predicate);
-            }
+        void add_predicate(Predicate predicate, bool is_on_cycle = true) {
             if (!is_on_cycle) {
                 predicates_not_on_cycle.insert(predicate);
+            }
+            if (predicate.is_equation()) { // inclusion
+                inclusions.insert(std::move(predicate));
+            } else {
+                SASSERT(predicate.is_transducer());
+                transducers.insert(std::move(predicate));
             }
         }
 
@@ -460,7 +460,13 @@ namespace smt::noodler {
          */
         void replace_dummy_symbol_in_transducers_with(std::set<mata::Symbol> replacements);
 
-        std::string DOT_name;
+        std::string DOT_name = "init";
+        std::string set_new_DOT_name() {
+            static size_t DOT_name_counter = 0;
+            DOT_name = std::string("SolvingState") + std::to_string(DOT_name_counter);
+            ++DOT_name_counter;
+            return DOT_name;
+        }
         std::string print_to_DOT() const;
     };
 
@@ -510,6 +516,26 @@ namespace smt::noodler {
 
         void process_inclusion(const Predicate& inclusion_to_process, SolvingState& solving_state);
         void process_transducer(const Predicate& transducer_to_process, SolvingState& solving_state);
+
+        void push_to_worklist(SolvingState solving_state, bool to_back) {
+            std::string old_DOT_name = solving_state.DOT_name;
+            solving_state.set_new_DOT_name();
+            STRACE("str-noodle-dot", tout << solving_state.print_to_DOT() << std::endl << old_DOT_name << " -> " << solving_state.DOT_name << ";\n");
+            if (to_back) {
+                worklist.push_back(std::move(solving_state));
+            } else {
+                worklist.push_front(std::move(solving_state));
+            }
+        }
+
+        unsigned num_of_popped_elements = 0;
+        SolvingState pop_from_worklist() {
+            SolvingState element_to_process = std::move(worklist.front());
+            worklist.pop_front();
+            STRACE("str-noodle-dot", tout << element_to_process.DOT_name << " -> " << element_to_process.DOT_name << " [penwidth=0,dir=none,label=" << num_of_popped_elements << "];\n";);
+            ++num_of_popped_elements;
+            return element_to_process;
+        }
 
         /**
          * @brief Get the formula encoding lengths of variables based on solution

--- a/src/smt/theory_str_noodler/formula.cpp
+++ b/src/smt/theory_str_noodler/formula.cpp
@@ -262,44 +262,19 @@ namespace smt::noodler {
     }
 
     std::string Predicate::to_string() const {
-
-        // joining BasicTerm in the given vector with str
-        auto join = [&](const std::vector<BasicTerm>& vec, const std::string& str) -> std::string {
-            if(vec.empty()) return "";
-            std::string ret = vec[0].to_string();
-            for(size_t i = 1; i < vec.size(); i++) {
-                ret += str + vec[i].to_string();
-            }
-            return ret;
-        };
-
-        switch (type) {
-            case PredicateType::Equation: {
-                std::string result{ "Equation: " };
-                result += join(get_left_side(), " ") + " = " + join(get_right_side(), " ");
-                return result;
-            }
-
-            case PredicateType::Inequation: {
-                std::string result{ "Inequation: " };
-                result += join(get_left_side(), " ") + " != " + join(get_right_side(), " ");
-                return result;
-            }
-
-            case PredicateType::NotContains: {
-                std::string result{ "Notcontains: " };
-                result += join(params[0], " ") + " , " + join(params[1], " ");
-                return result;
-            }
-
-            case PredicateType::Transducer: {
-                std::stringstream result;
-                result << "Transducer: " << join(params[1], " ") << " = T" << transducer << "(" << join(params[0], " ") << ")";
-                return result.str();
-            }
+        std::stringstream result;
+        if (is_equation()) {
+            result << "Equation: " << get_left_side() << " = " << get_right_side();
+        } else if (is_inequation()) {
+            result << "Inequation: " << get_left_side() << " != " << get_right_side();
+        } else if (is_not_cont()) {
+            result << "Notcontains: " << get_haystack() << ", " << get_needle();
+        } else if (is_transducer()) {
+            result << "Transducer: " << get_output() << " = T" << transducer << "(" << get_input() << ")";
+        } else {
+            util::throw_error("Unhandled predicate type passed as 'this' to to_string().");
         }
-
-        throw std::runtime_error("Unhandled predicate type passed as 'this' to to_string().");
+        return result.str();
     }
 
     bool Predicate::strong_equals(const Predicate& other) const {

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -132,6 +132,20 @@ namespace smt::noodler {
     }
     static bool operator>(const BasicTerm& lhs, const BasicTerm& rhs) { return !(lhs < rhs); }
 
+    [[nodiscard]] static std::string to_string(const std::vector<BasicTerm>& vec, const std::string& delimiter = " ") {
+        if(vec.empty()) return "";
+        std::string ret = vec[0].to_string();
+        for(size_t i = 1; i < vec.size(); i++) {
+            ret += delimiter + vec[i].to_string();
+        }
+        return ret;
+    }
+
+    static std::ostream& operator<<(std::ostream& os, const std::vector<BasicTerm>& vec) {
+        os << to_string(vec);
+        return os;
+    }
+
     //----------------------------------------------------------------------------------------------------------------------------------
 
     /**

--- a/src/smt/theory_str_noodler/inclusion_graph.h
+++ b/src/smt/theory_str_noodler/inclusion_graph.h
@@ -93,28 +93,18 @@ namespace smt::noodler {
         }
 
         [[nodiscard]] std::string print() const {
-            // joining BasicTerm in the given vector with str
-            auto join = [&](const std::vector<BasicTerm>& vec, const std::string& str) -> std::string {
-                if(vec.empty()) return "";
-                std::string ret = vec[0].to_string();
-                for(size_t i = 1; i < vec.size(); i++) {
-                    ret += str + vec[i].to_string();
-                }
-                return ret;
-            };
-
             std::ostringstream output;
-            output << join(get_real_left_side(), " ");
+            output << get_real_left_side();
             if (node_predicate.is_equation()) {
                 // inclusion
-                output << " ⊆ " << join(get_real_right_side(), " ");
+                output << " ⊆ " << get_real_right_side();
             } else {
                 //transducer, we name them based on the raw pointer
                 output << " = T" << node_predicate.get_transducer().get();
                 if (is_reversed()) {
                     output << "^-1";
                 }
-                output << "(" << join(get_real_right_side(), " ") << ")";
+                output << "(" << get_real_right_side() << ")";
             }
             return output.str();
         }


### PR DESCRIPTION
This PR adds new trace string `str-noodle-dot` which when it is enabled, prints to trace the dot representation of the computational graph for each run of `DecisionProcedure`.

It also adds a function to print vector of variables using `<<` operator.