### PR TITLE
Use ordered `map` and `set` instead of unordered

### DIFF
--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -24,7 +24,7 @@ namespace smt::noodler {
      *   - use at() instead of [] operator for getting the value, use [] only for assigning
      *   - if you want to assign some NFA, use std::make_shared<mata::nfa::Nfa>(NFA)
      */
-    class AutAssignment : public std::unordered_map<BasicTerm, std::shared_ptr<mata::nfa::Nfa>> {
+    class AutAssignment : public std::map<BasicTerm, std::shared_ptr<mata::nfa::Nfa>> {
 
     private:
         /// Union of all alphabets of automata in the aut assignment
@@ -39,7 +39,7 @@ namespace smt::noodler {
         }
 
     public:
-        using std::unordered_map<BasicTerm, std::shared_ptr<mata::nfa::Nfa>>::unordered_map;
+        using std::map<BasicTerm, std::shared_ptr<mata::nfa::Nfa>>::map;
 
         // used for tests, do not use normally
         AutAssignment(std::map<BasicTerm, mata::nfa::Nfa> val) {

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -355,10 +355,10 @@ namespace smt::noodler {
         /**
          * @brief Get all keys from the assignment
          * 
-         * @return std::unordered_set<BasicTerm> Keys
+         * @return std::set<BasicTerm> Keys
          */
-        std::unordered_set<BasicTerm> get_keys() const {
-            std::unordered_set<BasicTerm> ret;
+        std::set<BasicTerm> get_keys() const {
+            std::set<BasicTerm> ret;
             for(const auto & pr : *this) {
                 ret.insert(pr.first);
             }

--- a/src/smt/theory_str_noodler/ca_str_constr.cpp
+++ b/src/smt/theory_str_noodler/ca_str_constr.cpp
@@ -5,7 +5,6 @@
 #include <mata/nfa/delta.hh>
 #include <mata/nfa/nfa.hh>
 #include <mata/applications/strings.hh>
-#include <unordered_map>
 #include <mata/parser/re2parser.hh>
 
 namespace smt::noodler::ca {
@@ -328,7 +327,7 @@ namespace smt::noodler::ca {
         if (this->predicates.size() == 1) {
             size_t original_nfa_size = nfa_with_metadata.nfa.num_of_states();
 
-            std::unordered_map<mata::nfa::State, mata::nfa::State> state_renaming; // Original state -> New state
+            std::map<mata::nfa::State, mata::nfa::State> state_renaming; // Original state -> New state
 
             nfa_with_metadata.nfa.trim(&state_renaming);  // Automaton is modified in-place
 

--- a/src/smt/theory_str_noodler/ca_str_constr.cpp
+++ b/src/smt/theory_str_noodler/ca_str_constr.cpp
@@ -327,7 +327,7 @@ namespace smt::noodler::ca {
         if (this->predicates.size() == 1) {
             size_t original_nfa_size = nfa_with_metadata.nfa.num_of_states();
 
-            std::map<mata::nfa::State, mata::nfa::State> state_renaming; // Original state -> New state
+            mata::nfa::StateRenaming state_renaming; // Original state -> New state
 
             nfa_with_metadata.nfa.trim(&state_renaming);  // Automaton is modified in-place
 

--- a/src/smt/theory_str_noodler/counter_automaton.h
+++ b/src/smt/theory_str_noodler/counter_automaton.h
@@ -248,7 +248,7 @@ namespace smt::noodler::ca {
         TagAutStateMetadata metadata;
 
         // Debugging: color states in the tag automaton according to the variable it originates in
-        std::unordered_map<mata::nfa::State, uint64_t> node_color_map;
+        std::map<mata::nfa::State, uint64_t> node_color_map;
 
         size_t num_of_states_in_row;
 
@@ -278,7 +278,7 @@ namespace smt::noodler::ca {
 
             // Collect all used states so we do not create notes for needless states
             // #Optimize(mhecko): maybe bit_set could be faster
-            std::unordered_set<mata::nfa::State> used_states;
+            std::set<mata::nfa::State> used_states;
             for (mata::nfa::State source_state = 0; source_state < state_cnt; ++source_state) {
                 for (const mata::nfa::SymbolPost &move: nfa.delta[source_state]) {
                     for (mata::nfa::State target_state: move.targets) {

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -124,7 +124,7 @@ namespace smt::noodler {
         std::set<BasicTerm> init_length_sensitive_vars;
         Formula formula;
         AutAssignment init_aut_ass;
-        std::unordered_map<BasicTerm, std::vector<BasicTerm>> init_substitution_map;
+        std::map<BasicTerm, std::vector<BasicTerm>> init_substitution_map;
         ConversionHandler conversion_handler;
         ast_manager& m;
 

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -99,7 +99,7 @@ namespace smt::noodler {
         /**
          * @brief Get the length sensitive variables
          */
-        virtual const std::unordered_set<BasicTerm>& get_init_length_sensitive_vars() const {
+        virtual const std::set<BasicTerm>& get_init_length_sensitive_vars() const {
             throw std::runtime_error("Unimplemented");
         }
 
@@ -121,7 +121,7 @@ namespace smt::noodler {
         SolvingState solution;
 
         // initial length vars, formula, automata assignment and substitution map, can be updated by preprocessing, used for initializing the decision procedure
-        std::unordered_set<BasicTerm> init_length_sensitive_vars;
+        std::set<BasicTerm> init_length_sensitive_vars;
         Formula formula;
         AutAssignment init_aut_ass;
         std::unordered_map<BasicTerm, std::vector<BasicTerm>> init_substitution_map;
@@ -359,7 +359,7 @@ namespace smt::noodler {
          */
         DecisionProcedure(
              Formula formula, AutAssignment init_aut_ass,
-             std::unordered_set<BasicTerm> init_length_sensitive_vars,
+             std::set<BasicTerm> init_length_sensitive_vars,
              const theory_str_noodler_params &par,
              std::vector<TermConversion> conversions,
              ast_manager& m
@@ -396,7 +396,7 @@ namespace smt::noodler {
         /**
          * @brief Get the length sensitive variables
          */
-        const std::unordered_set<BasicTerm>& get_init_length_sensitive_vars() const override {
+        const std::set<BasicTerm>& get_init_length_sensitive_vars() const override {
             return this->init_length_sensitive_vars;
         }
     };

--- a/src/smt/theory_str_noodler/expr_cases.h
+++ b/src/smt/theory_str_noodler/expr_cases.h
@@ -8,8 +8,6 @@
 #include <map>
 #include <memory>
 #include <queue>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "params/smt_params.h"

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -17,12 +17,10 @@
 #include <stdexcept>
 #include <memory>
 #include <cassert>
-#include <unordered_map>
 #include <string>
 #include <string_view>
 #include <set>
 #include <map>
-#include <unordered_set>
 #include <iostream>
 #include <mata/nft/nft.hh>
 

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -57,22 +57,6 @@ namespace smt::noodler {
     }
 
     template<typename T>
-    bool set_disjoint(const std::unordered_set<T>& t1, const std::set<T>& t2) {
-        if (t1.size() < t2.size()) {
-            for(const auto& t : t1) {
-                if(t2.contains(t))
-                    return false;
-            }
-        } else {
-            for(const auto& t : t2) {
-                if(t1.contains(t))
-                    return false;
-            }
-        }
-        return true;
-    }
-
-    template<typename T>
     bool set_disjoint(const std::set<T>& t1, const std::set<T>& t2) {
         if (t1.size() < t2.size()) {
             for(const auto& t : t1) {
@@ -350,7 +334,7 @@ namespace smt::noodler {
         std::vector<Predicate> removed_inclusions_for_model;
 
         LenNode len_formula;
-        std::unordered_set<BasicTerm> len_variables;
+        std::set<BasicTerm> len_variables;
         std::set<BasicTerm> conversion_vars; // all conversion vars should always be also in len vars, also it should not contain literals
 
         const theory_str_noodler_params& m_params;
@@ -381,7 +365,7 @@ namespace smt::noodler {
 
 
     public:
-        FormulaPreprocessor(Formula conj, AutAssignment ass, std::unordered_set<BasicTerm> lv, const theory_str_noodler_params &par, std::set<BasicTerm> conversion_vars) :
+        FormulaPreprocessor(Formula conj, AutAssignment ass, std::set<BasicTerm> lv, const theory_str_noodler_params &par, std::set<BasicTerm> conversion_vars) :
             formula(conj),
             fresh_var_cnt(0),
             aut_ass(ass),
@@ -401,7 +385,7 @@ namespace smt::noodler {
         Dependency get_flat_dependency() const;
         void add_to_len_formula(LenNode len_to_add) { len_formula.succ.push_back(std::move(len_to_add)); }
         const LenNode& get_len_formula() const { return this->len_formula; }
-        const std::unordered_set<BasicTerm>& get_len_variables() const { return this->len_variables; }
+        const std::set<BasicTerm>& get_len_variables() const { return this->len_variables; }
         const std::vector<Predicate>& get_removed_inclusions_for_model() const {return this->removed_inclusions_for_model; }
 
         Formula get_modified_formula() const;

--- a/src/smt/theory_str_noodler/formula_preprocess.h
+++ b/src/smt/theory_str_noodler/formula_preprocess.h
@@ -119,7 +119,7 @@ namespace smt::noodler {
     //----------------------------------------------------------------------------------------------------------------------------------
 
     using ConcatGraphEdges = std::map<std::pair<BasicTerm,BasicTerm>, unsigned>;
-    using SubstitutionMap = std::unordered_map<BasicTerm, std::vector<BasicTerm>>;
+    using SubstitutionMap = std::map<BasicTerm, std::vector<BasicTerm>>;
 
     /**
      * @brief Concatenation graph. Oriented graph where each term (literal/variable) is node and two terms

--- a/src/smt/theory_str_noodler/length_decision_procedure.h
+++ b/src/smt/theory_str_noodler/length_decision_procedure.h
@@ -351,7 +351,7 @@ namespace smt::noodler {
      */
     class LengthDecisionProcedure : public AbstractDecisionProcedure {
     private:
-        std::unordered_set<BasicTerm> init_length_sensitive_vars;
+        std::set<BasicTerm> init_length_sensitive_vars;
         Formula formula;
         AutAssignment init_aut_ass;
         const theory_str_noodler_params& m_params;
@@ -391,7 +391,7 @@ namespace smt::noodler {
          * @param par Parameters for Noodler string theory.
          */
         LengthDecisionProcedure(const Formula &form, AutAssignment init_aut_ass,
-                           const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
+                           const std::set<BasicTerm>& init_length_sensitive_vars,
                            const theory_str_noodler_params& par
          ) : init_length_sensitive_vars{ init_length_sensitive_vars },
              formula { form },
@@ -436,7 +436,7 @@ namespace smt::noodler {
         /**
          * @brief Get the length sensitive variables
          */
-        const std::unordered_set<BasicTerm>& get_init_length_sensitive_vars() const override {
+        const std::set<BasicTerm>& get_init_length_sensitive_vars() const override {
             return this->init_length_sensitive_vars;
         }
     };

--- a/src/smt/theory_str_noodler/memb_heuristics_procedures.h
+++ b/src/smt/theory_str_noodler/memb_heuristics_procedures.h
@@ -22,7 +22,7 @@ namespace smt::noodler {
         const seq_util& m_util_s;
         const ast_manager& m;
         bool produce_model;
-        std::unordered_set<BasicTerm> init_length_vars {};
+        std::set<BasicTerm> init_length_vars {};
 
         std::optional<zstring> model;
     public:
@@ -41,7 +41,7 @@ namespace smt::noodler {
         /**
          * @brief Get the length sensitive variables
          */
-        const std::unordered_set<BasicTerm>& get_init_length_sensitive_vars() const override {
+        const std::set<BasicTerm>& get_init_length_sensitive_vars() const override {
             return this->init_length_vars;
         }
     };
@@ -52,7 +52,7 @@ namespace smt::noodler {
         const seq_util& m_util_s;
         const ast_manager& m;
         bool produce_model;
-        std::unordered_set<BasicTerm> init_length_vars {};
+        std::set<BasicTerm> init_length_vars {};
 
         std::map<BasicTerm, zstring> models;
     public:
@@ -71,7 +71,7 @@ namespace smt::noodler {
         /**
          * @brief Get the length sensitive variables
          */
-        const std::unordered_set<BasicTerm>& get_init_length_sensitive_vars() const override {
+        const std::set<BasicTerm>& get_init_length_sensitive_vars() const override {
             return this->init_length_vars;
         }
     };

--- a/src/smt/theory_str_noodler/nielsen_decision_procedure.h
+++ b/src/smt/theory_str_noodler/nielsen_decision_procedure.h
@@ -349,7 +349,7 @@ namespace smt::noodler {
      */
     class NielsenDecisionProcedure : public AbstractDecisionProcedure {
     private:
-        std::unordered_set<BasicTerm> init_length_sensitive_vars;
+        std::set<BasicTerm> init_length_sensitive_vars;
         Formula formula;
         AutAssignment init_aut_ass;
         const theory_str_noodler_params& m_params;
@@ -445,7 +445,7 @@ namespace smt::noodler {
          * @param par Parameters for Noodler string theory.
          */
         NielsenDecisionProcedure(const Formula &equalities, AutAssignment init_aut_ass,
-                           const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
+                           const std::set<BasicTerm>& init_length_sensitive_vars,
                            const theory_str_noodler_params& par
          ) : init_length_sensitive_vars{ init_length_sensitive_vars },
              formula { equalities },
@@ -487,7 +487,7 @@ namespace smt::noodler {
         /**
          * @brief Get the length sensitive variables
          */
-        const std::unordered_set<BasicTerm>& get_init_length_sensitive_vars() const override {
+        const std::set<BasicTerm>& get_init_length_sensitive_vars() const override {
             return this->init_length_sensitive_vars;
         }
 

--- a/src/smt/theory_str_noodler/parikh_image.h
+++ b/src/smt/theory_str_noodler/parikh_image.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <concepts>
 #include <compare>
+#include <unordered_map>
 
 #include <mata/nfa/nfa.hh>
 #include <mata/nft/nft.hh>

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -8,8 +8,6 @@
 #include <map>
 #include <memory>
 #include <queue>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "params/smt_params.h"

--- a/src/smt/theory_str_noodler/solving_state.cpp
+++ b/src/smt/theory_str_noodler/solving_state.cpp
@@ -97,7 +97,7 @@ namespace smt::noodler {
     }
 
     void SolvingState::flatten_substition_map() {
-        std::unordered_map<BasicTerm, std::vector<BasicTerm>> new_substitution_map;
+        std::map<BasicTerm, std::vector<BasicTerm>> new_substitution_map;
         std::function<std::vector<BasicTerm>(const BasicTerm&)> flatten_var;
 
         flatten_var = [&new_substitution_map, &flatten_var, this](const BasicTerm &var) -> std::vector<BasicTerm> {

--- a/src/smt/theory_str_noodler/solving_state.h
+++ b/src/smt/theory_str_noodler/solving_state.h
@@ -19,7 +19,7 @@ namespace smt::noodler {
         // of the automata from these variables). Each variable is either assigned in aut_ass or
         // substituted in substitution_map, but not both!
         AutAssignment aut_ass;
-        std::unordered_map<BasicTerm, std::vector<BasicTerm>> substitution_map;
+        std::map<BasicTerm, std::vector<BasicTerm>> substitution_map;
 
         // set of inclusions (i.e. Predicate must be of type equations which we pretend is an inclusion) where we are trying to find aut_ass + substitution_map such that they hold
         std::set<Predicate> inclusions;
@@ -44,7 +44,7 @@ namespace smt::noodler {
                      std::set<Predicate> transducers,
                      std::set<Predicate> predicates_not_on_cycle,
                      std::set<BasicTerm> length_sensitive_vars,
-                     std::unordered_map<BasicTerm, std::vector<BasicTerm>> substitution_map)
+                     std::map<BasicTerm, std::vector<BasicTerm>> substitution_map)
                         : aut_ass(aut_ass),
                           substitution_map(substitution_map),
                           inclusions(inclusions),

--- a/src/smt/theory_str_noodler/solving_state.h
+++ b/src/smt/theory_str_noodler/solving_state.h
@@ -34,7 +34,7 @@ namespace smt::noodler {
         std::deque<Predicate> predicates_to_process;
 
         // the variables that have length constraint on them in the rest of formula
-        std::unordered_set<BasicTerm> length_sensitive_vars;
+        std::set<BasicTerm> length_sensitive_vars;
 
 
         SolvingState() = default;
@@ -43,7 +43,7 @@ namespace smt::noodler {
                      std::set<Predicate> inclusions,
                      std::set<Predicate> transducers,
                      std::set<Predicate> predicates_not_on_cycle,
-                     std::unordered_set<BasicTerm> length_sensitive_vars,
+                     std::set<BasicTerm> length_sensitive_vars,
                      std::unordered_map<BasicTerm, std::vector<BasicTerm>> substitution_map)
                         : aut_ass(aut_ass),
                           substitution_map(substitution_map),

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -462,7 +462,7 @@ namespace smt::noodler {
         /**
          * Get initial length variables as a set of @c BasicTerm from their expressions.
          */
-        std::unordered_set<BasicTerm> get_init_length_vars(AutAssignment& ass);
+        std::set<BasicTerm> get_init_length_vars(AutAssignment& ass);
         /**
          * @brief Get the conversions (to/from_int/code) with noodler variables
          * 
@@ -481,7 +481,7 @@ namespace smt::noodler {
          * the original formula is SAT, otherwise we need to run normal decision procedure.
          */
         lbool solve_underapprox(const Formula& instance, const AutAssignment& aut_ass,
-                                const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
+                                const std::set<BasicTerm>& init_length_sensitive_vars,
                                 std::vector<TermConversion> conversions);
 
         /**
@@ -510,7 +510,7 @@ namespace smt::noodler {
          * @param init_length_sensitive_vars Length variables
          * @return true <-> suitable for Nielsen-based decision procedure
          */
-        bool is_nielsen_suitable(const Formula& instance, const std::unordered_set<BasicTerm>& init_length_sensitive_vars) const;
+        bool is_nielsen_suitable(const Formula& instance, const std::set<BasicTerm>& init_length_sensitive_vars) const;
 
         /**
          * @brief Check if the current instance is suitable for underapproximation.
@@ -546,7 +546,7 @@ namespace smt::noodler {
          * @param init_length_sensitive_vars Length sensitive variables
          * @return lbool Outcome of the procedure
          */
-        lbool run_nielsen(const Formula& instance, const AutAssignment& aut_assignment, const std::unordered_set<BasicTerm>& init_length_sensitive_vars);
+        lbool run_nielsen(const Formula& instance, const AutAssignment& aut_assignment, const std::set<BasicTerm>& init_length_sensitive_vars);
 
         /**
          * @brief Wrapper for running the length-based decision procedure. 
@@ -556,7 +556,7 @@ namespace smt::noodler {
          * @param init_length_sensitive_vars Length sensitive variables
          * @return lbool Outcome of the procedure
          */
-        lbool run_length_proc(const Formula& instance, const AutAssignment& aut_assignment, const std::unordered_set<BasicTerm>& init_length_sensitive_vars);
+        lbool run_length_proc(const Formula& instance, const AutAssignment& aut_assignment, const std::set<BasicTerm>& init_length_sensitive_vars);
 
         /**
          * @brief Wrapper for running the mulitple membership query heuristics.
@@ -584,7 +584,7 @@ namespace smt::noodler {
          * @return lbool Outcome of the procedure.
          */
         lbool run_length_sat(const Formula& instance, const AutAssignment& aut_ass,
-                                const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
+                                const std::set<BasicTerm>& init_length_sensitive_vars,
                                 std::vector<TermConversion> conversions);
 
         /**

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -13,8 +13,6 @@ Eternal glory to Yu-Fang.
 #include <map>
 #include <memory>
 #include <queue>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "params/smt_params.h"

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -192,7 +192,7 @@ namespace smt::noodler {
         }
 
         // Get the initial length vars that are needed here (i.e they are in aut_assignment)
-        std::unordered_set<BasicTerm> init_length_sensitive_vars{ get_init_length_vars(aut_assignment) };
+        std::set<BasicTerm> init_length_sensitive_vars{ get_init_length_vars(aut_assignment) };
         STRACE(str,
             tout << "Relevant formula:\n" << instance.to_string();
             for (const auto& conv : conversions) {
@@ -660,8 +660,8 @@ namespace smt::noodler {
         return aut_assignment;
     }
 
-    std::unordered_set<BasicTerm> theory_str_noodler::get_init_length_vars(AutAssignment& ass) {
-        std::unordered_set<BasicTerm> init_lengths{};
+    std::set<BasicTerm> theory_str_noodler::get_init_length_vars(AutAssignment& ass) {
+        std::set<BasicTerm> init_lengths{};
         for (const auto& len : len_vars) {
             BasicTerm v = util::get_variable_basic_term(len);
             if(ass.find(v) != ass.end())
@@ -740,7 +740,7 @@ namespace smt::noodler {
     }
 
     lbool theory_str_noodler::solve_underapprox(const Formula& instance, const AutAssignment& aut_assignment,
-                                                const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
+                                                const std::set<BasicTerm>& init_length_sensitive_vars,
                                                 std::vector<TermConversion> conversions) {
         dec_proc = std::make_shared<DecisionProcedure>(instance, aut_assignment, init_length_sensitive_vars, m_params, conversions, m);
         if (dec_proc->preprocess(PreprocessType::UNDERAPPROX, this->var_eqs.get_equivalence_bt(aut_assignment)) == l_false) {
@@ -842,7 +842,7 @@ namespace smt::noodler {
         STRACE(str_block, tout << __LINE__ << " leave " << __FUNCTION__ << std::endl;);
     }
 
-    bool theory_str_noodler::is_nielsen_suitable(const Formula& instance, const std::unordered_set<BasicTerm>& init_length_sensitive_vars) const {
+    bool theory_str_noodler::is_nielsen_suitable(const Formula& instance, const std::set<BasicTerm>& init_length_sensitive_vars) const {
         if(!this->m_membership_todo_rel.empty() || !this->m_not_contains_todo_rel.empty() || !this->m_conversion_todo.empty() || !this->m_word_diseq_todo_rel.empty() || instance.contains_pred_type(PredicateType::Transducer)) {
             return false;
         }
@@ -886,7 +886,7 @@ namespace smt::noodler {
         return true;
     }
 
-    lbool theory_str_noodler::run_nielsen(const Formula& instance, const AutAssignment& aut_assignment, const std::unordered_set<BasicTerm>& init_length_sensitive_vars) {
+    lbool theory_str_noodler::run_nielsen(const Formula& instance, const AutAssignment& aut_assignment, const std::set<BasicTerm>& init_length_sensitive_vars) {
         STRACE(str, tout << "Trying nielsen" << std::endl);
         dec_proc = std::make_shared<NielsenDecisionProcedure>(instance, aut_assignment, init_length_sensitive_vars, m_params);
         dec_proc->preprocess();
@@ -920,7 +920,7 @@ namespace smt::noodler {
         return l_undef;
     }
 
-    lbool theory_str_noodler::run_length_proc(const Formula& instance, const AutAssignment& aut_assignment, const std::unordered_set<BasicTerm>& init_length_sensitive_vars) {
+    lbool theory_str_noodler::run_length_proc(const Formula& instance, const AutAssignment& aut_assignment, const std::set<BasicTerm>& init_length_sensitive_vars) {
         STRACE(str, tout << "Trying length-based procedure" << std::endl);
         // we need a method get_formula from LengthDecisionProcedure
         std::shared_ptr<LengthDecisionProcedure> len_dec_proc = std::make_shared<LengthDecisionProcedure>(instance, aut_assignment, init_length_sensitive_vars, m_params);
@@ -1097,7 +1097,7 @@ namespace smt::noodler {
     }
 
     lbool theory_str_noodler::run_length_sat(const Formula& instance, const AutAssignment& aut_ass,
-                                const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
+                                const std::set<BasicTerm>& init_length_sensitive_vars,
                                 std::vector<TermConversion> conversions) {
 
         dec_proc = std::make_shared<UnaryDecisionProcedure>(instance, aut_ass, m_params);

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -53,26 +53,6 @@ namespace smt::noodler::util {
         }
     }
 
-    void get_variable_names(expr* const ex, const seq_util& m_util_s, const ast_manager& m, std::unordered_set<std::string>& res) {
-        if(m_util_s.str.is_string(ex)) {
-            return;
-        }
-
-        if(is_variable(ex)) {
-            res.insert(std::to_string(to_app(ex)->get_name()));
-            return;
-        }
-
-        SASSERT(is_app(ex));
-        app* ex_app{ to_app(ex) };
-
-        for(unsigned i = 0; i < ex_app->get_num_args(); i++) {
-            SASSERT(is_app(ex_app->get_arg(i)));
-            app *arg = to_app(ex_app->get_arg(i));
-            get_variable_names(arg, m_util_s, m, res);
-        }
-    }
-
     bool is_variable(const expr* expression) {
         if (!is_app(expression)) {
             return false;

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -89,15 +89,6 @@ namespace smt::noodler::util {
     bool is_variable(const expr* expression);
 
     /**
-     * Get variable names from a given expression @p ex. Append to the output parameter @p res.
-     * @param[in] ex Expression to be checked for variables.
-     * @param[in] m_util_s Seq util for AST.
-     * @param[in] m AST manager.
-     * @param[out] res Vector of found variables (may contain duplicities).
-     */
-    void get_variable_names(expr* ex, const seq_util& m_util_s, const ast_manager& m, std::unordered_set<std::string>& res);
-
-    /**
      * Collect basic terms (vars, literals) from a concatenation @p ex. Append the basic terms to the output parameter
      *  @p terms.
      * @param ex Expression to be checked for basic terms.

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -8,8 +8,6 @@
 #include <map>
 #include <memory>
 #include <queue>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 #include <mata/nft/nft.hh>
 #include <mata/applications/strings.hh>

--- a/src/smt/theory_str_noodler/var_union_find.h
+++ b/src/smt/theory_str_noodler/var_union_find.h
@@ -8,8 +8,6 @@
 #include <map>
 #include <memory>
 #include <queue>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
 #include "params/smt_params.h"

--- a/src/test/noodler/test_utils.h
+++ b/src/test/noodler/test_utils.h
@@ -33,7 +33,7 @@ public:
 class DecisionProcedureCUT : public DecisionProcedure {
 public:
     DecisionProcedureCUT(const Formula &equalities, AutAssignment init_aut_ass,
-                         const std::unordered_set<BasicTerm>& init_length_sensitive_vars,
+                         const std::set<BasicTerm>& init_length_sensitive_vars,
                          ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, const BasicTermEqiv& len_eq_vars, const theory_str_noodler_params& par
     ) : DecisionProcedure(equalities, std::move(init_aut_ass), init_length_sensitive_vars, par, {}, m) {}
 
@@ -81,7 +81,7 @@ inline std::shared_ptr<mata::nfa::Nfa> regex_to_nfa(const std::string& regex) {
     return std::make_shared<mata::nfa::Nfa>(aut);
 }
 
-inline std::map<BasicTerm, expr_ref> create_var_map(const std::unordered_set<BasicTerm>& vars, ast_manager& m, seq_util& m_util_s) {
+inline std::map<BasicTerm, expr_ref> create_var_map(const std::set<BasicTerm>& vars, ast_manager& m, seq_util& m_util_s) {
     std::map<BasicTerm, expr_ref> ret;
 
     for(const BasicTerm& v : vars) {


### PR DESCRIPTION
I changed most occurences of `std::unordered_map` or `std::unordered_set` to `std::map` or `std::set` so the behaviour is more deterministic.