### PR TITLE
Transducers from nested replace operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For a brief overview of the architecture, see [SMT-COMP'24 Z3-Noodler descriptio
 
 ### Dependencies
 
-1) The [Mata](https://github.com/VeriFIT/mata/) library for efficient handling of finite automata. Minimum required version of `mata` is `v1.9.0`.
+1) The [Mata](https://github.com/VeriFIT/mata/) library for efficient handling of finite automata. Minimum required version of `mata` is `v1.11.2`.
     ```shell
     git clone 'https://github.com/VeriFIT/mata.git'
     cd mata

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -909,14 +909,14 @@ namespace smt::noodler {
                     auto [input_trans, vars_on_tapes_of_input_trans] = get_composed_trans_with_tapes(transducers[i].get_input()[0]);
                     SASSERT(!vars_on_tapes_of_input_trans.empty() && vars_on_tapes_of_input_trans[0] == transducers[i].get_input()[0]);
                     // we compose Ti and Ti' on input_var, getting transducer output_var = Ti''(input_var, x1, x2, ...., xn)
-                    mata::nft::Nft composed_input = mata::nft::compose(invert_trans, input_trans, 1, 0, false).trim(); // TODO check if order of tapes in result is correct here
-                    composed_input = mata::nft::invert_levels(composed_input);
+                    mata::nft::Nft composed_input = mata::nft::compose(invert_trans, input_trans, 1, 0, false).trim();
                     SASSERT(!composed_input.contains_jump_transitions());
+                    SASSERT(composed_input.num_of_states() > 0);
                     // we have a transducer output_var = T(y1, y2, ..., ym) computed from previous Tj's, j < i, and we compose here on output_var with Ti''
                     // getting transducer output_var = T'(y1, y2, ..., ym, input_var, x1, x2, ..., xn)
-                    final_trans = mata::nft::compose(composed_input, final_trans, composed_input.num_of_levels-1, 0, false).trim(); // TODO check if order of tapes in result is correct here
+                    final_trans = mata::nft::compose(final_trans, composed_input, 0, 0, false).trim();
                     SASSERT(!final_trans.contains_jump_transitions());
-                    for (size_t i = 0; i < composed_input.num_of_levels-1; ++i) { final_trans = mata::nft::invert_levels(final_trans); }
+                    SASSERT(final_trans.num_of_states() > 0);
                     // we had vars_on_tapes = {output_var, y1, y2, ..., ym} we add to it vars_on_tapes_of_input_trans getting
                     //   {output_var, y1, y2, ..., ym, input_var, x1, x2, ..., xn}
                     vars_on_tapes.insert(vars_on_tapes.end(), vars_on_tapes_of_input_trans.begin(), vars_on_tapes_of_input_trans.end());

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -426,6 +426,9 @@ namespace smt::noodler {
                             var_aut.second->print_to_mata(tout);
                         }
                     }
+                    for (const auto& transd : solution.transducers) {
+                        tout << transd << "\n";
+                    }
                 );
                 STRACE("str-noodle-dot", tout << solution.DOT_name << " [style=filled,fillcolor=\"aqua\"];\n";);
                 return l_true;
@@ -735,7 +738,7 @@ namespace smt::noodler {
         SASSERT(output_vars_automata.size() == output_vars_divisions.size());
         SASSERT(output_vars_divisions.size() == output_vars.size());
 
-        std::vector<mata::strings::seg_nfa::TransducerNoodle> noodles = mata::strings::seg_nfa::noodlify_for_transducer(transducer_to_process.get_transducer(), input_vars_automata, output_vars_automata);
+        std::vector<mata::strings::seg_nfa::TransducerNoodle> noodles = mata::strings::seg_nfa::noodlify_for_transducer(transducer_to_process.get_transducer(), input_vars_automata, output_vars_automata, true);
         for (const auto& noodle : noodles) {
             // each noodle is a vector of tuples (T,i,Ai,o,Ao) where
             //      - T is a transducer, which will take one input and one output var: xo = T(xi)
@@ -906,11 +909,13 @@ namespace smt::noodler {
                     auto [input_trans, vars_on_tapes_of_input_trans] = get_composed_trans_with_tapes(transducers[i].get_input()[0]);
                     SASSERT(!vars_on_tapes_of_input_trans.empty() && vars_on_tapes_of_input_trans[0] == transducers[i].get_input()[0]);
                     // we compose Ti and Ti' on input_var, getting transducer output_var = Ti''(input_var, x1, x2, ...., xn)
-                    mata::nft::Nft composed_input = mata::nft::compose(invert_trans, input_trans, 1, 0, false); // TODO check if order of tapes in result is correct here
+                    mata::nft::Nft composed_input = mata::nft::compose(invert_trans, input_trans, 1, 0, false).trim(); // TODO check if order of tapes in result is correct here
                     composed_input = mata::nft::invert_levels(composed_input);
+                    SASSERT(!composed_input.contains_jump_transitions());
                     // we have a transducer output_var = T(y1, y2, ..., ym) computed from previous Tj's, j < i, and we compose here on output_var with Ti''
                     // getting transducer output_var = T'(y1, y2, ..., ym, input_var, x1, x2, ..., xn)
-                    final_trans = mata::nft::compose(composed_input, final_trans, composed_input.num_of_levels-1, 0, false); // TODO check if order of tapes in result is correct here
+                    final_trans = mata::nft::compose(composed_input, final_trans, composed_input.num_of_levels-1, 0, false).trim(); // TODO check if order of tapes in result is correct here
+                    SASSERT(!final_trans.contains_jump_transitions());
                     for (size_t i = 0; i < composed_input.num_of_levels-1; ++i) { final_trans = mata::nft::invert_levels(final_trans); }
                     // we had vars_on_tapes = {output_var, y1, y2, ..., ym} we add to it vars_on_tapes_of_input_trans getting
                     //   {output_var, y1, y2, ..., ym, input_var, x1, x2, ..., xn}

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -921,7 +921,7 @@ namespace smt::noodler::regex {
                 }
 
                 if (backward_iterator != backward_iterator_old) {
-                    return prefix_tree.create_transducer(mata_alph);
+                    return mata::nft::reduce(prefix_tree.create_transducer(mata_alph)).trim();
                 } else {
                     auto& find = backward_iterator->first;
                     zstring& replace = backward_iterator->second;
@@ -942,7 +942,14 @@ namespace smt::noodler::regex {
                 }
             );
             while (backward_iterator != backward_iterator_end) {
-                transducer = mata::nft::compose(transducer, get_next_transducer(), 1, 0);
+                mata::nft::Nft next_transducer = get_next_transducer();
+                STRACE("str-gather_transducer_constraints",
+                    tout << "Size of next NFT " << transducer.num_of_states() << "\n";
+                    if (is_trace_enabled("str-nfa")) {
+                        tout << transducer.print_to_dot(true);
+                    }
+                );
+                transducer = mata::nft::compose(transducer, next_transducer, 1, 0);
                 transducer = mata::nft::reduce(mata::nft::remove_epsilon(transducer).trim()).trim();
                 STRACE("str-gather_transducer_constraints",
                     tout << "Size of composed NFT " << transducer.num_of_states() << "\n";

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -779,6 +779,8 @@ namespace smt::noodler::regex {
             }
         }
 
+        // TODO I should check that find does not contains same chars multiple times
+
         mata::nfa::State cur_state = 0;
         for (unsigned find_char : find) {
             if (prefix_automaton.final[cur_state]) {

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -944,9 +944,9 @@ namespace smt::noodler::regex {
             while (backward_iterator != backward_iterator_end) {
                 mata::nft::Nft next_transducer = get_next_transducer();
                 STRACE("str-gather_transducer_constraints",
-                    tout << "Size of next NFT " << transducer.num_of_states() << "\n";
+                    tout << "Size of next NFT " << next_transducer.num_of_states() << "\n";
                     if (is_trace_enabled("str-nfa")) {
-                        tout << transducer.print_to_dot(true);
+                        tout << next_transducer.print_to_dot(true);
                     }
                 );
                 transducer = mata::nft::compose(transducer, next_transducer, 1, 0);

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -157,14 +157,47 @@ namespace smt::noodler::regex {
      */
     zstring get_model_from_regex(const app *regex, const seq_util& m_util_s);
 
+    /// Prefix tree for multiple replace_all applications so that we can construct transducer simultaneously
     class ReplaceAllPrefixTree {
-        std::set<unsigned> replace_chars;
-        mata::nfa::Nfa prefix_automaton{1,{0}};
-        std::map<mata::nfa::State, mata::Word> replacing_map;
+        std::set<unsigned> replace_chars; /// the chars occuring in the replace strings of replace_all operations
+        mata::nfa::Nfa prefix_automaton{1,{0}}; /// the prefix "tree" for find strings of replace_all operations (each find string will be a word of this automaton)
+        std::map<mata::nfa::State, mata::Word> replacing_map; /// maps final states of prefix_automaton that represent find strings to their corresponding replace strings
 
     public:
         ReplaceAllPrefixTree() = default;
+        /**
+         * @brief Add another replace_all application
+         * 
+         * It also checks if this application can be added to existing ones by some
+         * simple heuristics:
+         *      - @p find cannot contain some character which is in the replace string of
+         *        some previous replace_all application, as the replaced string could be
+         *        possibly matched by @p find (for example the first replace_all replaces
+         *        "a" with "bc" and the next one would replace "cd" with "d", so we would
+         *        need to for the word "ad" to get "bd" which would not happen in simultaneous
+         *        replacing)
+         *      - @p find cannot contain some character twice or more times as the created
+         *        transducer matches only, it cannot "start matching" while it is being
+         *        matched (for example matching "aab" on "aaab" would not work)
+         *      - @p find cannot be a prefix of the find string of some previous replace_all
+         *        operation (for example if we had "ab" is replaced with "c" and then we
+         *        would want replace_all where "a" is replaced with "d", the simultaneous
+         *        replacing would always replace "a" first, which is incorrect, "ab" should
+         *        be replaced)
+         * If it cannot be added, the function returns false and you should get the transducer.
+         * 
+         * @param find the string whose every occurence we want to replace
+         * @param replace what to replace with
+         * @return true If the replace_all application is added to this prefix tree
+         */
         bool add_find(const zstring& find, const zstring& replace);
+
+        /**
+         * @brief Creates a transducer replacing all added finds by their replaces simultaneously
+         * 
+         * @param mata_alph The alphabet used for creating the transducer
+         * @return The simultaneous transducer
+         */
         mata::nft::Nft create_transducer(mata::Alphabet* mata_alph);
     };
 

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -157,6 +157,18 @@ namespace smt::noodler::regex {
      */
     zstring get_model_from_regex(const app *regex, const seq_util& m_util_s);
 
+    class ReplaceAllPrefixTree {
+        std::set<zstring> find_prefixes;
+        std::set<unsigned> replace_chars;
+        mata::nfa::Nfa prefix_automaton{1,{0}};
+        std::map<mata::nfa::State, mata::Word> replacing_map;
+
+    public:
+        ReplaceAllPrefixTree() = default;
+        bool add_find(const zstring& find, const zstring& replace);
+        mata::nft::Nft create_transducer(mata::Alphabet* mata_alph);
+    };
+
     /**
      * @brief Gather transducer constraint (replace_all, replace_re_all) from a concatenation. Recursively applies also on 
      * nested calls of replace_all, replace_re_all.

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -158,7 +158,6 @@ namespace smt::noodler::regex {
     zstring get_model_from_regex(const app *regex, const seq_util& m_util_s);
 
     class ReplaceAllPrefixTree {
-        std::set<zstring> find_prefixes;
         std::set<unsigned> replace_chars;
         mata::nfa::Nfa prefix_automaton{1,{0}};
         std::map<mata::nfa::State, mata::Word> replacing_map;

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -161,7 +161,7 @@ namespace smt::noodler::regex {
      * @brief Gather transducer constraint (replace_all, replace_re_all) from a concatenation. Recursively applies also on 
      * nested calls of replace_all, replace_re_all.
      * 
-     * @param ex Concatenation of string terms.
+     * @param ex Expression to gather replaces from.
      * @param m AST manager
      * @param m_util_s Seq util for AST.
      * @param pred_replace Replacement of predicate and functions
@@ -169,7 +169,7 @@ namespace smt::noodler::regex {
      * @param mata_alph Mata alphabet containing symbols from the current instance
      * @param[out] transducer_preds Newly created transducer constraints
      */
-    void gather_transducer_constraints(app* const ex, ast_manager& m, const seq_util& m_util_s, obj_map<expr, expr*>& pred_replace, 
+    void gather_transducer_constraints(app* ex, ast_manager& m, const seq_util& m_util_s, obj_map<expr, expr*>& pred_replace, 
         std::map<BasicTerm, expr_ref>& var_name, mata::Alphabet* mata_alph, std::vector<Predicate>& transducer_preds);
 
 }


### PR DESCRIPTION
- add creating one transducer of nested `replace_all` operations with specific handling of `replace_all` that replaces always just one symbol
- fix creating transducer for parikh (mainly fixes in mata)