### PR TITLE
[WIP] Better construction of inclusion graph

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1700,7 +1700,7 @@ namespace smt::noodler {
         init_solving_state.substitution_map = std::move(this->init_substitution_map);
 
         if (!equations_and_transducers.get_predicates().empty()) {
-            FormulaGraph incl_graph = FormulaGraph::create_inclusion_graph(equations_and_transducers);
+            FormulaGraph incl_graph = FormulaGraph::create_inclusion_graph(equations_and_transducers, init_solving_state.length_sensitive_vars);
             for (const FormulaGraphNode &node : incl_graph.get_nodes()) {
                 Predicate node_pred = node.get_real_predicate();
                 if (node_pred.is_equation()) { // inclusion

--- a/src/smt/theory_str_noodler/inclusion_graph.cc
+++ b/src/smt/theory_str_noodler/inclusion_graph.cc
@@ -158,11 +158,21 @@ FormulaGraph smt::noodler::FormulaGraph::create_inclusion_graph(FormulaGraph& si
 }
 
 void FormulaGraph::print_to_dot(std::ostream &output_stream) const {
+    auto escape_quotes = [](const std::string& s) {
+        std::string escaped;
+        for (char c : s) {
+            if (c == '"')
+                escaped += "\\\"";
+            else
+                escaped += c;
+        }
+        return escaped;
+    };
     output_stream << "digraph inclusionGraph {\nnode [shape=none];\n";
     for (const FormulaGraphNode& node : nodes) {
-        output_stream << "\"" << node.print() << "\" -> {";
+        output_stream << "\"" << escape_quotes(node.print()) << "\" -> {";
         for (const FormulaGraphNode& target : get_edges_from(node)) {
-            output_stream << "\"" << target.print() << "\" ";
+            output_stream << "\"" << escape_quotes(target.print()) << "\" ";
         }
         output_stream << "} [label=\"\"]\n";
     }

--- a/src/smt/theory_str_noodler/inclusion_graph.cc
+++ b/src/smt/theory_str_noodler/inclusion_graph.cc
@@ -122,7 +122,7 @@ FormulaGraph smt::noodler::FormulaGraph::create_inclusion_graph(FormulaGraph& si
 
         auto best_score_it = init_nodes_with_score.begin();
         for (auto it = init_nodes_with_score.begin(); it != init_nodes_with_score.end(); ++it) {
-            if (it->second < best_score_it->second) { //score of this node is better
+            if (it->second > best_score_it->second) { //score of this node is better
                 best_score_it = it;
             }
         }

--- a/src/smt/theory_str_noodler/inclusion_graph.h
+++ b/src/smt/theory_str_noodler/inclusion_graph.h
@@ -270,7 +270,7 @@ namespace smt::noodler {
         /**
          * @brief Create an inclusion graph from splitting graph
          */
-        static FormulaGraph create_inclusion_graph(FormulaGraph& simplified_splitting_graph);
+        static FormulaGraph create_inclusion_graph(FormulaGraph& simplified_splitting_graph, std::unordered_set<BasicTerm> length_vars = {});
 
 
         /**
@@ -284,7 +284,7 @@ namespace smt::noodler {
          * @param formula must contain only equations and transducers
          * @return the inclusion graph 
          */
-        static FormulaGraph create_inclusion_graph(const Formula& formula);
+        static FormulaGraph create_inclusion_graph(const Formula& formula, std::unordered_set<BasicTerm> length_vars = {});
 
         /**
          * Print the inclusion graph in a DOT format.

--- a/src/test/noodler/inclusion-graph-node.cc
+++ b/src/test/noodler/inclusion-graph-node.cc
@@ -426,7 +426,7 @@ TEST_CASE("Inclusion graph with transducers", "[noodler]") {
         graph = FormulaGraph::create_inclusion_graph(formula);
 
         CHECK(graph.get_nodes().size() == 2);
-        CHECK(graph.get_num_of_edges() == 0);
+        CHECK(graph.get_num_of_edges() == 1);
         CHECK(!graph.is_cyclic());
     }
 }


### PR DESCRIPTION
Simple heuristic for constructing inclusion graph. It always adds the inclusion with the least expected number of generated noodles (the reasoning: we want to have those that generate more noodles at the end during the decision procedure, so the decision tree is smaller). Currently it just multiplies the number of variables on the left and the number of "splits" (i.e. borders between length and non-length variables) on the right side and takes the inclusion with this number the smallest.