### PR TITLE
Process possible solutions first

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -310,73 +310,59 @@ namespace smt::noodler {
             }
             return res.str();
         };
-
-        auto print_predicate_container_to_DOT = [&print_predicate_to_DOT]<typename T>(T predicate_container) {
+        
+        auto print_strings = [](std::vector<std::string>& strings, bool order, std::string del = "\\n") {
+            if (order) {
+                std::sort(strings.begin(), strings.end());
+            }
             bool first = true;
             std::ostringstream res;
-            for (const Predicate& pred : predicate_container) {
+            for (const std::string& string : strings) {
                 if (first) {
                     first = false;
-                    res << print_predicate_to_DOT(pred);
+                    res << string;
                 } else {
-                    res << "\\n" << print_predicate_to_DOT(pred);
+                    res << del << string;
                 }
             }
             return res.str(); 
         };
 
+        auto print_predicate_container_to_DOT = [&print_predicate_to_DOT, &print_strings]<typename T>(const T& predicate_container, bool order) {
+            std::vector<std::string> predicate_strings(predicate_container.size());
+            std::transform(predicate_container.begin(), predicate_container.end(), predicate_strings.begin(), print_predicate_to_DOT);
+            return print_strings(predicate_strings, order);
+        };
 
-        auto print_vars_to_DOT = [&escape_DOT_string](const std::vector<BasicTerm>& vars) {
-            bool first = true;
-            std::ostringstream res;
-            for (const BasicTerm& var : vars) {
-                if (first) {
-                    first = false;
-                    res << escape_DOT_string(var.to_string());
-                } else {
-                    res << "\\n" << escape_DOT_string(var.to_string());
-                }
-            }
-            return res.str(); 
+
+        auto print_vars_to_DOT = [&escape_DOT_string, &print_strings]<typename T>(const T& vars, bool order, bool delimit_by_space) {
+            std::vector<std::string> var_names(vars.size());
+            std::transform(vars.begin(), vars.end(), var_names.begin(), [&escape_DOT_string](const BasicTerm& var) { return escape_DOT_string(var.to_string());});
+            return print_strings(var_names, order, (delimit_by_space ? "\\ " : "\\n"));
         };
 
         std::ostringstream res;
-        res << DOT_name << "[shape=record,label=\"" << print_predicate_container_to_DOT(inclusions);
+        res << DOT_name << "[shape=record,label=\"" << print_predicate_container_to_DOT(inclusions, true);
         if (!inclusions.empty() && !transducers.empty()) {
             res << "\\n";
         }
-        res << print_predicate_container_to_DOT(transducers) << "|" << print_predicate_container_to_DOT(predicates_to_process) << "|";
+        res << print_predicate_container_to_DOT(transducers, true) << "|" << print_predicate_container_to_DOT(predicates_to_process, false) << "|";
 
-        bool first = true;
+        std::vector<std::string> strings_to_print;
         for (const auto& [var,subst_vars] : substitution_map) {
-            if (first) {
-                first = false;
-                res << escape_DOT_string(var.to_string()) << "\\ -\\>\\ " << print_vars_to_DOT(subst_vars);
-            } else {
-                res << "\\n" << escape_DOT_string(var.to_string()) << "\\ -\\>\\ " << print_vars_to_DOT(subst_vars);
-            }
+            strings_to_print.push_back(escape_DOT_string(var.to_string()) + std::string("\\ -\\>\\ ") + print_vars_to_DOT(subst_vars, false, true));
         }
         for (const BasicTerm& var : aut_ass.get_keys()) {
-            if (var.is_literal()) { continue; }
-            if (first) {
-                first = false;
-                res << escape_DOT_string(var.to_string()) << "\\ -\\>\\ NFA";
-            } else {
-                res << "\\n" << escape_DOT_string(var.to_string()) << "\\ -\\>\\ NFA";
+            if (!var.is_literal()) { 
+                strings_to_print.push_back(escape_DOT_string(var.to_string()) + std::string("\\ -\\>\\ NFA"));
             }
         }
+        res << print_strings(strings_to_print, true);
 
         res << "|";
 
-        first = true;
-        for (const BasicTerm& var : length_sensitive_vars) {
-            if (first) {
-                first = false;
-                res << escape_DOT_string(var.to_string());
-            } else {
-                res << "\\n" << escape_DOT_string(var.to_string());
-            }
-        }
+        res << print_vars_to_DOT(length_sensitive_vars, true, false);
+
         res << "\"];";
         return res.str();
     }

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -374,7 +374,7 @@ namespace smt::noodler {
                            << "Getting another solution"
                            << "------------------------" << std::endl;);
 
-        while (!worklist.empty()) {
+        while (!is_worklist_empty()) {
             SolvingState element_to_process = pop_from_worklist();
 
             if (element_to_process.predicates_to_process.empty()) {

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -477,6 +477,8 @@ namespace smt::noodler {
 
         // a deque containing states of decision procedure, each of them can lead to a solution
         std::deque<SolvingState> worklist;
+        // if a solving state has nothing to process, it can lead to solution, we keep these solving states here instead of worklist so we can process them immediately
+        std::vector<SolvingState> possible_solutions;
 
         /// State of a found satisfiable solution set when one is computed using
         ///  compute_next_solution() or after preprocess()
@@ -526,17 +528,27 @@ namespace smt::noodler {
             std::string old_DOT_name = solving_state.DOT_name;
             solving_state.set_new_DOT_name();
             STRACE(str_noodle_dot, tout << solving_state.print_to_DOT() << std::endl << old_DOT_name << " -> " << solving_state.DOT_name << ";\n");
-            if (to_back) {
-                worklist.push_back(std::move(solving_state));
+            if (solving_state.predicates_to_process.empty()) {
+                possible_solutions.push_back(std::move(solving_state));
             } else {
-                worklist.push_front(std::move(solving_state));
+                if (to_back) {
+                    worklist.push_back(std::move(solving_state));
+                } else {
+                    worklist.push_front(std::move(solving_state));
+                }
             }
         }
 
         unsigned num_of_popped_elements = 0;
         SolvingState pop_from_worklist() {
-            SolvingState element_to_process = std::move(worklist.front());
-            worklist.pop_front();
+            SolvingState element_to_process;
+            if (!possible_solutions.empty()) {
+                element_to_process = std::move(possible_solutions.back());
+                possible_solutions.pop_back();
+            } else {
+                element_to_process = std::move(worklist.front());
+                worklist.pop_front();
+            }
             STRACE(str_noodle_dot, tout << element_to_process.DOT_name << " -> " << element_to_process.DOT_name << " [penwidth=0,dir=none,label=" << num_of_popped_elements << "];\n";);
             ++num_of_popped_elements;
             return element_to_process;

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -524,6 +524,10 @@ namespace smt::noodler {
         void process_inclusion(const Predicate& inclusion_to_process, SolvingState& solving_state);
         void process_transducer(const Predicate& transducer_to_process, SolvingState& solving_state);
 
+        bool is_worklist_empty() {
+            return (worklist.empty() && possible_solutions.empty());
+        }
+
         void push_to_worklist(SolvingState solving_state, bool to_back) {
             std::string old_DOT_name = solving_state.DOT_name;
             solving_state.set_new_DOT_name();


### PR DESCRIPTION
If we find a possible solution (no inclusions/transducers to process), we always process it first. It should be mainly useful for cyclic inclusion graphs, where we use BFS instead of DFS to search solving space.

I also changed some stuff for printing solving state in DOT format, mainly ordering the output of some stuff.