### PR TITLE
Transducers with `to_code` + models

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For a brief overview of the architecture, see [SMT-COMP'24 Z3-Noodler descriptio
 
 ### Dependencies
 
-1) The [Mata](https://github.com/VeriFIT/mata/) library for efficient handling of finite automata. Minimum required version of `mata` is `v1.11.2`.
+1) The [Mata](https://github.com/VeriFIT/mata/) library for efficient handling of finite automata. Minimum required version of `mata` is `v1.16.2`.
     ```shell
     git clone 'https://github.com/VeriFIT/mata.git'
     cd mata

--- a/src/smt/theory_str_noodler/aut_assignment.cpp
+++ b/src/smt/theory_str_noodler/aut_assignment.cpp
@@ -265,6 +265,7 @@ namespace smt::noodler {
                 }
             }
         }
+        return is_there_some_dummy;
     }
 
     std::optional<mata::Symbol> AutAssignment::replace_dummy_with_new_symbol() {

--- a/src/smt/theory_str_noodler/aut_assignment.cpp
+++ b/src/smt/theory_str_noodler/aut_assignment.cpp
@@ -240,11 +240,7 @@ namespace smt::noodler {
         }
     }
 
-    std::optional<mata::Symbol> AutAssignment::replace_dummy_with_new_symbol() {
-        if(alphabet.size() == 0) {
-            return std::nullopt;
-        }
-        mata::Symbol new_symbol = regex::Alphabet(alphabet).get_unused_symbol();
+    bool AutAssignment::replace_dummy_with_symbols(std::set<mata::Symbol> symbols) {
         bool is_there_some_dummy = false;
         for (auto& [var, nfa] : *this) {
             for (mata::nfa::State state = 0; state < nfa->num_of_states(); ++state) {
@@ -255,12 +251,18 @@ namespace smt::noodler {
                         is_there_some_dummy = true;
                         mata::nfa::StateSet targets = delta_from_state.back().targets;
                         delta_from_state.pop_back();
-                        nfa->delta.add(state, new_symbol, targets);
+                        for (mata::Symbol symbol : symbols) {
+                            nfa->delta.add(state, symbol, targets);
+                        }
                     }
                 }
             }
         }
-        if (is_there_some_dummy) {
+    }
+
+    std::optional<mata::Symbol> AutAssignment::replace_dummy_with_new_symbol() {
+        mata::Symbol new_symbol = regex::Alphabet(alphabet).get_unused_symbol();
+        if (replace_dummy_with_symbols({new_symbol})) {
             alphabet.insert(new_symbol);
             return new_symbol;
         } else {

--- a/src/smt/theory_str_noodler/aut_assignment.cpp
+++ b/src/smt/theory_str_noodler/aut_assignment.cpp
@@ -223,6 +223,13 @@ namespace smt::noodler {
         return flat;
     }
 
+    mata::Symbol AutAssignment::add_fresh_symbol_to_alphabet() {
+        mata::Symbol new_symbol = regex::Alphabet(alphabet).get_unused_symbol();
+        this->alphabet.insert(new_symbol);
+        return new_symbol;
+    }
+
+
     void AutAssignment::add_symbol_from_dummy(mata::Symbol sym) {
         if(alphabet.contains(sym)) { return; }
         bool is_there_some_dummy = false;

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -209,11 +209,7 @@ namespace smt::noodler {
             this->alphabet.insert(s);
         }
 
-        mata::Symbol add_fresh_symbol_to_alphabet() {
-            mata::Symbol new_symbol = regex::Alphabet(alphabet).get_unused_symbol();
-            this->alphabet.insert(new_symbol);
-            return new_symbol;
-        }
+        mata::Symbol add_fresh_symbol_to_alphabet();
 
         /// @brief Add symbol @p s to alphabet and removes it from dummy symbol (i.e. adds transitions trough @p s in all automata if there is transition trough dummy symbol)
         void add_symbol_from_dummy(mata::Symbol s);

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -205,8 +205,20 @@ namespace smt::noodler {
             }
         }
 
+        void add_symbol_to_alphabet(mata::Symbol s) {
+            this->alphabet.insert(s);
+        }
+
+        mata::Symbol add_fresh_symbol_to_alphabet() {
+            mata::Symbol new_symbol = regex::Alphabet(alphabet).get_unused_symbol();
+            this->alphabet.insert(new_symbol);
+            return new_symbol;
+        }
+
         /// @brief Add symbol @p s to alphabet and removes it from dummy symbol (i.e. adds transitions trough @p s in all automata if there is transition trough dummy symbol)
         void add_symbol_from_dummy(mata::Symbol s);
+
+        bool replace_dummy_with_symbols(std::set<mata::Symbol> symbols);
 
         /**
          * @brief Replace dummy symbol in all automata by a new symbol

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -971,9 +971,7 @@ namespace smt::noodler {
                     }
                 }
             }
-            
 
-            // STRACE("str-parikh", tout << one_symbol_transducer;);
             one_symbol_transducer = mata::nft::reduce(mata::nft::remove_epsilon(one_symbol_transducer).trim()).trim();
 
             STRACE("str-parikh", tout << "Formula for transducer of size " << one_symbol_transducer.num_of_states() << " with variables " << vars_on_tapes << " is: ";);
@@ -983,7 +981,6 @@ namespace smt::noodler {
             result.succ.push_back(parikh_of_transducer);
 
             // Handle code-point vars that occur in this transducer
-            bool is_there_code_conversion_with_dummy_symbol = false; // whether there is some code-point var that can be a dummy symbol
             for (const BasicTerm& var : vars_on_tapes) {
                 if (code_subst_vars.contains(var)) {
                     code_subst_vars_handled_by_parikh.insert(var);
@@ -1008,7 +1005,7 @@ namespace smt::noodler {
                         // the rest is just computing 'code_version_of(var) is code point of one of the symbols based on parikh'
 
                         for (mata::Symbol s : parikh_transducer.get_tape_var_used_symbols().at(var)) {
-                            if (!util::is_dummy_symbol(s)) {
+                            if (util::is_dummy_symbol(s)) {
                                 // dummy symbols are hard, because there can be connections between different transitions with dummy symbols, even in different transducers
                                 // TODO add handling of dummy symbols
                                 util::throw_error("We cannot handle dummy symbols in tocode conversions with transducers");

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -2098,7 +2098,7 @@ namespace smt::noodler {
             for (size_t tape_num = 0; tape_num < tape_vars.size(); ++tape_num) {
                 transducer = transducer.apply(*solution.aut_ass.at(tape_vars[tape_num]), tape_num, false);
             }
-            mata::Word accepting_word = transducer.get_word(true).value();
+            mata::Word accepting_word = transducer.get_word(std::nullopt).value();
             std::vector<mata::Word> words_for_tape_vars{tape_vars.size()};
             size_t current_tape_var = 0;
             for (unsigned current_symbol : accepting_word) {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1033,6 +1033,8 @@ namespace smt::noodler {
                 }
             }
         }
+
+        return result;
     }
 
     LenNode DecisionProcedure::get_formula_for_len_vars() {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -711,7 +711,7 @@ namespace smt::noodler {
             Predicate new_inclusion = input_is_literal ? Predicate::create_equation(non_literal_side, {}) : Predicate::create_equation({}, non_literal_side);
             if (!mata::strings::is_lang_eps(application_to_literal)) {
                 // if the application does not lead to empty string we need to create a new var for literal side and replace it with its language set to application_to_literal
-                BasicTerm fresh_var = solving_state.add_fresh_var(std::make_shared<mata::nfa::Nfa>(application_to_literal), std::string("emptysideapp_") + std::to_string(noodlification_no), false, true);
+                BasicTerm fresh_var = solving_state.add_fresh_var(std::make_shared<mata::nfa::Nfa>(application_to_literal), std::string("literalsideapp_") + std::to_string(noodlification_no), false, true);
                 if (input_is_literal) {
                     new_inclusion.set_right_side({fresh_var});
                 } else {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -947,7 +947,7 @@ namespace smt::noodler {
             mata::nft::Nft transducer_reduced = mata::nft::reduce(mata::nft::remove_epsilon(transducer).trim()).trim();
 
             STRACE("str-parikh", tout << "Formula for transducer of size " << transducer_reduced.num_of_states() << " with variables " << vars_on_tapes << " is: ";);
-            LenNode parikh_of_transducer = parikh::ParikhImageTransducer{transducer_reduced, vars_on_tapes}.compute_parikh_image_vars();
+            LenNode parikh_of_transducer = parikh::ParikhImageTransducer{transducer_reduced, vars_on_tapes}.compute_parikh_image();
             STRACE("str-parikh", tout << parikh_of_transducer << "\n";);
             result.succ.push_back(parikh_of_transducer);
         }

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -947,7 +947,7 @@ namespace smt::noodler {
             mata::nft::Nft transducer_reduced = mata::nft::reduce(mata::nft::remove_epsilon(transducer).trim()).trim();
 
             STRACE("str-parikh", tout << "Formula for transducer of size " << transducer_reduced.num_of_states() << " with variables " << vars_on_tapes << " is: ";);
-            LenNode parikh_of_transducer = parikh::ParikhImageTransducer(transducer_reduced).compute_parikh_image_vars(vars_on_tapes);
+            LenNode parikh_of_transducer = parikh::ParikhImageTransducer{transducer_reduced, vars_on_tapes}.compute_parikh_image_vars();
             STRACE("str-parikh", tout << parikh_of_transducer << "\n";);
             result.succ.push_back(parikh_of_transducer);
         }

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -848,7 +848,7 @@ namespace smt::noodler {
         conjuncts.push_back(preprocessing_len_formula);
 
         // compute formula for vars in transducers (lengths and code-point conversions)
-        conjuncts.push_back(get_formula_for_len_vars());
+        conjuncts.push_back(get_formula_for_transducers());
 
         // formula for encoding lengths
         conjuncts.push_back(get_formula_for_len_vars());

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -950,10 +950,11 @@ namespace smt::noodler {
                 }
             }
 
-            // STRACE("str-parikh", tout << transducer;);
+            // we only need the length dependency between variables given by the transducers, therefore we can replace all symbols in the transducer by one symbol
+            // except for code-point variables, for these we need exact value (but still dependency of this variable on other non-code-point variables is only
+            // trough lengths)
             mata::nft::Nft one_symbol_transducer{transducer.num_of_states(), transducer.initial, transducer.final, transducer.levels, transducer.num_of_levels};
             for (mata::nfa::State source_state = 0; source_state < transducer.delta.num_of_states(); ++source_state) {
-                // STRACE("str-parikh", tout << "Processing state " << source_state << "\n" << one_symbol_transducer;);
                 mata::nfa::StatePost& state_post_of_new_source_state = one_symbol_transducer.delta.mutable_state_post(source_state);
                 if (code_subst_vars.contains(vars_on_tapes[transducer.levels[source_state]])) {
                     state_post_of_new_source_state = transducer.delta[source_state];

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -592,7 +592,7 @@ namespace smt::noodler {
                                                         // the var is length if the corresponding variable on the left or right is length too
                                                         new_element.length_sensitive_vars.contains(left_side_vars[noodle[i].second[0]])
                                                             || new_element.contains_length_var(right_side_division[noodle[i].second[1]]),
-                                                        false);
+                                                        true);
                 left_side_vars_to_new_vars[noodle[i].second[0]].push_back(new_var);
                 right_side_divisions_to_new_vars[noodle[i].second[1]].push_back(new_var);
                 STRACE("str-nfa", tout << new_var << std::endl << *noodle[i].first;);

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -661,6 +661,8 @@ namespace smt::noodler {
 
         // inclusions that resulted from preprocessing, we use them to generate model (we can pretend that they were all already refined)
         std::vector<Predicate> inclusions_from_preprocessing;
+
+        std::vector<std::pair<mata::nft::Nft,std::vector<BasicTerm>>> transducers_with_vars_on_tapes;
         
         bool is_model_initialized = false;
         /**
@@ -683,6 +685,7 @@ namespace smt::noodler {
          * @return the computed model 
          */
         zstring update_model_and_aut_ass(BasicTerm var, zstring computed_model) {
+            SASSERT(!model_of_var.contains(var) || model_of_var.at(var) == computed_model);
             model_of_var[var] = computed_model;
             if (solution.aut_ass.contains(var)) {
                 solution.aut_ass[var] = std::make_shared<mata::nfa::Nfa>(AutAssignment::create_word_nfa(computed_model));

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -504,6 +504,8 @@ namespace smt::noodler {
         std::set<BasicTerm> code_subst_vars;
         std::set<BasicTerm> int_subst_vars;
 
+        std::set<BasicTerm> code_subst_vars_handled_by_parikh;
+
         const theory_str_noodler_params& m_params;
 
         /**

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -490,6 +490,9 @@ namespace smt::noodler {
         // contains to/from_code/int conversions
         std::vector<TermConversion> conversions;
 
+        // length vars that occur as input/output of some transducer formula
+        std::set<BasicTerm> length_vars_with_transducers;
+
         // disequations that are supposed to be solved after a stable solution is found
         Formula disequations;
         // not contains that are supposed to be solved after a stable solution is found
@@ -540,15 +543,22 @@ namespace smt::noodler {
         }
 
         /**
-         * @brief Get the formula encoding lengths of variables based on solution
+         * @brief Get the (parikh) formula encoding lengths and code-point conversions of variables in transducers
          * 
-         * It creates parikh formula for length vars in transducers, for other length
+         * Assumes that code_subst_vars and int_subst_vars are computed already.
+         * It also updates length_vars_with_transducers and code_subst_vars_handled_by_parikh
+         */
+        LenNode get_formula_for_transducers();
+
+        /**
+         * @brief Get the formula encoding lengths of variables based on solution
+         * It ignores the length vars that are in tranducers, as formula for these
+         * should be in get_formula_for_transducers(). For the normal length
          * vars it either creates formula |x| = |x_1| + ... + |x_n| if
          *   solution.subtitution_map[x] = x_1 ... x_n
          * or it creates the formula from lasso construction of automaton
          *   solution.aut_ass[x]
          * 
-         * Assumes that code_subst_vars and int_subst_vars are computed already.
          */
         LenNode get_formula_for_len_vars();
 
@@ -651,9 +661,6 @@ namespace smt::noodler {
 
         // inclusions that resulted from preprocessing, we use them to generate model (we can pretend that they were all already refined)
         std::vector<Predicate> inclusions_from_preprocessing;
-
-        // length vars that occur as input/output of some transducer formula
-        std::set<BasicTerm> length_vars_with_transducers;
         
         bool is_model_initialized = false;
         /**

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -217,7 +217,7 @@ namespace smt::noodler {
          */
         void push_non_simple_transducers_to_processing() {
             for (const Predicate &transducer : transducers) {
-                if (transducer.get_input().size() != 1 || transducer.get_output().size() != 1) {
+                if (transducer.get_input().size() != 1 || transducer.get_output().size() != 1 || transducer.get_input()[0].is_literal() || transducer.get_input()[1].is_literal()) {
                     push_unique(transducer, false);
                 }
             }

--- a/src/smt/theory_str_noodler/length_decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/length_decision_procedure.cpp
@@ -760,7 +760,9 @@ namespace smt::noodler {
 
 
     LengthProcModel::LengthProcModel(const ConstraintPool& block_pool, const SubstitutionMap& subst, const AutAssignment& aut_ass, const std::set<BasicTerm>& multi_var_set) : model(), subst_map(subst), aut_ass(aut_ass), block_pool(block_pool), multi_var_set(multi_var_set) {
-        this->aut_ass.replace_dummy_with_new_symbol();
+        if(aut_ass.get_alphabet().size() != 0) {
+            this->aut_ass.replace_dummy_with_new_symbol();
+        }
         std::set<BasicTerm> len_vars{};
         this->lit_conversion = block_pool.get_lit_conversion();
         this->block_models = std::map<BasicTerm, BlockModel>();

--- a/src/smt/theory_str_noodler/parikh_image.cpp
+++ b/src/smt/theory_str_noodler/parikh_image.cpp
@@ -1398,7 +1398,6 @@ namespace smt::noodler::parikh {
     }
 
     LenNode ParikhImageTransducer::compute_parikh_image() {
-        this->tape_len.clear();
         LenNode parikhStruct = ParikhImage::compute_parikh_image();
         LenNode len_formula(LenFormulaType::AND);
 
@@ -1414,28 +1413,13 @@ namespace smt::noodler::parikh {
         }
 
         for(size_t i = 0; i < sum_tapes.size(); i++) {
-            this->tape_len.push_back(util::mk_noodler_var_fresh("tape_len"));
             len_formula.succ.push_back({
-                LenFormulaType::EQ, { this->tape_len[i], sum_tapes[i] }
+                LenFormulaType::EQ, { this->tape_vars[i], sum_tapes[i] }
             });
         }
 
         return LenNode{
             LenFormulaType::AND, { parikhStruct, len_formula }
         };
-    }
-
-    LenNode ParikhImageTransducer::compute_parikh_image_vars(const std::vector<BasicTerm>& tape_vars) {
-        LenNode pi = compute_parikh_image();
-        assert(tape_vars.size() == this->tape_len.size());
-
-        LenNode res(LenFormulaType::AND);
-        for(size_t i = 0; i < tape_vars.size(); i++) {
-            res.succ.push_back({
-                LenFormulaType::EQ, {tape_vars[i], this->tape_len[i]}
-            });
-        }
-        res.succ.push_back(pi);
-        return res;
     }
 }

--- a/src/smt/theory_str_noodler/parikh_image.h
+++ b/src/smt/theory_str_noodler/parikh_image.h
@@ -379,7 +379,7 @@ public:
      */
     ParikhImageTransducer(const mata::nft::Nft& nft, std::vector<BasicTerm> tape_vars, std::vector<BasicTerm> vars_that_need_symbol_mapping = {}) 
         : ParikhImage(nft.to_nfa_copy()), nft(nft), tape_vars(tape_vars), vars_that_need_symbol_mapping(vars_that_need_symbol_mapping) {
-            SASSERT(nft.num_of_levels() == tape_vars.size());
+            SASSERT(nft.num_of_levels == tape_vars.size());
         }
 
     /**

--- a/src/smt/theory_str_noodler/parikh_image.h
+++ b/src/smt/theory_str_noodler/parikh_image.h
@@ -377,7 +377,7 @@ public:
      * 
      * @param nft The non-deterministic finite transducer to analyze.
      */
-    ParikhImageTransducer(const mata::nft::Nft& nft, std::vector<BasicTerm> tape_vars, std::vector<BasicTerm> vars_that_need_symbol_mapping = {}) 
+    ParikhImageTransducer(const mata::nft::Nft& nft, std::vector<BasicTerm> tape_vars, std::set<BasicTerm> vars_that_need_symbol_mapping = {}) 
         : ParikhImage(nft.to_nfa_copy()), nft(nft), tape_vars(tape_vars), vars_that_need_symbol_mapping(vars_that_need_symbol_mapping) {
             SASSERT(nft.num_of_levels == tape_vars.size());
         }

--- a/src/smt/theory_str_noodler/parikh_image.h
+++ b/src/smt/theory_str_noodler/parikh_image.h
@@ -365,7 +365,8 @@ class ParikhImageTransducer : public ParikhImage {
 
 private: 
     mata::nft::Nft nft; ///< The non-deterministic finite transducer (NFT) being analyzed.
-    std::vector<BasicTerm> tape_len {}; ///< Variables representing the lengths of the output tape.
+    std::vector<BasicTerm> tape_vars {}; ///< Variables representing the lengths of the output tape.
+    std::set<BasicTerm> vars_that_need_symbol_mapping {}; ///< Variables for which we will compute also 
 
 public:
     /**
@@ -376,20 +377,10 @@ public:
      * 
      * @param nft The non-deterministic finite transducer to analyze.
      */
-    ParikhImageTransducer(const mata::nft::Nft& nft) 
-        : ParikhImage(nft.to_nfa_copy()), nft(nft) { }
-
-    /**
-     * @brief Compute the Parikh image of the transducer with tape length variables.
-     * 
-     * This method extends the Parikh image computation to include constraints 
-     * for the lengths of the output tape. It binds the tape length variables 
-     * to the computed tape lengths for each level of the transducer.
-     * 
-     * @param tape_vars Variables representing the lengths of the output tape.
-     * @return LenNode Formula representing the Parikh image with tape length constraints.
-     */
-    LenNode compute_parikh_image_vars(const std::vector<BasicTerm>& tape_vars);
+    ParikhImageTransducer(const mata::nft::Nft& nft, std::vector<BasicTerm> tape_vars, std::vector<BasicTerm> vars_that_need_symbol_mapping = {}) 
+        : ParikhImage(nft.to_nfa_copy()), nft(nft), tape_vars(tape_vars), vars_that_need_symbol_mapping(vars_that_need_symbol_mapping) {
+            SASSERT(nft.num_of_levels() == tape_vars.size());
+        }
 
     /**
      * @brief Compute the Parikh image of the transducer.

--- a/src/smt/theory_str_noodler/parikh_image.h
+++ b/src/smt/theory_str_noodler/parikh_image.h
@@ -416,6 +416,9 @@ public:
      * Furthermore, for each var in vars_that_need_symbol_mapping, it also encodes
      * the variables that say how many times each symbol occurs in such a var.
      * 
+     * If you only need lengths, it is recommended to use mata::nft::Nft::get_one_letter_aut()
+     * to reduce the size of the resulting formula.
+     * 
      * @return LenNode Formula representing the Parikh image of the transducer.
      */
     LenNode compute_parikh_image() override;

--- a/src/smt/theory_str_noodler/parikh_image.h
+++ b/src/smt/theory_str_noodler/parikh_image.h
@@ -370,19 +370,20 @@ private:
 
     std::map<BasicTerm, std::set<mata::Symbol>> tape_var_used_symbols;
 public:
-    BasicTerm get_tape_var_for_symbol_mapping(const BasicTerm& tape_var, mata::Symbol symbol) const {
-        return BasicTerm{ BasicTermType::Variable, zstring(tape_var.get_name() + "!symbolmappingfor" + zstring(rational(symbol))) };
-    }
-
-    const std::map<BasicTerm, std::set<mata::Symbol>>& get_tape_var_used_symbols() const { return tape_var_used_symbols; }
-
     /**
      * @brief Construct a ParikhImageTransducer object.
      * 
      * Initializes the ParikhImageTransducer with a given NFT. The underlying NFA
-     * representation of the NFT is used for Parikh image computation.
+     * representation of the NFT is used for Parikh image computation. The resulting
+     * formula will encode
+     *      |tape_vars[i]| == the length of the word on tape i of the NFT
+     * For each tape var that also occur in @p vars_that_need_symbol_mapping, we will
+     * encode in get_tape_var_for_symbol_mapping(tape_var, symbol) how many times symbol
+     * occurs on the word for the tape var.
      * 
      * @param nft The non-deterministic finite transducer to analyze.
+     * @param tape_vars The vars on tapes whose lengths we want to encode, |tape_vars| must be equal nft.num_of_levels()
+     * @param vars_that_need_symbol_mapping The tape vars that need the encoding of how many times each symbol occurs.
      */
     ParikhImageTransducer(const mata::nft::Nft& nft, std::vector<BasicTerm> tape_vars, std::set<BasicTerm> vars_that_need_symbol_mapping = {}) 
         : ParikhImage(nft.to_nfa_copy()), nft(nft), tape_vars(tape_vars), vars_that_need_symbol_mapping(vars_that_need_symbol_mapping) {
@@ -390,11 +391,30 @@ public:
         }
 
     /**
+     * @brief Get the variable encoding how many times @p tape_var contains @p symbol
+     */
+    BasicTerm get_tape_var_for_symbol_mapping(const BasicTerm& tape_var, mata::Symbol symbol) const {
+        SASSERT(vars_that_need_symbol_mapping.contains(tape_var));
+        return BasicTerm{ BasicTermType::Variable, zstring(tape_var.get_name() + "!symbolmappingfor" + zstring(rational(symbol))) };
+    }
+
+    /**
+     * @brief Get the mapping that maps each tape var from vars_that_need_symbol_mapping into symbols that can occur in tape var
+     * 
+     * Assumes that compute_parikh_image() was already run.
+     * If such a tape var does not contain any such symbols, then it is not mapped in this mapping.
+     */
+    const std::map<BasicTerm, std::set<mata::Symbol>>& get_tape_var_used_symbols() const { return tape_var_used_symbols; }
+
+
+    /**
      * @brief Compute the Parikh image of the transducer.
      * 
      * This method computes the Parikh image of the transducer, including constraints 
      * for the lengths of the output tape. It calculates the tape lengths for each 
      * level of the transducer and generates a formula representing the Parikh image.
+     * Furthermore, for each var in vars_that_need_symbol_mapping, it also encodes
+     * the variables that say how many times each symbol occurs in such a var.
      * 
      * @return LenNode Formula representing the Parikh image of the transducer.
      */

--- a/src/smt/theory_str_noodler/parikh_image.h
+++ b/src/smt/theory_str_noodler/parikh_image.h
@@ -366,9 +366,16 @@ class ParikhImageTransducer : public ParikhImage {
 private: 
     mata::nft::Nft nft; ///< The non-deterministic finite transducer (NFT) being analyzed.
     std::vector<BasicTerm> tape_vars {}; ///< Variables representing the lengths of the output tape.
-    std::set<BasicTerm> vars_that_need_symbol_mapping {}; ///< Variables for which we will compute also 
+    std::set<BasicTerm> vars_that_need_symbol_mapping {}; ///< Variables for which we will compute also the symbol mapping
 
+    std::map<BasicTerm, std::set<mata::Symbol>> tape_var_used_symbols;
 public:
+    BasicTerm get_tape_var_for_symbol_mapping(const BasicTerm& tape_var, mata::Symbol symbol) const {
+        return BasicTerm{ BasicTermType::Variable, zstring(tape_var.get_name() + "!symbolmappingfor" + zstring(rational(symbol))) };
+    }
+
+    const std::map<BasicTerm, std::set<mata::Symbol>>& get_tape_var_used_symbols() const { return tape_var_used_symbols; }
+
     /**
      * @brief Construct a ParikhImageTransducer object.
      * 

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -711,10 +711,16 @@ namespace smt::noodler::regex {
         } else if (m_util_s.re.is_loop(regex)) { // Handle loop.
             unsigned low, high;
             expr *body;
-            VERIFY(m_util_s.re.is_loop(regex, body, low, high) || m_util_s.re.is_loop(regex, body, low));
+            if (m_util_s.re.is_loop(regex, body, low, high)) {
+                if (low > high) {
+                    return zstring();
+                }
+            } else {
+                VERIFY(m_util_s.re.is_loop(regex, body, low));
+            }
 
             // return model from body iterated low times
-            if (low == 0 || low > high) {
+            if (low == 0) {
                 return zstring();
             } else {
                 const zstring inside = get_model_from_regex(to_app(body), m_util_s);

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -65,8 +65,13 @@ namespace smt::noodler::regex {
 
         /// @brief Returns any symbol that is not in the alphabet
         mata::Symbol get_unused_symbol() const {
+            if (alphabet.size() == zstring::max_char()) {
+                // alphabet is full, we throw error (TODO: should probably return nullopt or something like that)
+                util::throw_error("Trying to get a fresh symbol in full alphabet");
+                return 0; // this is unreachable, return something so we can compile
+            }
             // std::set is ordered, so alphabet is also ordered
-            if (*alphabet.begin() != 0) {
+            if (alphabet.empty() || *alphabet.begin() != 0) {
                 return 0;
             } else {
                 auto it = alphabet.begin();

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -7,8 +7,30 @@
 #include "inclusion_graph.h"
 #include "aut_assignment.h"
 
-namespace {
-    using mata::nfa::Nfa;
+template <typename T>
+size_t rec_bin_search_leftmost(const std::vector<T>& haystack, T needle, size_t start_idx, size_t end_idx) {
+
+    if (start_idx == end_idx) {
+        if (haystack.at(start_idx) >= needle) return start_idx;
+        return -1;
+    }
+
+    size_t midpoint = start_idx + (end_idx - start_idx) / 2;
+    if (needle < midpoint) {
+        return rec_bin_search_leftmost(haystack, needle, start_idx, midpoint);
+    }
+
+    size_t match = rec_bin_search_leftmost(haystack, needle, midpoint+1, end_idx);
+    if (match == -1) {
+        // We have not found the the in [midpoint+1 ... end_idx], therefore, the leftmost smaller is midpoint
+        return midpoint;
+    }
+    return match;
+}
+
+template <typename T>
+size_t bin_search_leftmost(const std::vector<T>& haystack, T needle) {
+    return rec_bin_search_leftmost(haystack, needle, 0, haystack.size());
 }
 
 namespace smt::noodler::util {
@@ -285,30 +307,22 @@ namespace smt::noodler::util {
         }
         return inclusions;
     }
-}
 
-template <typename T>
-size_t rec_bin_search_leftmost(const std::vector<T>& haystack, T needle, size_t start_idx, size_t end_idx) {
-
-    if (start_idx == end_idx) {
-        if (haystack.at(start_idx) >= needle) return start_idx;
-        return -1;
+    void replace_dummy_symbol_in_transducer_with(mata::nft::Nft& transducer, const std::set<mata::Symbol>& symbols_to_replace_with) {
+        for (mata::nfa::State state = 0; state < transducer.num_of_states(); ++state) {
+            if (!transducer.delta[state].empty()) { // if there is some transition from state
+                mata::nfa::StatePost& delta_from_state = transducer.delta.mutable_state_post(state); // then we can for sure get mutable transitions from state without side effect
+                for (auto iter = delta_from_state.begin(); iter != delta_from_state.end(); ++iter) {
+                    if (iter->symbol == util::get_dummy_symbol()) {
+                        mata::nfa::StateSet targets = iter->targets;
+                        delta_from_state.erase(iter);
+                        for (mata::Symbol replacement : symbols_to_replace_with) {
+                            transducer.delta.add(state, replacement, targets); // this invalidates iter, but we are breaking from the loop anyway
+                        }
+                        break;
+                    }
+                }
+            }
+        }
     }
-
-    size_t midpoint = start_idx + (end_idx - start_idx) / 2;
-    if (needle < midpoint) {
-        return rec_bin_search_leftmost(haystack, needle, start_idx, midpoint);
-    }
-
-    size_t match = rec_bin_search_leftmost(haystack, needle, midpoint+1, end_idx);
-    if (match == -1) {
-        // We have not found the the in [midpoint+1 ... end_idx], therefore, the leftmost smaller is midpoint
-        return midpoint;
-    }
-    return match;
-}
-
-template <typename T>
-size_t bin_search_leftmost(const std::vector<T>& haystack, T needle) {
-    return rec_bin_search_leftmost(haystack, needle, 0, haystack.size());
 }

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -309,6 +309,12 @@ namespace smt::noodler::util {
     }
 
     void replace_dummy_symbol_in_transducer_with(mata::nft::Nft& transducer, const std::set<mata::Symbol>& symbols_to_replace_with) {
+        if (symbols_to_replace_with.size() > 1) {
+            // different transitions with dummy symbol can be connected, i.e. they should have the same symbol, if we would replace
+            // by multiple symbols, it would allow situations where the transitions have different symbols on them
+            // TODO add handling for this? or model generation should be done differently
+            util::throw_error("We cannot replace dummy symbol by more than one symbol in transducers yet");
+        }
         for (mata::nfa::State state = 0; state < transducer.num_of_states(); ++state) {
             if (!transducer.delta[state].empty()) { // if there is some transition from state
                 mata::nfa::StatePost& delta_from_state = transducer.delta.mutable_state_post(state); // then we can for sure get mutable transitions from state without side effect

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -7,32 +7,6 @@
 #include "inclusion_graph.h"
 #include "aut_assignment.h"
 
-template <typename T>
-size_t rec_bin_search_leftmost(const std::vector<T>& haystack, T needle, size_t start_idx, size_t end_idx) {
-
-    if (start_idx == end_idx) {
-        if (haystack.at(start_idx) >= needle) return start_idx;
-        return -1;
-    }
-
-    size_t midpoint = start_idx + (end_idx - start_idx) / 2;
-    if (needle < midpoint) {
-        return rec_bin_search_leftmost(haystack, needle, start_idx, midpoint);
-    }
-
-    size_t match = rec_bin_search_leftmost(haystack, needle, midpoint+1, end_idx);
-    if (match == -1) {
-        // We have not found the the in [midpoint+1 ... end_idx], therefore, the leftmost smaller is midpoint
-        return midpoint;
-    }
-    return match;
-}
-
-template <typename T>
-size_t bin_search_leftmost(const std::vector<T>& haystack, T needle) {
-    return rec_bin_search_leftmost(haystack, needle, 0, haystack.size());
-}
-
 namespace smt::noodler::util {
 
     void throw_error(std::string errMsg) {

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -325,4 +325,16 @@ namespace smt::noodler::util {
             }
         }
     }
+
+    bool is_concatenation_of_literals(const std::vector<BasicTerm>& concatenation, zstring& literal) {
+        literal.reset();
+        for (const BasicTerm& bt : concatenation) {
+            if (bt.is_literal()) {
+                literal += bt.get_name();
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -163,8 +163,8 @@ namespace smt::noodler::util {
      * Assumes that @p left_sides and @p right_sides have the same size.
      */
     std::vector<Predicate> create_inclusions_from_multiple_sides(const std::vector<std::vector<BasicTerm>>& left_sides, const std::vector<std::vector<BasicTerm>>& right_sides);
-}
 
-size_t bin_search_leftmost(const std::vector<mata::nfa::State>& haystack, mata::nfa::State needle);
+    void replace_dummy_symbol_in_transducer_with(mata::nft::Nft& transducer, const std::set<mata::Symbol>& symbols_to_replace_with);
+}
 
 #endif

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -165,6 +165,8 @@ namespace smt::noodler::util {
     std::vector<Predicate> create_inclusions_from_multiple_sides(const std::vector<std::vector<BasicTerm>>& left_sides, const std::vector<std::vector<BasicTerm>>& right_sides);
 
     void replace_dummy_symbol_in_transducer_with(mata::nft::Nft& transducer, const std::set<mata::Symbol>& symbols_to_replace_with);
+
+    bool is_concatenation_of_literals(const std::vector<BasicTerm>& concatenation, zstring& literal);
 }
 
 #endif

--- a/src/test/noodler/parikh.cc
+++ b/src/test/noodler/parikh.cc
@@ -947,6 +947,7 @@ TEST_CASE("Transducers :: simple lengths", "[noodler]") {
     cmd_context ctx(false, &m);
     std::ostringstream trash;
     ctx.set_regular_stream(trash);
+    std::vector<BasicTerm> vars_on_tapes{{BasicTermType::Variable, "x1"}, {BasicTermType::Variable, "x2"}};
 
     SECTION("Simple transducer 1") {
         mata::nft::Nft nft1{2};
@@ -954,11 +955,11 @@ TEST_CASE("Transducers :: simple lengths", "[noodler]") {
         nft1.final = {1};
         nft1.insert_word_by_parts(0, { {'a'}, {'b'} } , 1);
 
-        ParikhImageTransducer pi(nft1);
+        ParikhImageTransducer pi(nft1, vars_on_tapes);
         LenNode formula = pi.compute_parikh_image();
 
         expr_ref result = len_node_to_expr(m, ctx, formula);
-        check_lia_model(m, result, {{"tape_len!n0", "1"}, {"tape_len!n1", "1"}});
+        check_lia_model(m, result, {{"x1", "1"}, {"x2", "1"}});
     }
 
     SECTION("Simple transducer 2") {
@@ -967,11 +968,11 @@ TEST_CASE("Transducers :: simple lengths", "[noodler]") {
         nft2.final = {1};
         nft2.insert_word_by_parts(0, { {'a', 'b'}, {'b', 'b'} } , 1);
 
-        ParikhImageTransducer pi(nft2);
+        ParikhImageTransducer pi(nft2, vars_on_tapes);
         LenNode formula = pi.compute_parikh_image();
 
         expr_ref result = len_node_to_expr(m, ctx, formula);
-        check_lia_model(m, result, {{"tape_len!n2", "2"}, {"tape_len!n3", "2"}});
+        check_lia_model(m, result, {{"x1", "2"}, {"x2", "2"}});
     }
 
     SECTION("Simple transducer 3") {
@@ -980,21 +981,8 @@ TEST_CASE("Transducers :: simple lengths", "[noodler]") {
         nft3.final = {1};
         nft3.insert_word_by_parts(0, { {'a', 'b'}, {'b'} } , 1);
 
-        ParikhImageTransducer pi(nft3);
+        ParikhImageTransducer pi(nft3, vars_on_tapes);
         LenNode formula = pi.compute_parikh_image();
-
-        expr_ref result = len_node_to_expr(m, ctx, formula);
-        check_lia_model(m, result, {{"tape_len!n4", "2"}, {"tape_len!n5", "1"}});
-    }
-
-    SECTION("Simple transducer 3; explicit vars") {
-        mata::nft::Nft nft3{2};
-        nft3.initial = {0};
-        nft3.final = {1};
-        nft3.insert_word_by_parts(0, { {'a', 'b'}, {'b'} } , 1);
-
-        ParikhImageTransducer pi(nft3);
-        LenNode formula = pi.compute_parikh_image_vars({ BasicTerm(BasicTermType::Variable, "x1"), BasicTerm(BasicTermType::Variable, "x2") });
 
         expr_ref result = len_node_to_expr(m, ctx, formula);
         check_lia_model(m, result, {{"x1", "2"}, {"x2", "1"}});


### PR DESCRIPTION
This PR adds support for code-point conversions with transducers (which also means we can combine with disequations). **This is not actually true, we cannot process dummy symbols with code-point conversions with transducers yet, so it does not work for most cases.**
Furthermore, the parikh formula is constructed from NFT with only one symbol (except for variables that needed for code-point conversions).

There is a slight optimization for transducers, if we have a literal, so for example `x = T("abc")`, we directly change it to `x ⊆ T("abc")` where `T("abc")` represents the output of applying `"abc"` on `T`.

Also I updated model generation so it works with transducers and lengths.

Needs verifit/mata#527