### PR TITLE
Nicer models

### DIFF
--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -13,6 +13,45 @@ namespace {
 
 namespace smt::noodler::regex {
 
+    mata::Symbol Alphabet::get_unused_symbol() const {
+        if (alphabet.size() == zstring::max_char()) {
+            // alphabet is full, we throw error (TODO: should probably return nullopt or something like that)
+            util::throw_error("Trying to get a fresh symbol in full alphabet");
+            return 0; // this is unreachable, return something so we can compile
+        }
+
+        // We want to find first "nice" character where we go in this order
+        //  - lowercase a-z
+        //  - uppercase A-Z
+        //  - digits 0-9
+        //  - printable ASCII characters except space
+        //  - space
+        //  - ASCII control codes 0-31
+        //  - ASCII control code DEL (127)
+        //  - anything over 127, always incrementing by one
+        auto get_next_symbol = [](const mata::Symbol s) {
+            if (s == zstring::max_char()) { util::throw_error("Trying to get a fresh symbol in full alphabet"); return mata::Symbol{0}; }
+            else if (s == 'z') { return mata::Symbol{'A'}; } // lowercase is followed by uppercase
+            else if (s == 'Z') { return mata::Symbol{'0'}; } // uppercase is followed by digits
+            else if (s == '9') { return mata::Symbol{33}; } // digits are followed by printable ASCII characters (starting with '!')
+            else if (s == 47) { return mata::Symbol{58}; } // we are in printable ASCII characters, jumping over digits 0-9
+            else if (s == 64) { return mata::Symbol{91}; } // we are in printable ASCII characters, jumping over uppercase A-Z
+            else if (s == 96) { return mata::Symbol{123}; } // we are in printable ASCII characters, jumping over lowercase a-z
+            else if (s == 126) { return mata::Symbol{32}; } // last printable ASCII character, return space
+            else if (s == 32) { return mata::Symbol{0}; } // space is followed by ASCII contol codes 0-31
+            else if (s == 31) { return mata::Symbol{127}; } // last control code in 0-31 followed by DEL (127)
+            else { return s+1; }
+        };
+
+        mata::Symbol current_symbol{'a'}; // start with 'a'
+
+        while (alphabet.contains(current_symbol)) {
+            current_symbol = get_next_symbol(current_symbol);
+        }
+
+        return current_symbol;
+    }
+
     void extract_symbols(expr* const ex, const seq_util& m_util_s, std::set<uint32_t>& alphabet) {
         if (m_util_s.str.is_string(ex)) {
             auto ex_app{ to_app(ex) };

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -64,30 +64,7 @@ namespace smt::noodler::regex {
         }
 
         /// @brief Returns any symbol that is not in the alphabet
-        mata::Symbol get_unused_symbol() const {
-            if (alphabet.size() == zstring::max_char()) {
-                // alphabet is full, we throw error (TODO: should probably return nullopt or something like that)
-                util::throw_error("Trying to get a fresh symbol in full alphabet");
-                return 0; // this is unreachable, return something so we can compile
-            }
-            // std::set is ordered, so alphabet is also ordered
-            if (alphabet.empty() || *alphabet.begin() != 0) {
-                return 0;
-            } else {
-                auto it = alphabet.begin();
-                while (true) {
-                    auto old_it = it++;
-                    // we are trying to find two values in alphabet that have something inbetween,
-                    // i.e., they differ more than by one, or if no such space exists, the last
-                    // symbol will not be max_char() (because of the test at the beginning of the
-                    // function), so we can return the value one larger
-                    if ((*old_it)+1 != *it // the values at old_it and at it differ by more than one
-                      || it == alphabet.end()) {
-                        return (*old_it)+1;
-                    }
-                }
-            }
-        }
+        mata::Symbol get_unused_symbol() const;
 
         /// @brief Return zstring corresponding the the word @p word, where dummy symbol is replaced with some valid symbol not in the alphabet.
         zstring get_string_from_mata_word(mata::Word word) const {


### PR DESCRIPTION
This PR rewrites function for replacing dummy symbol.
Before, we always started from ASCII symbol 0, getting models like `"\u{0}"` which is not really nice. Instead, we now replace them with(if possible) printable ASCII characters, starting with lowercase, then uppercase letters, followed by digits and then other printable characters.