### PR TITLE
Fix: Relevance marking for string expressions

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -194,6 +194,17 @@ namespace smt::noodler {
             else ctx.mark_as_relevant(expr);
         }
 
+        if(init && (
+            m_util_s.str.is_index(expr) || 
+            m_util_s.str.is_at(expr) ||
+            m_util_s.str.is_extract(expr) ||
+            m_util_s.str.is_replace(expr) || 
+            m_util_s.str.is_replace_all(expr) ||
+            m_util_s.str.is_replace_re_all(expr)
+        )) {
+            ctx.mark_as_relevant(expr);
+        }
+
         // Check if we already axiomatized the expr
         if (propagated_string_theory.contains(expr)) {
             return;

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -194,6 +194,10 @@ namespace smt::noodler {
             else ctx.mark_as_relevant(expr);
         }
 
+        // in the initialization phase, we need to mark all string terms as relevant. We want to 
+        // prevent the situation when the string functions/predicates are axiomatized 
+        // on higher decision level than 0 (otherwise the axioms are lost).
+        // String propagation of the input formula works on level 0.
         if(init && (
             m_util_s.str.is_index(expr) || 
             m_util_s.str.is_at(expr) ||


### PR DESCRIPTION
This pull request introduces an additional relevance marking for string terms. The change ensures that expressions involving string functions are marked as relevant during initialization, which ensures that they are axiomatized on decision level 0.