### PR TITLE
Special handling of one input automaton in transducers

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -740,13 +740,16 @@ namespace smt::noodler {
         auto [input_vars_automata, input_vars_divisions] = solving_state.get_automata_and_division_of_concatenation(input_vars, true);
         SASSERT(input_vars_automata.size() == input_vars_divisions.size());
 
-        // In the case that input side leads to one automaton, i.e., either there is only one (length) var, or multiple non-length vars,
-        // then we can apply this automaton directly to the transducer. So if we have
+        // In the case that input side leads to one automaton where we have only non-length vars, we can apply this automaton directly to the transducer.
+        // So if we have
         //   output_vars = T(input_vars),
         // we take the language of applying automaton from input_vars on T and create a new fresh_var with this language, where we create
         //    fresh_var = T(input_vars)         and         output_vars ⊆ fresh_var
-        // We also set fresh_var as length if input_vars contain any length var (in that case input_vars contain exactly one var, which is length).
-        if (input_vars_automata.size() == 1) {
+        // where the inclusion must be processed to update the languages of output_vars.
+        // Note: It would seem that we could also use this optimization for when we have one input length var (that leads to one automaton). However,
+        // this would not work, after processing the inclusion, the fresh_var (which would need to be length) would be substituted and then "fresh_var = T(input_vars)"
+        // woudl be processed again, but input_vars still lead to one automaton so we would repeat this and get stuck.
+        if (input_vars_automata.size() == 1 && !solving_state.contains_length_var(input_vars)) {
             mata::nfa::Nfa application_to_input_automaton = transducer_to_process.get_transducer()->apply(*input_vars_automata[0], 0).to_nfa_move();
             application_to_input_automaton = mata::nfa::reduce(mata::nfa::remove_epsilon(application_to_input_automaton.trim()));
             
@@ -756,7 +759,7 @@ namespace smt::noodler {
             }
 
             // the language of fresh_var is the application, it is length if input_vars contain length
-            BasicTerm fresh_var = solving_state.add_fresh_var(std::make_shared<mata::nfa::Nfa>(application_to_input_automaton), std::string("onevarapp_") + std::to_string(noodlification_no), solving_state.contains_length_var(input_vars), true);
+            BasicTerm fresh_var = solving_state.add_fresh_var(std::make_shared<mata::nfa::Nfa>(application_to_input_automaton), std::string("onevarapp_") + std::to_string(noodlification_no), false, true);
             // we add transducer "fresh_var = T(input_vars)"
             solving_state.add_transducer(transducer_to_process.get_transducer(), input_vars, {fresh_var}, false);
             // we add inclusion "output_vars ⊆ fresh_var"

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -740,6 +740,33 @@ namespace smt::noodler {
         auto [input_vars_automata, input_vars_divisions] = solving_state.get_automata_and_division_of_concatenation(input_vars, true);
         SASSERT(input_vars_automata.size() == input_vars_divisions.size());
 
+        // In the case that input side leads to one automaton, i.e., either there is only one (length) var, or multiple non-length vars,
+        // then we can apply this automaton directly to the transducer. So if we have
+        //   output_vars = T(input_vars),
+        // we take the language of applying automaton from input_vars on T and create a new fresh_var with this language, where we create
+        //    fresh_var = T(input_vars)         and         output_vars ⊆ fresh_var
+        // We also set fresh_var as length if input_vars contain any length var (in that case input_vars contain exactly one var, which is length).
+        if (input_vars_automata.size() == 1) {
+            mata::nfa::Nfa application_to_input_automaton = transducer_to_process.get_transducer()->apply(*input_vars_automata[0], 0).to_nfa_move();
+            application_to_input_automaton = mata::nfa::reduce(mata::nfa::remove_epsilon(application_to_input_automaton.trim()));
+            
+            if (application_to_input_automaton.is_lang_empty()) {
+                // applying input on the transducer results in empty language, this solving_state cannot lead to solution
+                return;
+            }
+
+            // the language of fresh_var is the application, it is length if input_vars contain length
+            BasicTerm fresh_var = solving_state.add_fresh_var(std::make_shared<mata::nfa::Nfa>(application_to_input_automaton), std::string("onevarapp_") + std::to_string(noodlification_no), solving_state.contains_length_var(input_vars), true);
+            // we add transducer "fresh_var = T(input_vars)"
+            solving_state.add_transducer(transducer_to_process.get_transducer(), input_vars, {fresh_var}, false);
+            // we add inclusion "output_vars ⊆ fresh_var"
+            Predicate new_inclusion = Predicate::create_equation(output_vars, {fresh_var});
+            solving_state.add_predicate(new_inclusion, false);
+            solving_state.push_front_unique(new_inclusion); // we need to process the inclusion, to update the languages of output_vars
+            push_to_worklist(std::move(solving_state), false);
+            return;
+        }
+
         STRACE(str_nfa, tout << "Output automata:" << std::endl);
         auto [output_vars_automata, output_vars_divisions] = solving_state.get_automata_and_division_of_concatenation(output_vars, false);
         SASSERT(output_vars_automata.size() == output_vars_divisions.size());

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -748,7 +748,7 @@ namespace smt::noodler {
         // where the inclusion must be processed to update the languages of output_vars.
         // Note: It would seem that we could also use this optimization for when we have one input length var (that leads to one automaton). However,
         // this would not work, after processing the inclusion, the fresh_var (which would need to be length) would be substituted and then "fresh_var = T(input_vars)"
-        // woudl be processed again, but input_vars still lead to one automaton so we would repeat this and get stuck.
+        // would be processed again, but input_vars still lead to one automaton so we would repeat this and get stuck.
         if (input_vars_automata.size() == 1 && !solving_state.contains_length_var(input_vars)) {
             mata::nfa::Nfa application_to_input_automaton = transducer_to_process.get_transducer()->apply(*input_vars_automata[0], 0).to_nfa_move();
             application_to_input_automaton = mata::nfa::reduce(mata::nfa::remove_epsilon(application_to_input_automaton.trim()));

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -217,7 +217,7 @@ namespace smt::noodler {
          */
         void push_non_simple_transducers_to_processing() {
             for (const Predicate &transducer : transducers) {
-                if (transducer.get_input().size() != 1 || transducer.get_output().size() != 1 || transducer.get_input()[0].is_literal() || transducer.get_input()[1].is_literal()) {
+                if (contains_length_var(transducer.get_input()) && (transducer.get_input().size() != 1 || transducer.get_output().size() != 1 || transducer.get_input()[0].is_literal() || transducer.get_input()[1].is_literal())) {
                     push_unique(transducer, false);
                 }
             }

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -210,7 +210,7 @@ namespace smt::noodler {
         }
 
         /**
-         * @brief Adds all transducers that are not simple (that do not have one input and one output var) back to processing.
+         * @brief Adds all transducers that contain length vars on input and are not simple (they do not have one input and one output var) back to processing.
          * 
          * It pushes a transducer only if it is not pushed already.
          * Useful after calling substitute_vars().


### PR DESCRIPTION
If we have a transducer `xyz = T(uvr)` where `uvr` are all non-length, we can replace the transducer with
`xyz = f && f = T(uvr)` where `f` is a fresh var whose language is the application of the language of `uvr` on `T`. We then just need to handle `xyz = f` to update the languages of `xyz`.