### PR TITLE
Single product heuristic

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1,5 +1,4 @@
 #include <queue>
-
 #include <utility>
 #include <algorithm>
 #include <functional>
@@ -1656,157 +1655,43 @@ namespace smt::noodler {
         return ca::get_lia_for_not_contains(proj_not_cont, this->solution.aut_ass, true);
     }
 
-    // ********************************** JUST ATTEMPT *************/
-    using State = unsigned long;
-
-    using StateRenaming = std::unordered_map<State, State>;
-
-    mata::nfa::Nfa concatenate_eps(const mata::nfa::Nfa& lhs, const mata::nfa::Nfa& rhs, const mata::Symbol& epsilon, bool use_epsilon) {
-    // Compute concatenation of given automata.
-    // Concatenation will proceed in the order of the passed automata: Result is 'lhs . rhs'.
-
-    if (lhs.num_of_states() == 0 || rhs.num_of_states() == 0 || lhs.initial.empty() || lhs.final.empty() ||
-        rhs.initial.empty() || rhs.final.empty()) {
-        return mata::nfa::Nfa{};
-    }
-
-    StateRenaming* lhs_state_renaming = nullptr;
-    StateRenaming* rhs_state_renaming = nullptr;
-
-    const unsigned long lhs_states_num{lhs.num_of_states() };
-    const unsigned long rhs_states_num{rhs.num_of_states() };
-    mata::nfa::Nfa result{}; // Concatenated automaton.
-    StateRenaming _lhs_states_renaming{}; // Map mapping rhs states to result states.
-    StateRenaming _rhs_states_renaming{}; // Map mapping rhs states to result states.
-
-    const size_t result_num_of_states{lhs_states_num + rhs_states_num};
-    if (result_num_of_states == 0) { return mata::nfa::Nfa{}; }
-
-    // Map lhs states to result states.
-    _lhs_states_renaming.reserve(lhs_states_num);
-    mata::Symbol result_state_index{ 0 };
-    for (State lhs_state{ 0 }; lhs_state < lhs_states_num; ++lhs_state) {
-        _lhs_states_renaming.insert(std::make_pair(lhs_state, result_state_index));
-        ++result_state_index;
-    }
-    // Map rhs states to result states.
-    _rhs_states_renaming.reserve(rhs_states_num);
-    for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state) {
-        _rhs_states_renaming.insert(std::make_pair(rhs_state, result_state_index));
-        ++result_state_index;
-    }
-
-    result = mata::nfa::Nfa();
-    result.delta = lhs.delta;
-    result.initial = lhs.initial;
-    result.add_state(result_num_of_states-1);
-
-    // Add epsilon transitions connecting lhs and rhs automata.
-    // The epsilon transitions lead from lhs original final states to rhs original initial states.
-    for (const auto& lhs_final_state: lhs.final) {
-        for (const auto& rhs_initial_state: rhs.initial) {
-            result.delta.add(lhs_final_state, epsilon,
-                             _rhs_states_renaming[rhs_initial_state]);
-        }
-    }
-
-    // Make result final states.
-    for (const auto& rhs_final_state: rhs.final)
-    {
-        result.final.insert(_rhs_states_renaming[rhs_final_state]);
-    }
-
-    // Add rhs transitions to the result.
-    for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state)
-    {
-        for (const mata::nfa::SymbolPost& rhs_move: rhs.delta.state_post(rhs_state))
-        {
-            for (const State& rhs_state_to: rhs_move.targets)
-            {
-                result.delta.add(_rhs_states_renaming[rhs_state],
-                                 rhs_move.symbol,
-                                 _rhs_states_renaming[rhs_state_to]);
-            }
-        }
-    }
-
-    if (!use_epsilon) {
-        result.remove_epsilon();
-    }
-    if (lhs_state_renaming != nullptr) { *lhs_state_renaming = _lhs_states_renaming; }
-    if (rhs_state_renaming != nullptr) { *rhs_state_renaming = _rhs_states_renaming; }
-    return result;
-} // concatenate_eps().
-
-    // /**
-    //  * @brief Unify (as best as possible) the initial states and the final states of NFAs in @p nfas
-    //  *
-    //  * The unification happens only if the given automaton is not already unified, i.e. it is in @p unified_nfas.
-    //  * We also add the newly unified automata to @p unified_nfas.
-    //  *
-    //  * @param[in] nfas The automata to unify
-    //  * @param[in,out] unified_nfas The set of already unified automata
-    //  */
-    // void unify_initial_and_final_states(const std::vector<std::shared_ptr<mata::nfa::Nfa>>& nfas, std::unordered_set<std::shared_ptr<mata::nfa::Nfa>>& unified_nfas) {
-    //     for (std::shared_ptr<mata::nfa::Nfa> nfa : nfas) {
-    //         if (!unified_nfas.contains(nfa)) {
-    //             nfa->unify_initial();
-    //             nfa->unify_final();
-    //             unified_nfas.insert(nfa);
-    //         }
-    //     }
-    // }
-
-    mata::nfa::Nfa concatenate_with(const std::vector<std::shared_ptr<mata::nfa::Nfa>>& nfas, mata::Symbol delimiter) {
+    // help function for concatenation using epsilon - didn't find noodler version - TODO find it ?? 
+    mata::nfa::Nfa epsilon_concatenation(const std::vector<std::shared_ptr<mata::nfa::Nfa>>& nfas) {
         mata::nfa::Nfa concatenation{*nfas[0]};
+        // for every automata concatenate it to the result with epsilon
         for (size_t i = 1; i < nfas.size(); ++i) {
-            concatenation = concatenate_eps(concatenation, *nfas[i], delimiter, true);
+            concatenation = mata::nfa::concatenate(concatenation, *nfas[i], mata::nfa::EPSILON);
         }
         return concatenation;
     }
-    // ********************************** END JUST ATTEMPT *************/
 
-    AutAssignment DecisionProcedure::get_product_languages(SolvingState& solving_state, std::vector<BasicTerm> lhs_vars, std::vector<BasicTerm> rhs_vars) {
+    AutAssignment DecisionProcedure::get_product_languages(SolvingState& solving_state, const std::vector<BasicTerm>& lhs_vars, const std::vector<BasicTerm>& rhs_vars) {
         // Get automata of the variables on the left side
         STRACE(str_nfa, tout << "Left automata:" << std::endl);
         auto [lhs_automata, lhs_division] = solving_state.get_automata_and_division_of_concatenation(lhs_vars, false);
         SASSERT(lhs_division.size() == lhs_vars.size()); // each division should contain exactly one left variable
         SASSERT(lhs_automata.size() == lhs_division.size()); // we have one automaton for each division
 
-        // // Get automata of the variables on the right side
-        // STRACE(str_nfa, tout << "Right automata:" << std::endl);
-        // auto [rhs_automata, rhs_division] = solving_state.get_automata_and_division_of_concatenation(rhs_vars, false);
-        // SASSERT(rhs_automata.size() == rhs_division.size()); // we have one automaton for each division
+        // concatenation of lhs using epsilon transition - these transition will then be removed during segmatation
+        mata::nfa::Nfa concatenated_lhs = epsilon_concatenation(lhs_automata);
 
-        // *********** START ATTEMPT **********
-        // just trying what does segmentation do
-
-        // Automata representing the left/rigth side concatenated over different epsilon transitions.
-        mata::nfa::Nfa concatenated_lhs = concatenate_with(lhs_automata, mata::nfa::EPSILON);
-        STRACE(str, tout << "Left automaton:\n" << concatenated_lhs << "\n");
-
+        // ordinary concatenation of right hand side
         mata::nfa::Nfa concatenated_rhs = solving_state.aut_ass.get_automaton_concat(rhs_vars);
-        STRACE(str, tout << "Right automaton:\n" << concatenated_rhs << "\n");
 
         auto product_pres_eps_trans{
-                intersection(concatenated_lhs, concatenated_rhs).trim() };
+                mata::nfa::intersection(concatenated_lhs, concatenated_rhs).trim() };
 
         if (product_pres_eps_trans.is_lang_empty()) {
             return {};
         }
 
-        product_pres_eps_trans = reduce(product_pres_eps_trans);
-        STRACE(str, tout << "Product automaton:\n" << product_pres_eps_trans << "\n");
+        product_pres_eps_trans = mata::nfa::reduce(product_pres_eps_trans);
 
+        // own segmentation of epsilon product
         mata::applications::strings::seg_nfa::Segmentation segmentation{product_pres_eps_trans, { mata::nfa::EPSILON }};
-        const auto& segments{ segmentation.get_untrimmed_segments() };
+        const auto& segments{ segmentation.get_segments() };
 
-        STRACE(str, tout << lhs_vars.size() << " " << segments.size() << "\n");
-        for (unsigned ind = 0; ind < segments.size(); ind++) {
-            STRACE(str, tout << "Initial segment automata for " << lhs_vars[ind] << " :\n" << segments[ind] << "\n");
-        }
-        // *********** END ATTEMPT **********
-
+        // performing necesarry intersection and moving segments to resulting aut assignment
         AutAssignment eps_product_lang = {};
         for (unsigned ind = 0; ind < lhs_vars.size(); ind++) {
             BasicTerm left_var = lhs_vars[ind];
@@ -1817,23 +1702,24 @@ namespace smt::noodler {
                 eps_product_lang.restrict_lang(left_var, segments[ind]);
             }
         }
-        for (const auto &x : eps_product_lang) {
-            STRACE(str, tout << "Epsilon product automata for " << x.first << " :\n" << *x.second << "\n");
-        }
+
+        // another reduction - don't know if necesarry
+        eps_product_lang.reduce();
 
         return eps_product_lang;
     }
 
     void DecisionProcedure::single_product_heuristic() {
         STRACE(str, tout << "Single product heuristic...\n");
+        // getting current state
         SolvingState process_state = pop_from_worklist();
 
         int init_predicate_size = process_state.predicates_to_process.size();
 
-        // loop once through initial inclusion graph - now don't care about other created dependent predicates
+        // loop once through initial inclusion graph
         for (int processed_count = 0; processed_count < init_predicate_size; processed_count++)
         {
-
+            // pick current predicates to be processed
             Predicate predicate_to_process = process_state.predicates_to_process[processed_count];
 
             // don't know what to do with transducers
@@ -1850,13 +1736,11 @@ namespace smt::noodler {
 
         // pushing process state back - think it doesnt depend second argument
         push_to_worklist(std::move(process_state), false);
-
     }
 
-    bool DecisionProcedure::process_inclusion_single_product(Predicate &inclusion, SolvingState& solving_state) {
+    bool DecisionProcedure::process_inclusion_single_product(Predicate& inclusion, SolvingState& solving_state) {
 
         // getting automata for both sides
-        // TODO - probably can be done easier without copying
         const auto &left_side_vars = inclusion.get_left_side();
         const auto &right_side_vars = inclusion.get_right_side();
 
@@ -1873,6 +1757,9 @@ namespace smt::noodler {
         for (const auto &left_var : left_side_vars) {
             solving_state.aut_ass.restrict_lang(left_var, *product_aut_ass.at(left_var));
         }
+
+        // another reduction - don't know if necesarry
+        solving_state.aut_ass.reduce();
 
         return solving_state.aut_ass.is_sat();
     }
@@ -1966,7 +1853,7 @@ namespace smt::noodler {
         STRACE(str_noodle_dot, tout << "digraph Procedure {\ninit[shape=none, label=\"\"]\n";);
         push_to_worklist(std::move(init_solving_state), true);
 
-        // temmporary place for single product heuristic
+        // temporary place for single product heuristic
         single_product_heuristic();
     }
 

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1656,19 +1656,172 @@ namespace smt::noodler {
         return ca::get_lia_for_not_contains(proj_not_cont, this->solution.aut_ass, true);
     }
 
+    // ********************************** JUST ATTEMPT *************/
+    using State = unsigned long;
+
+    using StateRenaming = std::unordered_map<State, State>;
+
+    mata::nfa::Nfa concatenate_eps(const mata::nfa::Nfa& lhs, const mata::nfa::Nfa& rhs, const mata::Symbol& epsilon, bool use_epsilon) {
+    // Compute concatenation of given automata.
+    // Concatenation will proceed in the order of the passed automata: Result is 'lhs . rhs'.
+
+    if (lhs.num_of_states() == 0 || rhs.num_of_states() == 0 || lhs.initial.empty() || lhs.final.empty() ||
+        rhs.initial.empty() || rhs.final.empty()) {
+        return mata::nfa::Nfa{};
+    }
+
+    StateRenaming* lhs_state_renaming = nullptr;
+    StateRenaming* rhs_state_renaming = nullptr;
+
+    const unsigned long lhs_states_num{lhs.num_of_states() };
+    const unsigned long rhs_states_num{rhs.num_of_states() };
+    mata::nfa::Nfa result{}; // Concatenated automaton.
+    StateRenaming _lhs_states_renaming{}; // Map mapping rhs states to result states.
+    StateRenaming _rhs_states_renaming{}; // Map mapping rhs states to result states.
+
+    const size_t result_num_of_states{lhs_states_num + rhs_states_num};
+    if (result_num_of_states == 0) { return mata::nfa::Nfa{}; }
+
+    // Map lhs states to result states.
+    _lhs_states_renaming.reserve(lhs_states_num);
+    mata::Symbol result_state_index{ 0 };
+    for (State lhs_state{ 0 }; lhs_state < lhs_states_num; ++lhs_state) {
+        _lhs_states_renaming.insert(std::make_pair(lhs_state, result_state_index));
+        ++result_state_index;
+    }
+    // Map rhs states to result states.
+    _rhs_states_renaming.reserve(rhs_states_num);
+    for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state) {
+        _rhs_states_renaming.insert(std::make_pair(rhs_state, result_state_index));
+        ++result_state_index;
+    }
+
+    result = mata::nfa::Nfa();
+    result.delta = lhs.delta;
+    result.initial = lhs.initial;
+    result.add_state(result_num_of_states-1);
+
+    // Add epsilon transitions connecting lhs and rhs automata.
+    // The epsilon transitions lead from lhs original final states to rhs original initial states.
+    for (const auto& lhs_final_state: lhs.final) {
+        for (const auto& rhs_initial_state: rhs.initial) {
+            result.delta.add(lhs_final_state, epsilon,
+                             _rhs_states_renaming[rhs_initial_state]);
+        }
+    }
+
+    // Make result final states.
+    for (const auto& rhs_final_state: rhs.final)
+    {
+        result.final.insert(_rhs_states_renaming[rhs_final_state]);
+    }
+
+    // Add rhs transitions to the result.
+    for (State rhs_state{ 0 }; rhs_state < rhs_states_num; ++rhs_state)
+    {
+        for (const mata::nfa::SymbolPost& rhs_move: rhs.delta.state_post(rhs_state))
+        {
+            for (const State& rhs_state_to: rhs_move.targets)
+            {
+                result.delta.add(_rhs_states_renaming[rhs_state],
+                                 rhs_move.symbol,
+                                 _rhs_states_renaming[rhs_state_to]);
+            }
+        }
+    }
+
+    if (!use_epsilon) {
+        result.remove_epsilon();
+    }
+    if (lhs_state_renaming != nullptr) { *lhs_state_renaming = _lhs_states_renaming; }
+    if (rhs_state_renaming != nullptr) { *rhs_state_renaming = _rhs_states_renaming; }
+    return result;
+} // concatenate_eps().
+
+    // /**
+    //  * @brief Unify (as best as possible) the initial states and the final states of NFAs in @p nfas
+    //  *
+    //  * The unification happens only if the given automaton is not already unified, i.e. it is in @p unified_nfas.
+    //  * We also add the newly unified automata to @p unified_nfas.
+    //  *
+    //  * @param[in] nfas The automata to unify
+    //  * @param[in,out] unified_nfas The set of already unified automata
+    //  */
+    // void unify_initial_and_final_states(const std::vector<std::shared_ptr<mata::nfa::Nfa>>& nfas, std::unordered_set<std::shared_ptr<mata::nfa::Nfa>>& unified_nfas) {
+    //     for (std::shared_ptr<mata::nfa::Nfa> nfa : nfas) {
+    //         if (!unified_nfas.contains(nfa)) {
+    //             nfa->unify_initial();
+    //             nfa->unify_final();
+    //             unified_nfas.insert(nfa);
+    //         }
+    //     }
+    // }
+
+    mata::nfa::Nfa concatenate_with(const std::vector<std::shared_ptr<mata::nfa::Nfa>>& nfas, mata::Symbol delimiter) {
+        mata::nfa::Nfa concatenation{*nfas[0]};
+        for (size_t i = 1; i < nfas.size(); ++i) {
+            concatenation = concatenate_eps(concatenation, *nfas[i], delimiter, true);
+        }
+        return concatenation;
+    }
+    // ********************************** END JUST ATTEMPT *************/
+
     AutAssignment DecisionProcedure::get_product_languages(SolvingState& solving_state, std::vector<BasicTerm> lhs_vars, std::vector<BasicTerm> rhs_vars) {
         // Get automata of the variables on the left side
         STRACE(str_nfa, tout << "Left automata:" << std::endl);
-        auto [left_side_automata, left_side_division] = solving_state.get_automata_and_division_of_concatenation(lhs_vars, false);
-        SASSERT(left_side_division.size() == left_side_vars.size()); // each division should contain exactly one left variable
-        SASSERT(left_side_automata.size() == left_side_division.size()); // we have one automaton for each division
+        auto [lhs_automata, lhs_division] = solving_state.get_automata_and_division_of_concatenation(lhs_vars, false);
+        SASSERT(lhs_division.size() == lhs_vars.size()); // each division should contain exactly one left variable
+        SASSERT(lhs_automata.size() == lhs_division.size()); // we have one automaton for each division
 
-        // Get automata of the variables on the right side
-        STRACE(str_nfa, tout << "Right automata:" << std::endl);
-        auto [right_side_automata, right_side_division] = solving_state.get_automata_and_division_of_concatenation(rhs_vars, false);
-        SASSERT(right_side_automata.size() == right_side_division.size()); // we have one automaton for each division
+        // // Get automata of the variables on the right side
+        // STRACE(str_nfa, tout << "Right automata:" << std::endl);
+        // auto [rhs_automata, rhs_division] = solving_state.get_automata_and_division_of_concatenation(rhs_vars, false);
+        // SASSERT(rhs_automata.size() == rhs_division.size()); // we have one automaton for each division
 
-        return {};
+        // *********** START ATTEMPT **********
+        // just trying what does segmentation do
+
+        // Automata representing the left/rigth side concatenated over different epsilon transitions.
+        mata::nfa::Nfa concatenated_lhs = concatenate_with(lhs_automata, mata::nfa::EPSILON);
+        STRACE(str, tout << "Left automaton:\n" << concatenated_lhs << "\n");
+
+        mata::nfa::Nfa concatenated_rhs = solving_state.aut_ass.get_automaton_concat(rhs_vars);
+        STRACE(str, tout << "Right automaton:\n" << concatenated_rhs << "\n");
+
+        auto product_pres_eps_trans{
+                intersection(concatenated_lhs, concatenated_rhs).trim() };
+
+        if (product_pres_eps_trans.is_lang_empty()) {
+            return {};
+        }
+
+        product_pres_eps_trans = reduce(product_pres_eps_trans);
+        STRACE(str, tout << "Product automaton:\n" << product_pres_eps_trans << "\n");
+
+        mata::applications::strings::seg_nfa::Segmentation segmentation{product_pres_eps_trans, { mata::nfa::EPSILON }};
+        const auto& segments{ segmentation.get_untrimmed_segments() };
+
+        STRACE(str, tout << lhs_vars.size() << " " << segments.size() << "\n");
+        for (unsigned ind = 0; ind < segments.size(); ind++) {
+            STRACE(str, tout << "Initial segment automata for " << lhs_vars[ind] << " :\n" << segments[ind] << "\n");
+        }
+        // *********** END ATTEMPT **********
+
+        AutAssignment eps_product_lang = {};
+        for (unsigned ind = 0; ind < lhs_vars.size(); ind++) {
+            BasicTerm left_var = lhs_vars[ind];
+            // there is not left var in result language
+            if (eps_product_lang.find(left_var) == eps_product_lang.end()) {
+                eps_product_lang[left_var] = std::make_shared<mata::nfa::Nfa>(segments[ind]);
+            } else {
+                eps_product_lang.restrict_lang(left_var, segments[ind]);
+            }
+        }
+        for (const auto &x : eps_product_lang) {
+            STRACE(str, tout << "Epsilon product automata for " << x.first << " :\n" << *x.second << "\n");
+        }
+
+        return eps_product_lang;
     }
 
     void DecisionProcedure::single_product_heuristic() {
@@ -1714,6 +1867,7 @@ namespace smt::noodler {
 
         // get new languages from epsilon product
         AutAssignment product_aut_ass = get_product_languages(solving_state, left_side_vars, right_side_vars);
+        if (product_aut_ass.size() == 0) return false;
 
         // perform intersection of current languages and new product languages
         for (const auto &left_var : left_side_vars) {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1,4 +1,5 @@
 #include <queue>
+
 #include <utility>
 #include <algorithm>
 #include <functional>
@@ -1655,6 +1656,40 @@ namespace smt::noodler {
         return ca::get_lia_for_not_contains(proj_not_cont, this->solution.aut_ass, true);
     }
 
+    void DecisionProcedure::single_product_heuristic() {
+        STRACE(str, tout << "Single product heuristic...\n");
+        SolvingState process_state = pop_from_worklist();
+
+        int init_predicate_size = process_state.predicates_to_process.size();
+
+        // loop once through initial inclusion graph - now don't care about other created dependent predicates
+        for (int processed_count = 0; processed_count < init_predicate_size; processed_count++)
+        {
+
+            Predicate predicate_to_process = process_state.predicates_to_process[processed_count];
+
+            // don't know what to do with transducers
+            if (predicate_to_process.is_equation()) { // inclusion
+                // if found UNSAT inclusion - this solving state is UNSAT - just return no pushing to worklist
+                if (!process_inclusion_single_product(predicate_to_process, process_state)) {
+                    return;
+                }
+            } else {
+                SASSERT(predicate_to_process.is_transducer());
+            }
+
+        } 
+
+        // pushing process state back - think it doesnt depend second argument
+        push_to_worklist(std::move(process_state), false);
+
+    }
+
+    bool DecisionProcedure::process_inclusion_single_product(Predicate &inclusion, SolvingState& solving_state) {
+        
+        return true;
+    }
+
     /**
      * @brief Creates initial inclusion graph according to the preprocessed instance.
      */
@@ -1743,6 +1778,9 @@ namespace smt::noodler {
 
         STRACE(str_noodle_dot, tout << "digraph Procedure {\ninit[shape=none, label=\"\"]\n";);
         push_to_worklist(std::move(init_solving_state), true);
+
+        // temmporary place for single product heuristic
+        single_product_heuristic();
     }
 
     lbool DecisionProcedure::preprocess(PreprocessType opt, const BasicTermEqiv &len_eq_vars) {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1716,6 +1716,8 @@ namespace smt::noodler {
 
         int init_predicate_size = process_state.predicates_to_process.size();
 
+        SolvingState tmp_state = process_state;
+
         // loop once through initial inclusion graph
         for (int processed_count = 0; processed_count < init_predicate_size; processed_count++)
         {
@@ -1725,7 +1727,7 @@ namespace smt::noodler {
             // don't know what to do with transducers
             if (predicate_to_process.is_equation()) { // inclusion
                 // if found UNSAT inclusion - this solving state is UNSAT - just return no pushing to worklist
-                if (!process_inclusion_single_product(predicate_to_process, process_state)) {
+                if (!process_inclusion_single_product(predicate_to_process, tmp_state)) {
                     return;
                 }
             } else {

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1656,6 +1656,21 @@ namespace smt::noodler {
         return ca::get_lia_for_not_contains(proj_not_cont, this->solution.aut_ass, true);
     }
 
+    AutAssignment DecisionProcedure::get_product_languages(SolvingState& solving_state, std::vector<BasicTerm> lhs_vars, std::vector<BasicTerm> rhs_vars) {
+        // Get automata of the variables on the left side
+        STRACE(str_nfa, tout << "Left automata:" << std::endl);
+        auto [left_side_automata, left_side_division] = solving_state.get_automata_and_division_of_concatenation(lhs_vars, false);
+        SASSERT(left_side_division.size() == left_side_vars.size()); // each division should contain exactly one left variable
+        SASSERT(left_side_automata.size() == left_side_division.size()); // we have one automaton for each division
+
+        // Get automata of the variables on the right side
+        STRACE(str_nfa, tout << "Right automata:" << std::endl);
+        auto [right_side_automata, right_side_division] = solving_state.get_automata_and_division_of_concatenation(rhs_vars, false);
+        SASSERT(right_side_automata.size() == right_side_division.size()); // we have one automaton for each division
+
+        return {};
+    }
+
     void DecisionProcedure::single_product_heuristic() {
         STRACE(str, tout << "Single product heuristic...\n");
         SolvingState process_state = pop_from_worklist();
@@ -1686,8 +1701,26 @@ namespace smt::noodler {
     }
 
     bool DecisionProcedure::process_inclusion_single_product(Predicate &inclusion, SolvingState& solving_state) {
-        
-        return true;
+
+        // getting automata for both sides
+        // TODO - probably can be done easier without copying
+        const auto &left_side_vars = inclusion.get_left_side();
+        const auto &right_side_vars = inclusion.get_right_side();
+
+        // inclusion contains length aware variables can't od anything
+        if (solving_state.contains_length_var(right_side_vars) || solving_state.contains_length_var(left_side_vars)) {
+            return true;
+        }
+
+        // get new languages from epsilon product
+        AutAssignment product_aut_ass = get_product_languages(solving_state, left_side_vars, right_side_vars);
+
+        // perform intersection of current languages and new product languages
+        for (const auto &left_var : left_side_vars) {
+            solving_state.aut_ass.restrict_lang(left_var, *product_aut_ass.at(left_var));
+        }
+
+        return solving_state.aut_ass.is_sat();
     }
 
     /**

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -683,6 +683,17 @@ namespace smt::noodler {
          */
         Formula not_contains{};
 
+        /**
+         * @brief Heuristic method based on only epsilon-product generation and refining languages based on this product
+         * First creates epsilon-product for every inclusion and refines variable language based on segment automaton recieved
+         * from product
+         * Can provide adventage in some UNSAT problems - no need to do time consuming noodlifications
+         * Overapproximates languages - if finds UNSAT, can return UNSAT - if end languages are satisfiable - works with refined languages
+         */
+        void single_product_heuristic();
+
+        bool process_inclusion_single_product(Predicate &inclusion, SolvingState& solving_state);
+
         ////////////////////////////////////////////////////////////////
         //////////////////// FOR MODEL GENERATION //////////////////////
         ////////////////////////////////////////////////////////////////

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -692,17 +692,28 @@ namespace smt::noodler {
          * 
          * @return Unordered map where for each varaible there is a new language
          */
-        AutAssignment get_product_languages(SolvingState& solving_state, std::vector<BasicTerm> lhs_vars, std::vector<BasicTerm> rhs_vars);
+        AutAssignment get_product_languages(SolvingState& solving_state, const std::vector<BasicTerm>& lhs_vars, const std::vector<BasicTerm>& rhs_vars);
 
         /**
          * @brief Heuristic method based on only epsilon-product generation and refining languages based on this product
          * First creates epsilon-product for every inclusion and refines variable language based on segment automaton recieved
          * from product
          * Can provide adventage in some UNSAT problems - no need to do time consuming noodlifications
-         * Overapproximates languages - if finds UNSAT, can return UNSAT - if end languages are satisfiable - works with refined languages
+         * Overapproximates languages - if finds UNSAT, can return UNSAT (or in fact wouldn't push back solving state)
+         * if end languages are satisfiable - works with refined languages
          */
         void single_product_heuristic();
 
+        /**
+         * @brief Processes inclusion from inclusion graph and eventually refines solving state languages
+         * Creates epsilon product of given inclusion and performs segmentation
+         * Refines solving state based on these segments (for every left side variable there is segment - we perform intersection with current variable language)
+         * 
+         * @param inclusion Inclusion to be processed
+         * @param solving_state Solving state instance - it's can be altered after returning from function (due language refinment)
+         * 
+         * @return true <-> current solving state is still SAT
+         */
         bool process_inclusion_single_product(Predicate &inclusion, SolvingState& solving_state);
 
         ////////////////////////////////////////////////////////////////

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -684,6 +684,17 @@ namespace smt::noodler {
         Formula not_contains{};
 
         /**
+         * @brief Function that gets new product languages
+         * Performs segmentation on given automata
+         * 
+         * @param lhs_vars Left hand side variables
+         * @param rhs_vars Right hand side variables
+         * 
+         * @return Unordered map where for each varaible there is a new language
+         */
+        AutAssignment get_product_languages(SolvingState& solving_state, std::vector<BasicTerm> lhs_vars, std::vector<BasicTerm> rhs_vars);
+
+        /**
          * @brief Heuristic method based on only epsilon-product generation and refining languages based on this product
          * First creates epsilon-product for every inclusion and refines variable language based on segment automaton recieved
          * from product


### PR DESCRIPTION
Implementation of single product heuristic. Basic idea is, that as a preprocessing step we perform epsilon products according to inclusion graph, but we don't perform whole noodlification. We end up with segments we got from epsilon products, so no huge branching is needed.