### PR TITLE
Add nix derivation and flake

### DIFF
--- a/README-Z3.md
+++ b/README-Z3.md
@@ -1,7 +1,7 @@
 # Z3
 
 Z3 is a theorem prover from Microsoft Research. 
-It is licensed under the [MIT license](LICENSE.txt).
+It is licensed under the [MIT license](LICENSE_Z3.txt).
 
 If you are not familiar with Z3, you can start [here](https://github.com/Z3Prover/z3/wiki#background).
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1747426788,
+        "narHash": "sha256-N4cp0asTsJCnRMFZ/k19V9akkxb7J/opG+K+jU57JGc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12a55407652e04dcf2309436eb06fef0d3713ef3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs =
+    inputs@{
+      flake-parts,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+      perSystem =
+        { pkgs, ... }:
+
+        {
+          formatter = pkgs.nixfmt-rfc-style;
+          packages.default = pkgs.callPackage ./package.nix { };
+        };
+    };
+}

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,43 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  catch2_3,
+  python3,
+  fetchFromGitHub,
+}:
+let
+  mata = stdenv.mkDerivation {
+    pname = "mata";
+    version = "1.15.0";
+    src = fetchFromGitHub {
+      owner = "VeriFIT";
+      repo = "mata";
+      rev = "1.15.0";
+      hash = "sha256-mo/E+gk/5/56GyWPNbza75hGkPhvvXiGg89htqB4nH8=";
+    };
+
+    buildInputs = [
+      cmake
+      ninja
+      python3
+    ];
+  };
+in
+stdenv.mkDerivation {
+  name = "z3-noodler";
+
+  src = ./.;
+
+  nativeBuildInputs = [
+    cmake
+    ninja
+    python3
+    mata
+  ];
+
+  buildInputs = [
+    catch2_3
+  ];
+}

--- a/package.nix
+++ b/package.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   stdenv,
   cmake,
   ninja,
@@ -28,7 +27,10 @@ in
 stdenv.mkDerivation {
   name = "z3-noodler";
 
-  src = ./.;
+  src = builtins.path {
+    path = ./.;
+    name = "z3-noodler";
+  };
 
   nativeBuildInputs = [
     cmake

--- a/scripts/mk_unix_dist.py
+++ b/scripts/mk_unix_dist.py
@@ -261,7 +261,7 @@ def mk_zip():
     os.chdir(old)
 
 def cp_license():
-    shutil.copy("LICENSE.txt", os.path.join(DIST_DIR, get_dist_path()))
+    shutil.copy("LICENSE_Z3.txt", os.path.join(DIST_DIR, get_dist_path()))
 
 # Entry point
 def main():

--- a/scripts/mk_unix_dist_cmake.py
+++ b/scripts/mk_unix_dist_cmake.py
@@ -255,7 +255,7 @@ def cp_license():
         print("copy licence")
     path = get_build_dist_path()
     mk_dir(path)
-    shutil.copy("LICENSE.txt", path)
+    shutil.copy("LICENSE_Z3.txt", path)
 
 # Entry point
 def main():

--- a/scripts/mk_util.py
+++ b/scripts/mk_util.py
@@ -636,7 +636,7 @@ def dos2unix_tree():
 def check_eol():
     if not IS_WINDOWS:
         # Linux/OSX/BSD check if the end-of-line is cr/lf
-        if is_cr_lf('LICENSE.txt'):
+        if is_cr_lf('LICENSE_Z3.txt'):
             if is_verbose():
                 print("Fixing end of line...")
             dos2unix_tree()

--- a/scripts/mk_win_dist.py
+++ b/scripts/mk_win_dist.py
@@ -300,7 +300,7 @@ def cp_vs_runtimes():
     cp_vs_runtime(False)
 
 def cp_license(x64):
-    shutil.copy("LICENSE.txt", os.path.join(DIST_DIR, get_dist_path(x64)))
+    shutil.copy("LICENSE_Z3.txt", os.path.join(DIST_DIR, get_dist_path(x64)))
 
 def cp_licenses():
     cp_license(True)

--- a/scripts/mk_win_dist_cmake.py
+++ b/scripts/mk_win_dist_cmake.py
@@ -353,7 +353,7 @@ def cp_license(arch):
         print("copy licence")
     path = get_build_dist_path(arch)
     mk_dir(path)
-    shutil.copy("LICENSE.txt", path)
+    shutil.copy("LICENSE_Z3.txt", path)
 
 def cp_dotnet(arch):
     if not DOTNET_CORE_ENABLED:

--- a/src/api/python/MANIFEST.in
+++ b/src/api/python/MANIFEST.in
@@ -1,4 +1,4 @@
-include core/LICENSE.txt
+include core/LICENSE_Z3.txt
 include core/z3.pc.cmake.in
 recursive-include core CMakeLists.txt
 recursive-include core *.cmake

--- a/src/api/python/setup.py
+++ b/src/api/python/setup.py
@@ -240,7 +240,7 @@ def _copy_sources():
     shutil.rmtree(SRC_DIR_LOCAL, ignore_errors=True)
     os.mkdir(SRC_DIR_LOCAL)
 
-    shutil.copy(os.path.join(SRC_DIR_REPO, 'LICENSE.txt'), SRC_DIR_LOCAL)
+    shutil.copy(os.path.join(SRC_DIR_REPO, 'LICENSE_Z3.txt'), SRC_DIR_LOCAL)
     shutil.copy(os.path.join(SRC_DIR_REPO, 'z3.pc.cmake.in'), SRC_DIR_LOCAL)
     shutil.copy(os.path.join(SRC_DIR_REPO, 'CMakeLists.txt'), SRC_DIR_LOCAL)
     shutil.copytree(os.path.join(SRC_DIR_REPO, 'cmake'), os.path.join(SRC_DIR_LOCAL, 'cmake'))

--- a/z3.pc.cmake.in
+++ b/z3.pc.cmake.in
@@ -1,8 +1,8 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-sharedlibdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=${exec_prefix}@CMAKE_INSTALL_LIBDIR@
+sharedlibdir=${exec_prefix}@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: z3
 Description: The Z3 Theorem Prover


### PR DESCRIPTION
Hello all, I used z3-noodler for my bachelor thesis and I had to to package it with Nix, so I thought I would open the PR here in case you want to add it to the tree. 

If this is _not_ something you want feel free to close this PR, of course. No hard feelings :)

The benefit of having nix support is that it makes it very simple to get the project up and running in an independent way (in my case, I had some problems install mata and, generally, I don't love having to install stuff system wide).

In terms of code, I changed a few occurrences of `LICENSE` to `LICENSE_Z3` because I was getting errors from that, and it also seems that these paths `libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@` have an unnecessary slash.