### PR TITLE
Disable `str.in_re` rewriting rule introducing length variables

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -4667,9 +4667,9 @@ br_status seq_rewriter::mk_str_in_regexp(expr* a, expr* b, expr_ref& result) {
     }
     expr* b1 = nullptr;
     expr* eps = nullptr;
-    if (re().is_opt(b, b1) ||
+    if (false && re().is_opt(b, b1) ||
         (re().is_union(b, b1, eps) && re().is_epsilon(eps)) ||
-        (re().is_union(b, eps, b1) && re().is_epsilon(eps)))
+        (re().is_union(b, eps, b1) && re().is_epsilon(eps))) // FIXME: NOODLER adding length variables from regexes is not beneficial for noodler
     {
         result = m().mk_ite(m().mk_eq(str().mk_length(a), zero()),
             m().mk_true(),

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -4667,9 +4667,9 @@ br_status seq_rewriter::mk_str_in_regexp(expr* a, expr* b, expr_ref& result) {
     }
     expr* b1 = nullptr;
     expr* eps = nullptr;
-    if (false && re().is_opt(b, b1) ||
+    if (false && (re().is_opt(b, b1) ||
         (re().is_union(b, b1, eps) && re().is_epsilon(eps)) ||
-        (re().is_union(b, eps, b1) && re().is_epsilon(eps))) // FIXME: NOODLER adding length variables from regexes is not beneficial for noodler
+        (re().is_union(b, eps, b1) && re().is_epsilon(eps)))) // FIXME: NOODLER adding length variables from regexes is not beneficial for noodler
     {
         result = m().mk_ite(m().mk_eq(str().mk_length(a), zero()),
             m().mk_true(),


### PR DESCRIPTION
There is a rewriter rule for `str.in_re` that for a specific type of regex can introduce length constraints. I noticed it in `hornstr` benchmark set, there were length vars even though the whole formula contained only regexes + equations.