### PR TITLE
Fix unary procedure suitability check

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -1084,7 +1084,7 @@ namespace smt::noodler {
                                 std::vector<TermConversion> conversions) {
 
         dec_proc = std::make_shared<UnaryDecisionProcedure>(instance, aut_ass, m_params);
-        expr_ref lengths = len_node_to_z3_formula(dec_proc->get_lengths().first); // it is assumed that lenght formulas from equations were added in new_eq_eh, so we can just have 'true'
+        expr_ref lengths = len_node_to_z3_formula(dec_proc->get_lengths().first);
         this->statistics.at("unary").num_start++;
         this->statistics.at("unary").num_finish++;
         if(check_len_sat(lengths, nullptr) == l_false) {

--- a/src/smt/theory_str_noodler/unary_decision_procedure.h
+++ b/src/smt/theory_str_noodler/unary_decision_procedure.h
@@ -64,6 +64,7 @@ namespace smt::noodler {
                 }
                 
             }
+            STRACE("str-unary-lengths", tout << ln << "\n";);
             return {ln, LenNodePrecision::PRECISE};
         }
 
@@ -91,11 +92,11 @@ namespace smt::noodler {
             // it is ok to have only equations with \Sigma^* constraints
             bool only_eqs = !formula.contains_pred_type(PredicateType::Inequation);
             mata::nfa::Nfa sigma_star = init_aut_ass.sigma_star_automaton();
-            for(const BasicTerm& bt : formula.get_vars()) {
+            for(const auto& [bt, aut] : init_aut_ass) {
                 if(only_eqs && init_aut_ass.are_equivalent(bt, sigma_star)) {
                     continue;
                 }
-                auto used_symbols = init_aut_ass.at(bt)->delta.get_used_symbols();
+                auto used_symbols = aut->delta.get_used_symbols();
                 if(used_symbols.size() != 1 || util::is_dummy_symbol(used_symbols.back())) {
                     return false;
                 } 


### PR DESCRIPTION
The suitability test of unary decision procedure checked automata only for variables in the formula. This does not work correctly if we have only regular expressions for model generation. For example, the procedure would run for `x notin {"a"}`, however, the model generation knows only about `a`, so it will return `x = "a"` which is incorrect.