### PR TITLE
Simplify substituting

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -11,7 +11,7 @@
 
 namespace smt::noodler {
 
-    void SolvingState::substitute_vars(const std::set<BasicTerm>& vars_to_substitute, const std::set<BasicTerm>& initial_variables) {
+    void SolvingState::substitute_vars(const std::set<BasicTerm>& vars_to_substitute) {
         // substitutes variables in a vector using substitution_map
         auto substitute_vector = [this, &vars_to_substitute](const std::vector<BasicTerm> &vector) {
             std::vector<BasicTerm> result;
@@ -73,12 +73,14 @@ namespace smt::noodler {
         for (auto& [subst_var, substitution] : substitution_map) {
             substitution = substitute_vector(substitution);
         }
+    }
 
-        for (const BasicTerm& var_to_substitute : vars_to_substitute) {
-            if (!initial_variables.contains(var_to_substitute)) {
-                substitution_map.erase(var_to_substitute);
-                length_sensitive_vars.erase(var_to_substitute);
-                aut_ass.erase(var_to_substitute); // just to be safe, it should not be in aut_ass
+    void SolvingState::remove_vars(const std::set<BasicTerm>& vars_to_remove, const std::set<BasicTerm>& vars_to_keep) {
+        for (const BasicTerm& var : vars_to_remove) {
+            if (!vars_to_keep.contains(var)) {
+                substitution_map.erase(var);
+                length_sensitive_vars.erase(var);
+                aut_ass.erase(var);
             }
         }
     }
@@ -203,7 +205,7 @@ namespace smt::noodler {
         return std::make_pair<std::vector<std::shared_ptr<mata::nfa::Nfa>>,std::vector<std::vector<BasicTerm>>>(std::move(automata_for_concatenation), std::move(divisions));
     }
 
-    void SolvingState::process_substituting_inclusions_from_right(const std::vector<Predicate>& inclusions, bool on_cycle, const std::set<BasicTerm>& initial_variables) {
+    std::set<BasicTerm> SolvingState::process_substituting_inclusions_from_right(const std::vector<Predicate>& inclusions, bool on_cycle) {
         std::set<BasicTerm> newly_substituted_vars;
         for (const Predicate& inclusion : inclusions) {
             SASSERT(inclusion.is_equation());
@@ -235,15 +237,17 @@ namespace smt::noodler {
             }
         }
         // we need to substitute the variables in all other inclusions/transducers
-        substitute_vars(newly_substituted_vars, initial_variables);
+        substitute_vars(newly_substituted_vars);
         // some simple transducers could possibly become non-simple after substitution, we need to readd them for processing
         push_non_simple_transducers_to_processing();
         // note that we do not need to add any inclusions into processing here, as all inclusions that had a variable from newly_substituted_vars
         // on the right side must have been in the queue already, otherwise it would have to be processed and substituted before
+
+        return newly_substituted_vars;
     }
 
 
-    void SolvingState::process_substituting_inclusions_from_left(const std::vector<Predicate>& inclusions, bool on_cycle, const std::set<BasicTerm>& initial_variables) {
+    std::set<BasicTerm> SolvingState::process_substituting_inclusions_from_left(const std::vector<Predicate>& inclusions, bool on_cycle) {
         std::set<BasicTerm> newly_substituted_vars;
         for (const Predicate& inclusion : inclusions) {
             SASSERT(inclusion.is_equation());
@@ -271,9 +275,11 @@ namespace smt::noodler {
         // before substituting, we need to push all variables that depend on the changed vars for processing
         push_dependent_predicates(newly_substituted_vars, on_cycle);
         // we need to substitute the variables in all other inclusions/transducers
-        substitute_vars(newly_substituted_vars, initial_variables);
+        substitute_vars(newly_substituted_vars);
         // some simple transducers could possibly become non-simple after substitution, we need to readd them for processing
         push_non_simple_transducers_to_processing();
+
+        return newly_substituted_vars;
     }
 
     BasicTerm SolvingState::add_fresh_var(std::shared_ptr<mata::nfa::Nfa> nfa, std::string var_prefix, bool is_length, bool optimize_literal) {
@@ -485,7 +491,8 @@ namespace smt::noodler {
                 // if we are updating vars on the left side, we need to add dependent predicates for processing
                 solving_state.push_dependent_predicates(non_empty_side_vars, is_inclusion_to_process_on_cycle);
             }
-            solving_state.substitute_vars(non_empty_side_vars, initial_variables); // we need to substitute the variables in other predicates
+            solving_state.substitute_vars(non_empty_side_vars); // we need to substitute the variables in other predicates
+            solving_state.remove_vars(non_empty_side_vars, initial_variables);
             // it is possible that some transducer become non-simple (one of its side becomes empty), we want to process these again
             solving_state.push_non_simple_transducers_to_processing();
 
@@ -609,7 +616,7 @@ namespace smt::noodler {
              * because they are length-aware vars and we only add the inclusion t_6 ⊆ x_5 x_6.
              * The following function does this and it also add new inclusions/transducers to processing if needed.
              */
-            new_element.process_substituting_inclusions_from_right(right_side_inclusions, is_inclusion_to_process_on_cycle, initial_variables);
+            std::set<BasicTerm> newly_substituted_vars_from_right = new_element.process_substituting_inclusions_from_right(right_side_inclusions, is_inclusion_to_process_on_cycle);
 
             /* Following the example from before, the following will create these inclusions from the left side:
              *           x_1 ⊆ t_1
@@ -627,7 +634,10 @@ namespace smt::noodler {
              * and we only add inclusions x_1 ⊆ t_1 and t_2 t_3 ⊆ t_5 t_6.
              * The following function does this and it also add new inclusions/transducers to processing if needed.
              */
-            new_element.process_substituting_inclusions_from_left(left_side_inclusions, is_inclusion_to_process_on_cycle, initial_variables);
+            std::set<BasicTerm> newly_substituted_vars_from_left = new_element.process_substituting_inclusions_from_left(left_side_inclusions, is_inclusion_to_process_on_cycle);
+
+            new_element.remove_vars(newly_substituted_vars_from_right, initial_variables);
+            new_element.remove_vars(newly_substituted_vars_from_left, initial_variables);
 
             // we push to front when the inclusion is not on cycle, because we want to get to the result as fast as possible
             // and if there is no cycle, we do not need to do BFS, the algorithm should end
@@ -782,10 +792,13 @@ namespace smt::noodler {
             }
 
             std::vector<Predicate> input_inclusions = util::create_inclusions_from_multiple_sides(input_vars_to_new_input_vars, input_vars_divisions);
-            new_element.process_substituting_inclusions_from_right(input_inclusions, false, initial_variables);
+            std::set<BasicTerm> newly_substituted_vars_from_right = new_element.process_substituting_inclusions_from_right(input_inclusions, false);
 
             std::vector<Predicate> output_inclusions = util::create_inclusions_from_multiple_sides(output_vars_divisions, output_vars_to_new_output_vars);
-            new_element.process_substituting_inclusions_from_left(output_inclusions, false, initial_variables);
+            std::set<BasicTerm> newly_substituted_vars_from_left = new_element.process_substituting_inclusions_from_left(output_inclusions, false);
+
+            new_element.remove_vars(newly_substituted_vars_from_right, initial_variables);
+            new_element.remove_vars(newly_substituted_vars_from_left, initial_variables);
 
             push_to_worklist(std::move(new_element), false);
         }

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -11,7 +11,7 @@
 
 namespace smt::noodler {
 
-    void SolvingState::substitute_vars(const std::set<BasicTerm>& vars_to_substitute) {
+    void SolvingState::substitute_vars(const std::set<BasicTerm>& vars_to_substitute, const std::set<BasicTerm>& initial_variables) {
         // substitutes variables in a vector using substitution_map
         auto substitute_vector = [this, &vars_to_substitute](const std::vector<BasicTerm> &vector) {
             std::vector<BasicTerm> result;
@@ -72,6 +72,14 @@ namespace smt::noodler {
 
         for (auto& [subst_var, substitution] : substitution_map) {
             substitution = substitute_vector(substitution);
+        }
+
+        for (const BasicTerm& var_to_substitute : vars_to_substitute) {
+            if (!initial_variables.contains(var_to_substitute)) {
+                substitution_map.erase(var_to_substitute);
+                length_sensitive_vars.erase(var_to_substitute);
+                aut_ass.erase(var_to_substitute); // just to be safe, it should not be in aut_ass
+            }
         }
     }
 
@@ -195,7 +203,7 @@ namespace smt::noodler {
         return std::make_pair<std::vector<std::shared_ptr<mata::nfa::Nfa>>,std::vector<std::vector<BasicTerm>>>(std::move(automata_for_concatenation), std::move(divisions));
     }
 
-    void SolvingState::process_substituting_inclusions_from_right(const std::vector<Predicate>& inclusions, bool on_cycle) {
+    void SolvingState::process_substituting_inclusions_from_right(const std::vector<Predicate>& inclusions, bool on_cycle, const std::set<BasicTerm>& initial_variables) {
         std::set<BasicTerm> newly_substituted_vars;
         for (const Predicate& inclusion : inclusions) {
             SASSERT(inclusion.is_equation());
@@ -227,7 +235,7 @@ namespace smt::noodler {
             }
         }
         // we need to substitute the variables in all other inclusions/transducers
-        substitute_vars(newly_substituted_vars);
+        substitute_vars(newly_substituted_vars, initial_variables);
         // some simple transducers could possibly become non-simple after substitution, we need to readd them for processing
         push_non_simple_transducers_to_processing();
         // note that we do not need to add any inclusions into processing here, as all inclusions that had a variable from newly_substituted_vars
@@ -235,7 +243,7 @@ namespace smt::noodler {
     }
 
 
-    void SolvingState::process_substituting_inclusions_from_left(const std::vector<Predicate>& inclusions, bool on_cycle) {
+    void SolvingState::process_substituting_inclusions_from_left(const std::vector<Predicate>& inclusions, bool on_cycle, const std::set<BasicTerm>& initial_variables) {
         std::set<BasicTerm> newly_substituted_vars;
         for (const Predicate& inclusion : inclusions) {
             SASSERT(inclusion.is_equation());
@@ -263,7 +271,7 @@ namespace smt::noodler {
         // before substituting, we need to push all variables that depend on the changed vars for processing
         push_dependent_predicates(newly_substituted_vars, on_cycle);
         // we need to substitute the variables in all other inclusions/transducers
-        substitute_vars(newly_substituted_vars);
+        substitute_vars(newly_substituted_vars, initial_variables);
         // some simple transducers could possibly become non-simple after substitution, we need to readd them for processing
         push_non_simple_transducers_to_processing();
     }
@@ -477,7 +485,7 @@ namespace smt::noodler {
                 // if we are updating vars on the left side, we need to add dependent predicates for processing
                 solving_state.push_dependent_predicates(non_empty_side_vars, is_inclusion_to_process_on_cycle);
             }
-            solving_state.substitute_vars(non_empty_side_vars); // we need to substitute the variables in other predicates
+            solving_state.substitute_vars(non_empty_side_vars, initial_variables); // we need to substitute the variables in other predicates
             // it is possible that some transducer become non-simple (one of its side becomes empty), we want to process these again
             solving_state.push_non_simple_transducers_to_processing();
 
@@ -601,7 +609,7 @@ namespace smt::noodler {
              * because they are length-aware vars and we only add the inclusion t_6 ⊆ x_5 x_6.
              * The following function does this and it also add new inclusions/transducers to processing if needed.
              */
-            new_element.process_substituting_inclusions_from_right(right_side_inclusions, is_inclusion_to_process_on_cycle);
+            new_element.process_substituting_inclusions_from_right(right_side_inclusions, is_inclusion_to_process_on_cycle, initial_variables);
 
             /* Following the example from before, the following will create these inclusions from the left side:
              *           x_1 ⊆ t_1
@@ -619,7 +627,7 @@ namespace smt::noodler {
              * and we only add inclusions x_1 ⊆ t_1 and t_2 t_3 ⊆ t_5 t_6.
              * The following function does this and it also add new inclusions/transducers to processing if needed.
              */
-            new_element.process_substituting_inclusions_from_left(left_side_inclusions, is_inclusion_to_process_on_cycle);
+            new_element.process_substituting_inclusions_from_left(left_side_inclusions, is_inclusion_to_process_on_cycle, initial_variables);
 
             // we push to front when the inclusion is not on cycle, because we want to get to the result as fast as possible
             // and if there is no cycle, we do not need to do BFS, the algorithm should end
@@ -774,10 +782,10 @@ namespace smt::noodler {
             }
 
             std::vector<Predicate> input_inclusions = util::create_inclusions_from_multiple_sides(input_vars_to_new_input_vars, input_vars_divisions);
-            new_element.process_substituting_inclusions_from_right(input_inclusions, false);
+            new_element.process_substituting_inclusions_from_right(input_inclusions, false, initial_variables);
 
             std::vector<Predicate> output_inclusions = util::create_inclusions_from_multiple_sides(output_vars_divisions, output_vars_to_new_output_vars);
-            new_element.process_substituting_inclusions_from_left(output_inclusions, false);
+            new_element.process_substituting_inclusions_from_left(output_inclusions, false, initial_variables);
 
             push_to_worklist(std::move(new_element), false);
         }
@@ -2221,6 +2229,19 @@ namespace smt::noodler {
             }
         }
         return needed_vars;
+    }
+
+    void DecisionProcedure::set_initial_variables() {
+        initial_variables = formula.get_vars();
+        for (const auto& [var,_aut] : init_aut_ass) {
+            initial_variables.insert(var);
+        }
+        for (const auto& var : init_length_sensitive_vars) {
+            initial_variables.insert(var);
+        }
+        for (const auto& conv : conversions) {
+            initial_variables.insert(conv.string_var);
+        }
     }
 
 } // Namespace smt::noodler.

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -492,7 +492,7 @@ namespace smt::noodler {
                 solving_state.push_dependent_predicates(non_empty_side_vars, is_inclusion_to_process_on_cycle);
             }
             solving_state.substitute_vars(non_empty_side_vars); // we need to substitute the variables in other predicates
-            solving_state.remove_vars(non_empty_side_vars, initial_variables);
+            solving_state.remove_vars(non_empty_side_vars, initial_variables); // remove unneccesary variables that were substituted
             // it is possible that some transducer become non-simple (one of its side becomes empty), we want to process these again
             solving_state.push_non_simple_transducers_to_processing();
 
@@ -636,8 +636,9 @@ namespace smt::noodler {
              */
             std::set<BasicTerm> newly_substituted_vars_from_left = new_element.process_substituting_inclusions_from_left(left_side_inclusions, is_inclusion_to_process_on_cycle);
 
-            new_element.remove_vars(newly_substituted_vars_from_right, initial_variables);
-            new_element.remove_vars(newly_substituted_vars_from_left, initial_variables);
+            // Remove unneccesary variables that were substituted (we do it here, because we the code before depends on the newly substituted vars to be in subtitution_map)
+            new_element.remove_vars(newly_substituted_vars_from_right, initial_variables); // remove unneccesary variables that were substituted
+            new_element.remove_vars(newly_substituted_vars_from_left, initial_variables); // remove unneccesary variables that were substituted
 
             // we push to front when the inclusion is not on cycle, because we want to get to the result as fast as possible
             // and if there is no cycle, we do not need to do BFS, the algorithm should end
@@ -797,6 +798,7 @@ namespace smt::noodler {
             std::vector<Predicate> output_inclusions = util::create_inclusions_from_multiple_sides(output_vars_divisions, output_vars_to_new_output_vars);
             std::set<BasicTerm> newly_substituted_vars_from_left = new_element.process_substituting_inclusions_from_left(output_inclusions, false);
 
+            // Remove unneccesary variables that were substituted (we do it here, because we the code before depends on the newly substituted vars to be in subtitution_map)
             new_element.remove_vars(newly_substituted_vars_from_right, initial_variables);
             new_element.remove_vars(newly_substituted_vars_from_left, initial_variables);
 

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -69,6 +69,10 @@ namespace smt::noodler {
             }
         }
         predicates_to_process = new_predicates_to_process;
+
+        for (auto& [subst_var, substitution] : substitution_map) {
+            substitution = substitute_vector(substitution);
+        }
     }
 
     LenNode SolvingState::get_lengths(const BasicTerm& var) const {
@@ -813,9 +817,6 @@ namespace smt::noodler {
             // disequations nor conversions), it is not needed to create the lengths formula.
             return {LenNode(LenFormulaType::TRUE), precision};
         }
-
-        // some formulas (lie the one for conversions) assumes that we have flattened substitution map
-        solution.flatten_substition_map();
 
         // collect all variables that substitute some string_var of some conversion (we do it here
         // because we need to know which variables are used in conversions for parikh image of variables
@@ -1708,6 +1709,7 @@ namespace smt::noodler {
             }
         }
 
+        init_solving_state.flatten_substition_map();
 
         STRACE(str_noodle_dot, tout << "digraph Procedure {\ninit[shape=none, label=\"\"]\n";);
         push_to_worklist(std::move(init_solving_state), true);

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1686,6 +1686,8 @@ namespace smt::noodler {
             }
         );
 
+        set_initial_variables(equations_and_transducers);
+
         SolvingState init_solving_state;
         init_solving_state.length_sensitive_vars = std::move(this->init_length_sensitive_vars);
         init_solving_state.aut_ass = std::move(this->init_aut_ass);
@@ -2231,8 +2233,8 @@ namespace smt::noodler {
         return needed_vars;
     }
 
-    void DecisionProcedure::set_initial_variables() {
-        initial_variables = formula.get_vars();
+    void DecisionProcedure::set_initial_variables(const Formula& f) {
+        initial_variables = f.get_vars();
         for (const auto& [var,_aut] : init_aut_ass) {
             initial_variables.insert(var);
         }
@@ -2241,6 +2243,11 @@ namespace smt::noodler {
         }
         for (const auto& conv : conversions) {
             initial_variables.insert(conv.string_var);
+        }
+        for (const auto& incl : inclusions_from_preprocessing) {
+            for (const auto& var : incl.get_vars()) {
+                initial_variables.insert(var);
+            }
         }
     }
 

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -515,8 +515,10 @@ namespace smt::noodler {
 
         const theory_str_noodler_params& m_params;
 
+        /// @brief We save here all string variables that exist before the decision procedure is run (useful for removing variables created in decision procedure)
         std::set<BasicTerm> initial_variables;
 
+        /// @brief Sets the initial_variables by adding all variables from @p f and other stuff (init_aut_ass, init_length_sensitive_vars, conversions, inclusions_from_preprocessing)
         void set_initial_variables(const Formula& f);
 
         /**

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -339,7 +339,9 @@ namespace smt::noodler {
          * both in the corresponding sets and in the worklist of predicates to process (if two nodes become equal, keeps only
          * one). Furthermore, it removes inclusions that have both sides equal after substitution.
          */
-        void substitute_vars(const std::set<BasicTerm>& vars_to_substitute, const std::set<BasicTerm>& initial_variables);
+        void substitute_vars(const std::set<BasicTerm>& vars_to_substitute);
+
+        void remove_vars(const std::set<BasicTerm>& vars_to_remove, const std::set<BasicTerm>& vars_to_keep);
 
         /**
          * @brief Get the length constraints for variable @p var
@@ -420,7 +422,7 @@ namespace smt::noodler {
          * @param inclusions Inclusion to process
          * @param on_cycle Whether the inclusions should be on cycle or not
          */
-        void process_substituting_inclusions_from_right(const std::vector<Predicate>& inclusions, bool on_cycle, const std::set<BasicTerm>& initial_variables);
+        std::set<BasicTerm> process_substituting_inclusions_from_right(const std::vector<Predicate>& inclusions, bool on_cycle);
 
         /**
          * @brief Similar to process_substituting_inclusions_from_right but opposite (left var should be substituted by right side).
@@ -439,7 +441,7 @@ namespace smt::noodler {
          * @param inclusions Inclusions to process
          * @param on_cycle Whether the inclusions should be on cycle or not
          */
-        void process_substituting_inclusions_from_left(const std::vector<Predicate>& inclusions, bool on_cycle, const std::set<BasicTerm>& initial_variables);
+        std::set<BasicTerm> process_substituting_inclusions_from_left(const std::vector<Predicate>& inclusions, bool on_cycle);
 
 
         /**

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -515,7 +515,7 @@ namespace smt::noodler {
 
         std::set<BasicTerm> initial_variables;
 
-        void set_initial_variables();
+        void set_initial_variables(const Formula& f);
 
         /**
          * @brief Replace disequality L != R with equalities and a length constraint saved in disequations_len_formula_conjuncts.
@@ -739,7 +739,6 @@ namespace smt::noodler {
             init_aut_ass(init_aut_ass),
             conversions(conversions),
             m_params(par) {
-                set_initial_variables();
         }
         
         /**

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -341,6 +341,7 @@ namespace smt::noodler {
          */
         void substitute_vars(const std::set<BasicTerm>& vars_to_substitute);
 
+        /// @brief Remove vars @p vars_to_remove (except those in @p vars_to_keep ) from the subtitution_map/aut_ass
         void remove_vars(const std::set<BasicTerm>& vars_to_remove, const std::set<BasicTerm>& vars_to_keep);
 
         /**
@@ -517,7 +518,7 @@ namespace smt::noodler {
 
         const theory_str_noodler_params& m_params;
 
-        /// @brief We save here all string variables that exist before the decision procedure is run (useful for removing variables created in decision procedure)
+        /// @brief We save here all string variables that exist before the decision procedure is run (useful for removing variables created in decision procedure, @sa SolvingState::remove_vars())
         std::set<BasicTerm> initial_variables;
 
         /// @brief Sets the initial_variables by adding all variables from @p f and other stuff (init_aut_ass, init_length_sensitive_vars, conversions, inclusions_from_preprocessing)

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -339,7 +339,7 @@ namespace smt::noodler {
          * both in the corresponding sets and in the worklist of predicates to process (if two nodes become equal, keeps only
          * one). Furthermore, it removes inclusions that have both sides equal after substitution.
          */
-        void substitute_vars(const std::set<BasicTerm>& vars_to_substitute);
+        void substitute_vars(const std::set<BasicTerm>& vars_to_substitute, const std::set<BasicTerm>& initial_variables);
 
         /**
          * @brief Get the length constraints for variable @p var
@@ -420,7 +420,7 @@ namespace smt::noodler {
          * @param inclusions Inclusion to process
          * @param on_cycle Whether the inclusions should be on cycle or not
          */
-        void process_substituting_inclusions_from_right(const std::vector<Predicate>& inclusions, bool on_cycle);
+        void process_substituting_inclusions_from_right(const std::vector<Predicate>& inclusions, bool on_cycle, const std::set<BasicTerm>& initial_variables);
 
         /**
          * @brief Similar to process_substituting_inclusions_from_right but opposite (left var should be substituted by right side).
@@ -439,7 +439,7 @@ namespace smt::noodler {
          * @param inclusions Inclusions to process
          * @param on_cycle Whether the inclusions should be on cycle or not
          */
-        void process_substituting_inclusions_from_left(const std::vector<Predicate>& inclusions, bool on_cycle);
+        void process_substituting_inclusions_from_left(const std::vector<Predicate>& inclusions, bool on_cycle, const std::set<BasicTerm>& initial_variables);
 
 
         /**
@@ -512,6 +512,10 @@ namespace smt::noodler {
         std::set<BasicTerm> code_subst_vars_handled_by_parikh;
 
         const theory_str_noodler_params& m_params;
+
+        std::set<BasicTerm> initial_variables;
+
+        void set_initial_variables();
 
         /**
          * @brief Replace disequality L != R with equalities and a length constraint saved in disequations_len_formula_conjuncts.
@@ -735,7 +739,7 @@ namespace smt::noodler {
             init_aut_ass(init_aut_ass),
             conversions(conversions),
             m_params(par) {
-            
+                set_initial_variables();
         }
         
         /**

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -411,7 +411,7 @@ namespace smt::noodler {
          * @brief Processes inclusions from noodlification that are of the form where the right side var should be substituted by left side.
          * 
          * It assumes that left sides contain fresh variables, right sides are not substituted yet and all inclusions hold.
-         * This function then takes each inclusions t_1 t_2 ... t_n ⊆ x where x is length var  and substitutes substitution_map[x] = t_1 t_2 ... t_n.
+         * This function then takes each inclusions t_1 t_2 ... t_n ⊆ x where x is length var and substitutes substitution_map[x] = t_1 t_2 ... t_n.
          * It is possible that x is on the right side of two inclusions, the first one substitutes it and the second one is added into this SolvingState
          * and also it is added for processing.
          * There can be inclusions t_1 t_2 ... t_n ⊆ x y ... z where there are multiple variables on the right side, but all the variables on the right
@@ -421,6 +421,7 @@ namespace smt::noodler {
          * 
          * @param inclusions Inclusion to process
          * @param on_cycle Whether the inclusions should be on cycle or not
+         * @return std::set<BasicTerm> The set of variables that were substituted
          */
         std::set<BasicTerm> process_substituting_inclusions_from_right(const std::vector<Predicate>& inclusions, bool on_cycle);
 
@@ -440,6 +441,7 @@ namespace smt::noodler {
          * 
          * @param inclusions Inclusions to process
          * @param on_cycle Whether the inclusions should be on cycle or not
+         * @return std::set<BasicTerm> The set of variables that were substituted
          */
         std::set<BasicTerm> process_substituting_inclusions_from_left(const std::vector<Predicate>& inclusions, bool on_cycle);
 


### PR DESCRIPTION
Depends on #251.

This PR simplifies substituting in main decision procedure, so that the substitution map is always flat. So for example if we have `x1 -> x2 x3` and we get from noodlification that `x2` should now map to `x4`, we do not only add `x2 -> x4` but we replace alse `x2` on the right side of `x1 -> x2 x3`.
We also remove all the variables from the subtitution map, which were introduced during the decision procedure. This could possibly help Z3 LIA solver, as there will be far less variables. For future TODO, we could also remove variables introduced during preprocessing.