### PR TITLE
Fix: Interface equations for uninterpreted functions

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -1215,8 +1215,11 @@ namespace smt::noodler {
                         result++;
                         ctx.internalize(eq, false);
                         ctx.mark_as_relevant(eq);
-                        // add axiom for the equality
-                        add_axiom(eq);
+                        // Previously we added the equality as a theory axiom here (add_axiom(eq)).
+                        // This forced all interface pairs to become equal immediately, preventing the SAT core
+                        // from exploring assignments where they differ. Instead we only internalize and mark it
+                        // relevant so the core solver may choose (dis)equalities later, and other theory reasoning
+                        // can derive necessary consequences.
                     }
                 }
             }


### PR DESCRIPTION
This pull request fixes the handling of interface equalities in the `smt::noodler` theory's final check logic.