### PR TITLE
Add checks for soft timeout

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -375,6 +375,7 @@ namespace smt::noodler {
                            << "------------------------" << std::endl;);
 
         while (!is_worklist_empty()) {
+            util::check_limit(m);
             SolvingState element_to_process = pop_from_worklist();
 
             if (element_to_process.predicates_to_process.empty()) {
@@ -552,6 +553,7 @@ namespace smt::noodler {
                                                                     {{"reduce", "forward"}});
 
         for (const auto &noodle : noodles) {
+            util::check_limit(m);
             STRACE(str, tout << "Processing noodle" << (is_trace_enabled(TraceTag::str_nfa) ? " with automata:" : "") << std::endl;);
             SolvingState new_element = solving_state;
 
@@ -721,6 +723,7 @@ namespace smt::noodler {
 
         std::vector<mata::applications::strings::seg_nfa::TransducerNoodle> noodles = mata::applications::strings::seg_nfa::noodlify_for_transducer(transducer_to_process.get_transducer(), input_vars_automata, output_vars_automata, true);
         for (const auto& noodle : noodles) {
+            util::check_limit(m);
             // each noodle is a vector of tuples (T,i,Ai,o,Ao) where
             //      - T is a transducer, which will take one input and one output var: xo = T(xi)
             //      - i is the number denoting which input variable is connected with T
@@ -830,9 +833,11 @@ namespace smt::noodler {
 
         // compute formula for vars in transducers (lengths and code-point conversions)
         conjuncts.push_back(get_formula_for_transducers());
+        util::check_limit(m);
 
         // formula for encoding lengths
         conjuncts.push_back(get_formula_for_len_vars());
+        util::check_limit(m);
 
         // add formula for conversions
         auto conv_form_with_precision = get_formula_for_conversions();

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -491,6 +491,7 @@ namespace smt::noodler {
         std::unordered_map<BasicTerm, std::vector<BasicTerm>> init_substitution_map;
         // contains to/from_code/int conversions
         std::vector<TermConversion> conversions;
+        ast_manager& m;
 
         // length vars that occur as input/output of some transducer formula
         std::set<BasicTerm> length_vars_with_transducers;
@@ -729,11 +730,13 @@ namespace smt::noodler {
              Formula formula, AutAssignment init_aut_ass,
              std::unordered_set<BasicTerm> init_length_sensitive_vars,
              const theory_str_noodler_params &par,
-             std::vector<TermConversion> conversions
+             std::vector<TermConversion> conversions,
+             ast_manager& m
         ) : init_length_sensitive_vars(init_length_sensitive_vars),
             formula(formula),
             init_aut_ass(init_aut_ass),
             conversions(conversions),
+            m(m),
             m_params(par) {
             
         }

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -214,7 +214,7 @@ namespace smt::noodler {
         }
 
         // we do not put into dec_proc directly, because we might do underapproximation that saves into dec_proc
-        std::shared_ptr<DecisionProcedure> main_dec_proc = std::make_shared<DecisionProcedure>(instance, aut_assignment, init_length_sensitive_vars, m_params, conversions);
+        std::shared_ptr<DecisionProcedure> main_dec_proc = std::make_shared<DecisionProcedure>(instance, aut_assignment, init_length_sensitive_vars, m_params, conversions, m);
 
         // the skip_len_sat preprocessing rule requires that the input formula is length satisfiable
         // --> before we apply the preprocessing, we need to be sure that it is indeed true.
@@ -287,6 +287,7 @@ namespace smt::noodler {
 
         expr_ref block_len(m.mk_false(), m);
         while (true) {
+            util::check_limit(m);
             result = dec_proc->compute_next_solution();
             if (result == l_true) {
                 auto [noodler_lengths, precision] = dec_proc->get_lengths();
@@ -725,7 +726,7 @@ namespace smt::noodler {
     lbool theory_str_noodler::solve_underapprox(const Formula& instance, const AutAssignment& aut_assignment,
                                                 const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
                                                 std::vector<TermConversion> conversions) {
-        dec_proc = std::make_shared<DecisionProcedure>(instance, aut_assignment, init_length_sensitive_vars, m_params, conversions);
+        dec_proc = std::make_shared<DecisionProcedure>(instance, aut_assignment, init_length_sensitive_vars, m_params, conversions, m);
         if (dec_proc->preprocess(PreprocessType::UNDERAPPROX, this->var_eqs.get_equivalence_bt(aut_assignment)) == l_false) {
             return l_undef;
         }

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -20,6 +20,13 @@ namespace smt::noodler::util {
 #endif
     }
 
+    void check_limit(ast_manager& m) {
+        if (m.limit().is_canceled()) {
+            STRACE(str, tout << "LIMIT REACHED\n";);
+            throw default_exception("Limit reached");
+        }
+    }
+
     void get_str_variables(expr* const ex, const seq_util& m_util_s, const ast_manager& m, obj_hashtable<expr>& res, obj_map<expr, expr*>* pred_map) {
         if(m_util_s.str.is_string(ex)) {
             return;

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -55,6 +55,11 @@ namespace smt::noodler::util {
     void throw_error(std::string errMsg);
 
     /**
+     * @brief Check if we reached some resource limit (timeout) and throws error if yes
+     */
+    void check_limit(ast_manager& m);
+
+    /**
     Get variables from a given expression @p ex. Append to the output parameter @p res.
     @param ex Expression to be checked for variables.
     @param m_util_s Seq util for AST

--- a/src/test/noodler/test_utils.h
+++ b/src/test/noodler/test_utils.h
@@ -35,7 +35,7 @@ public:
     DecisionProcedureCUT(const Formula &equalities, AutAssignment init_aut_ass,
                          const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
                          ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, const BasicTermEqiv& len_eq_vars, const theory_str_noodler_params& par
-    ) : DecisionProcedure(equalities, std::move(init_aut_ass), init_length_sensitive_vars, par, {}) {}
+    ) : DecisionProcedure(equalities, std::move(init_aut_ass), init_length_sensitive_vars, par, {}, m) {}
 
     using DecisionProcedure::compute_next_solution;
     using DecisionProcedure::get_lengths;


### PR DESCRIPTION
This PR adds a check for soft timeout in some places of the main decision procedure so that `-t` argument is not completely ignored inside string solving.