### PR TITLE
Fix: variables in transducer equations

### DIFF
--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -512,6 +512,9 @@ namespace smt::noodler {
             // ignore trivial equations obtained from axiomatization of 
             // transducer constraints, e.g., tmp = replace_all(...)
             if(is_tmp_transducer_eq(ctx.mk_eq_atom(we.first, we.second))) {
+                // add variables to var_name map (the fresh variables are not converted to str.len in length formula otherwise)
+                util::add_vars_to_map(to_app(we.first), this->m, this->m_util_s, this->var_name);
+                util::add_vars_to_map(to_app(we.second), this->m, this->m_util_s, this->var_name);
                 continue;
             }
             Predicate inst = this->conv_eq_pred(ctx.mk_eq_atom(we.first, we.second));

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -85,6 +85,17 @@ namespace smt::noodler::util {
         return m_util_s.is_string(expression->get_sort()) && is_variable(expression);
     }
 
+
+    void add_vars_to_map(app *const ex, ast_manager& m, const seq_util& m_util_s, std::map<BasicTerm, expr_ref>& var_name) {
+        obj_hashtable<expr> vars;
+        util::get_str_variables(ex, m_util_s, m, vars);
+        for(expr * const v : vars) {
+
+            BasicTerm vterm(BasicTermType::Variable, to_app(v)->get_name().str());
+            var_name.insert({vterm, expr_ref(v, m)});
+        }
+    }
+
     void collect_terms(app* const ex, ast_manager& m, const seq_util& m_util_s, obj_map<expr, expr*>& pred_replace,
                        std::map<BasicTerm, expr_ref>& var_name, std::vector<BasicTerm>& terms) {
 

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -215,6 +215,25 @@ namespace smt::noodler::util {
      * @return std::optional<std::vector<mata::Word>> The accepting words or std::nullopt if none exist.
      */
     std::optional<std::vector<mata::Word>> get_word_from_nft(const mata::nft::Nft nft, const std::vector<unsigned>& lengths, const std::set<mata::nft::State>& potentional_initial_states, const std::map<mata::nft::Transition,std::shared_ptr<unsigned>>& num_of_transitions_passes);
+
+    /**
+     * @brief Insert string variables occurring in the given (concat) expression into the provided map.
+     *
+     * Traverses the application @p ex and, for every
+     * encountered string variable, inserts an entry into @p var_name. The key is the corresponding
+     * BasicTerm created from the variable, and the value is the original Z3 expression reference.
+     *
+     * Notes:
+     * - The map is updated in-place; existing entries are preserved.
+     * - Only string variables are considered; non-string terms (ints, regexes, composites) are ignored.
+     * - This helper complements collect_terms(), which also accepts @p var_name for consistent mapping.
+     *
+     * @param ex       Application to inspect (may be a concatenation or a standalone term).
+     * @param m        AST manager used to manage lifetimes of expr_ref values.
+     * @param m_util_s Sequence utilities used to recognize string constructs.
+     * @param[out] var_name Mapping from BasicTerm to the original variable expr; populated/updated by this call.
+     */
+    void add_vars_to_map(app *const ex, ast_manager& m, const seq_util& m_util_s, std::map<BasicTerm, expr_ref>& var_name);
 }
 
 #endif


### PR DESCRIPTION
This pull request introduces a new utility function to fix handling of string variables in transducer-related equations. The main change ensures that fresh string variables generated by transducer constraints are properly tracked and mapped, which is important for downstream length formula.