### PR TITLE
Use only `regex::Alphabet` for representing alphabets (nearly) everywhere

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -2288,19 +2288,14 @@ void seq_rewriter::replace_all_subvectors(expr_ref_vector const& a, expr_ref_vec
 br_status seq_rewriter::replace_re_version(expr* a, expr* b, expr* c, expr_ref& result, bool is_all_version) {
     zstring s1, s2;
     if (str().is_string(a, s1) && str().is_string(c, s2) && u().is_re(b)) {
-        std::set<mata::Symbol> symbols;
-        smt::noodler::regex::extract_symbols(a, u(), symbols);
-        smt::noodler::regex::extract_symbols(b, u(), symbols);
-        smt::noodler::regex::Alphabet alph(symbols);
-        mata::EnumAlphabet mata_alph{};
-        for(const mata::Symbol& symb : symbols) {
-            mata_alph.add_new_symbol(symb);
-        }
+        smt::noodler::regex::Alphabet alph;
+        smt::noodler::regex::extract_symbols(a, u(), alph);
+        smt::noodler::regex::extract_symbols(b, u(), alph);
         mata::nfa::Nfa find_nfa = conv_to_nfa(to_app(b), u(), m(), alph); // this should throw error/unknown if b is a regex variable (so we can assume it is regex constant)
         mata::nft::Nft transducer = mata::applications::strings::replace::replace_reluctant_regex(
                                             mata::nfa::determinize(find_nfa),
                                             smt::noodler::util::get_mata_word_zstring(s2),
-                                            &mata_alph,
+                                            &alph.get_mata_alphabet(),
                                             is_all_version ?
                                                 mata::applications::strings::replace::ReplaceMode::All :
                                                 mata::applications::strings::replace::ReplaceMode::Single);

--- a/src/smt/theory_str_noodler/aut_assignment.cpp
+++ b/src/smt/theory_str_noodler/aut_assignment.cpp
@@ -223,31 +223,12 @@ namespace smt::noodler {
         return flat;
     }
 
-    mata::Symbol AutAssignment::add_fresh_symbol_to_alphabet() {
-        mata::Symbol new_symbol = regex::Alphabet(alphabet).get_unused_symbol();
-        this->alphabet.insert(new_symbol);
-        return new_symbol;
-    }
-
-
-    void AutAssignment::add_symbol_from_dummy(mata::Symbol sym) {
-        if(alphabet.contains(sym)) { return; }
-        bool is_there_some_dummy = false;
-        for (auto& [var, nfa] : *this) {
-            for (mata::nfa::State state = 0; state < nfa->num_of_states(); ++state) {
-                const mata::nfa::StatePost& delta_from_state = nfa->delta[state];
-                if (!delta_from_state.empty() && delta_from_state.back().symbol == util::get_dummy_symbol()) { // dummy symbol should be largest (we do not have epsilons), so should be at the back
-                    is_there_some_dummy = true;
-                    nfa->delta.add(state, sym, nfa->delta[state].back().targets);
-                }
-            }
-        }
-        if (is_there_some_dummy) {
-            alphabet.insert(sym);
-        }
-    }
-
     bool AutAssignment::replace_dummy_with_symbols(std::set<mata::Symbol> symbols) {
+        SASSERT(alphabet.contains(util::get_dummy_symbol()));
+        alphabet.erase(util::get_dummy_symbol());
+        for (const mata::Symbol symbol : symbols) {
+            alphabet.insert(symbol);
+        }
         bool is_there_some_dummy = false;
         for (auto& [var, nfa] : *this) {
             for (mata::nfa::State state = 0; state < nfa->num_of_states(); ++state) {
@@ -269,9 +250,9 @@ namespace smt::noodler {
     }
 
     std::optional<mata::Symbol> AutAssignment::replace_dummy_with_new_symbol() {
+        SASSERT(alphabet.contains(util::get_dummy_symbol()));
         mata::Symbol new_symbol = regex::Alphabet(alphabet).get_unused_symbol();
         if (replace_dummy_with_symbols({new_symbol})) {
-            alphabet.insert(new_symbol);
             return new_symbol;
         } else {
             return std::nullopt;

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -14,6 +14,7 @@
 #include <mata/nfa/builder.hh>
 
 #include "formula.h"
+#include "regex.h"
 
 namespace smt::noodler {
 
@@ -28,7 +29,7 @@ namespace smt::noodler {
 
     private:
         /// Union of all alphabets of automata in the aut assignment
-        std::set<mata::Symbol> alphabet;
+        regex::Alphabet alphabet;
 
         void update_alphabet() {
             this->alphabet.clear();
@@ -224,7 +225,7 @@ namespace smt::noodler {
             }
         }
 
-        const std::set<mata::Symbol>& get_alphabet() const {
+        const regex::Alphabet& get_alphabet() const {
             return this->alphabet;
         }
 

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -42,6 +42,8 @@ namespace smt::noodler {
     public:
         using std::unordered_map<BasicTerm, std::shared_ptr<mata::nfa::Nfa>>::unordered_map;
 
+        AutAssignment(regex::Alphabet alph) : alphabet(std::move(alph)) { }
+
         // used for tests, do not use normally
         AutAssignment(std::map<BasicTerm, mata::nfa::Nfa> val) {
             for (const auto &key_value : val) {
@@ -229,11 +231,8 @@ namespace smt::noodler {
             return this->alphabet;
         }
 
-        void set_alphabet(const std::set<uint32_t>& alphabet) {
-            this->alphabet.clear();
-            for (const auto& symbol : alphabet) {
-                this->alphabet.insert(symbol);
-            }
+        void set_alphabet(regex::Alphabet alph) {
+            this->alphabet = std::move(alph);
         }
 
         void add_symbol_to_alphabet(mata::Symbol s) {

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -239,11 +239,6 @@ namespace smt::noodler {
             this->alphabet.insert(s);
         }
 
-        mata::Symbol add_fresh_symbol_to_alphabet();
-
-        /// @brief Add symbol @p s to alphabet and removes it from dummy symbol (i.e. adds transitions trough @p s in all automata if there is transition trough dummy symbol)
-        void add_symbol_from_dummy(mata::Symbol s);
-
         bool replace_dummy_with_symbols(std::set<mata::Symbol> symbols);
 
         /**

--- a/src/smt/theory_str_noodler/aut_assignment.h
+++ b/src/smt/theory_str_noodler/aut_assignment.h
@@ -260,12 +260,7 @@ namespace smt::noodler {
          * @return true Is complement of a finite language
          */
         bool is_co_finite(const BasicTerm& t) const {
-            mata::OnTheFlyAlphabet mata_alphabet{};
-            for (const auto& symbol : this->alphabet) {
-                mata_alphabet.add_new_symbol(std::to_string(symbol), symbol);
-            }
-
-            mata::nfa::Nfa cmp = mata::nfa::minimize(mata::nfa::complement(*(*this).at(t), mata_alphabet));
+            mata::nfa::Nfa cmp = mata::nfa::minimize(mata::nfa::complement(*(*this).at(t), alphabet.get_mata_alphabet()));
             return cmp.trim().is_acyclic();
         }
 
@@ -407,11 +402,7 @@ namespace smt::noodler {
          * @return mata::nfa::Nfa 
          */
         mata::nfa::Nfa complement_aut(const mata::nfa::Nfa& aut) const {
-            mata::OnTheFlyAlphabet mata_alphabet{};
-            for (const auto& symbol : get_alphabet()) {
-                mata_alphabet.add_new_symbol(std::to_string(symbol), symbol);
-            }
-            return mata::nfa::complement(aut, mata_alphabet);
+            return mata::nfa::complement(aut, alphabet.get_mata_alphabet());
         }
 
         /**

--- a/src/smt/theory_str_noodler/conversion_handler.h
+++ b/src/smt/theory_str_noodler/conversion_handler.h
@@ -128,7 +128,7 @@ namespace smt::noodler {
         LenNode get_formula_for_int_real_conversion(const TermConversion& conv);
 
     public:
-        ConversionHandler(std::vector<TermConversion> conversions, unsigned underapprox_length) : conversions(conversions), underapprox_length(underapprox_length), only_digits(AutAssignment::digit_automaton_with_epsilon()), real_numbers(AutAssignment::decimal_automaton()) {
+        ConversionHandler(std::vector<TermConversion> conversions, unsigned underapprox_length) : conversions(conversions), only_digits(AutAssignment::digit_automaton_with_epsilon()), real_numbers(AutAssignment::decimal_automaton()), underapprox_length(underapprox_length) {
         };
 
         /// Gets a solution for which we want to compute the LIA formula (can be called multiple times to get formula for different solutions)

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -1183,19 +1183,21 @@ namespace smt::noodler {
                     // the code value is not a symbol of an alphabet, therefore it is "hidden" in a dummy symbol
                     // we want to "unhide" it, and make it explicit
                     set_of_symbols_to_replace_dummy_symbol_with.insert(to_code_value_as_symbol);
-                    solution.aut_ass.add_symbol_to_alphabet(to_code_value.get_unsigned());
                 }
                 update_model_and_aut_ass(var, zstring(to_code_value.get_unsigned())); // zstring(unsigned) returns char with the code point of the argument
             } // for the case to_code_value == -1 we should have (str.len var) != 1, this restriction will be sorted out further
         }
 
-        // if there is no symbol from code-point conversions, we add a fresh one instead
-        if (set_of_symbols_to_replace_dummy_symbol_with.empty()) {
-            set_of_symbols_to_replace_dummy_symbol_with.insert(solution.aut_ass.add_fresh_symbol_to_alphabet());
+        if (solution.aut_ass.get_alphabet().contains(util::get_dummy_symbol())) {
+            // if there is no symbol from code-point conversions, we add a fresh one instead
+            if (set_of_symbols_to_replace_dummy_symbol_with.empty()) {
+                set_of_symbols_to_replace_dummy_symbol_with.insert(solution.aut_ass.get_alphabet().get_unused_symbol());
+            }
+
+            // we can now replace dummy symbol in automata
+            solution.aut_ass.replace_dummy_with_symbols(set_of_symbols_to_replace_dummy_symbol_with);
         }
 
-        // we can now replace dummy symbol in automata
-        solution.aut_ass.replace_dummy_with_symbols(set_of_symbols_to_replace_dummy_symbol_with);
         // we have to also replace dummy symbol in transducers
         // TODO it is incorrect, dummy symbols need to be replaced on the level of transducer transitions, not on nfa transitions (works only if there is one symbol to replace with)
         solution.replace_dummy_symbol_in_transducers_with(set_of_symbols_to_replace_dummy_symbol_with);

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -289,6 +289,7 @@ namespace smt::noodler {
 
             /// Replaces transitions with dummy symbol in @c nft and @c transition_to_var by new transitions with the symbols from @p set_of_symbols_to_replace_dummy_symbol_with and maps them to the same var
             void replace_dummy_symbol(const std::set<mata::Symbol>& set_of_symbols_to_replace_dummy_symbol_with) {
+                if (set_of_symbols_to_replace_dummy_symbol_with.empty()) { return; }
                 if (set_of_symbols_to_replace_dummy_symbol_with.size() > 1) {
                     // TODO fix this? if we had more dummy symbols, for code-points vars, we can only have transitions with the correct code-point value
                     util::throw_error("We cannot replace dummy symbol by more than one symbol in transducers yet");

--- a/src/smt/theory_str_noodler/formula.h
+++ b/src/smt/theory_str_noodler/formula.h
@@ -39,7 +39,7 @@ namespace smt::noodler {
         Transducer, 
     };
 
-    [[nodiscard]] static std::string to_string(PredicateType predicate_type) {
+    [[nodiscard, maybe_unused]] static inline std::string to_string(PredicateType predicate_type) {
         switch (predicate_type) {
             case PredicateType::Equation:
                 return "Equation";
@@ -61,7 +61,7 @@ namespace smt::noodler {
         Length, // numeral literal
     };
 
-    [[nodiscard]] static std::string to_string(BasicTermType term_type) {
+    [[nodiscard, maybe_unused]] static inline std::string to_string(BasicTermType term_type) {
         switch (term_type) {
             case BasicTermType::Variable:
                 return "Variable";
@@ -110,19 +110,19 @@ namespace smt::noodler {
         zstring name;
     }; // Class BasicTerm.
 
-    [[nodiscard]] static std::string to_string(const BasicTerm& basic_term) {
+    [[nodiscard, maybe_unused]] static inline std::string to_string(const BasicTerm& basic_term) {
         return basic_term.to_string();
     }
 
 
-    static std::ostream& operator<<(std::ostream& os, const BasicTerm& basic_term) {
+    [[maybe_unused]] static inline std::ostream& operator<<(std::ostream& os, const BasicTerm& basic_term) {
         os << basic_term.to_string();
         return os;
     }
 
-    static bool operator==(const BasicTerm& lhs, const BasicTerm& rhs) { return lhs.equals(rhs); }
-    static bool operator!=(const BasicTerm& lhs, const BasicTerm& rhs) { return !(lhs == rhs); }
-    static bool operator<(const BasicTerm& lhs, const BasicTerm& rhs) {
+    static inline bool operator==(const BasicTerm& lhs, const BasicTerm& rhs) { return lhs.equals(rhs); }
+    static inline bool operator!=(const BasicTerm& lhs, const BasicTerm& rhs) { return !(lhs == rhs); }
+    static inline bool operator<(const BasicTerm& lhs, const BasicTerm& rhs) {
         if (lhs.get_type() < rhs.get_type()) {
             return true;
         } else if (lhs.get_type() > rhs.get_type()) {
@@ -134,7 +134,7 @@ namespace smt::noodler {
         }
         return false;
     }
-    static bool operator>(const BasicTerm& lhs, const BasicTerm& rhs) { return !(lhs < rhs); }
+    static inline bool operator>(const BasicTerm& lhs, const BasicTerm& rhs) { return !(lhs < rhs); }
 
     [[nodiscard]] static std::string to_string(const std::vector<BasicTerm>& vec, const std::string& delimiter = " ") {
         if(vec.empty()) return "";
@@ -145,7 +145,7 @@ namespace smt::noodler {
         return ret;
     }
 
-    static std::ostream& operator<<(std::ostream& os, const std::vector<BasicTerm>& vec) {
+    [[maybe_unused]] static inline std::ostream& operator<<(std::ostream& os, const std::vector<BasicTerm>& vec) {
         os << to_string(vec);
         return os;
     }
@@ -203,7 +203,7 @@ namespace smt::noodler {
         LenNode(LenFormulaType tp, std::vector<struct LenNode> s = {}) : type(tp), atom_val(BasicTerm(BasicTermType::Length)), succ(s) { };
     };
 
-    static std::ostream& operator<<(std::ostream& os, const LenNode& node) {
+    static inline std::ostream& operator<<(std::ostream& os, const LenNode& node) {
         auto children_iterator = node.succ.begin(); // Some nodes, e.g., quantifiers would like to consume successor nodes
         bool was_opening_parenthesis_emitted = true;
 
@@ -789,11 +789,11 @@ namespace smt::noodler {
         }
     }; // Class Predicate.
 
-    [[nodiscard]] static std::string to_string(const Predicate& predicate) {
+    [[nodiscard, maybe_unused]] static inline std::string to_string(const Predicate& predicate) {
         return predicate.to_string();
     }
 
-    static std::ostream& operator<<(std::ostream& os, const Predicate& predicate) {
+    [[maybe_unused]] static inline std::ostream& operator<<(std::ostream& os, const Predicate& predicate) {
         os << predicate.to_string();
         return os;
     }
@@ -941,12 +941,12 @@ namespace smt::noodler {
         }
     }; // Class Formula.
 
-    static bool operator==(const Formula& lhs, const Formula& rhs) { return lhs.get_predicates() == rhs.get_predicates(); }
-    static bool operator!=(const Formula& lhs, const Formula& rhs) { return !(lhs == rhs); }
-    static bool operator<(const Formula& lhs, const Formula& rhs) {
+    [[nodiscard]] static inline bool operator==(const Formula& lhs, const Formula& rhs) { return lhs.get_predicates() == rhs.get_predicates(); }
+    [[nodiscard, maybe_unused]] static inline bool operator!=(const Formula& lhs, const Formula& rhs) { return !(lhs == rhs); }
+    [[nodiscard]] static inline bool operator<(const Formula& lhs, const Formula& rhs) {
        return lhs.get_predicates() < rhs.get_predicates();
     }
-    static bool operator>(const Formula& lhs, const Formula& rhs) { return !(lhs < rhs); }
+    [[nodiscard, maybe_unused]] static inline bool operator>(const Formula& lhs, const Formula& rhs) { return !(lhs < rhs); }
 
     // Conversions of strings to ints/code values and vice versa
     enum class ConversionType {

--- a/src/smt/theory_str_noodler/length_decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/length_decision_procedure.cpp
@@ -760,7 +760,7 @@ namespace smt::noodler {
 
 
     LengthProcModel::LengthProcModel(const ConstraintPool& block_pool, const SubstitutionMap& subst, const AutAssignment& aut_ass, const std::set<BasicTerm>& multi_var_set) : model(), subst_map(subst), aut_ass(aut_ass), block_pool(block_pool), multi_var_set(multi_var_set) {
-        if(aut_ass.get_alphabet().size() != 0) {
+        if(aut_ass.get_alphabet().size() != 0 && aut_ass.get_alphabet().contains(util::get_dummy_symbol())) {
             this->aut_ass.replace_dummy_with_new_symbol();
         }
         std::set<BasicTerm> len_vars{};

--- a/src/smt/theory_str_noodler/memb_heuristics_procedures.cpp
+++ b/src/smt/theory_str_noodler/memb_heuristics_procedures.cpp
@@ -24,15 +24,15 @@ namespace smt::noodler {
                 // the universal automaton (as complementation can blow up)
 
                 // create alphabet (start with minterm representing symbols not ocurring in the regex)
-                std::set<mata::Symbol> symbols_in_regex{util::get_dummy_symbol()};
-                regex::extract_symbols(regex, m_util_s, symbols_in_regex);
-                regex::Alphabet alph(symbols_in_regex);
+                regex::Alphabet alph;
+                regex::extract_symbols(regex, m_util_s, alph);
+                alph.insert_dummy_if_not_full();
 
                 mata::nfa::Nfa nfa{ regex::conv_to_nfa(to_app(regex), m_util_s, m, alph, false, false) };
 
                 if (produce_model) {
                     mata::nfa::Run model_run;
-                    if(mata::nfa::algorithms::is_universal_antichains(nfa, alph.mata_alphabet, &model_run)) {
+                    if(mata::nfa::algorithms::is_universal_antichains(nfa, alph.get_mata_alphabet(), &model_run)) {
                         // x does not belong to universal automaton -> it must be unsat
                         return l_false;
                     } else {
@@ -41,7 +41,7 @@ namespace smt::noodler {
                         return l_true;
                     }
                 } else {
-                    if(mata::nfa::algorithms::is_universal_antichains(nfa, alph.mata_alphabet, nullptr)) {
+                    if(mata::nfa::algorithms::is_universal_antichains(nfa, alph.get_mata_alphabet(), nullptr)) {
                         return l_false;
                     } else {
                         return l_true;
@@ -69,9 +69,9 @@ namespace smt::noodler {
         // TODO try handling also complement of regex directly
 
         // create alphabet (start with minterm representing symbols not ocurring in the regex)
-        std::set<mata::Symbol> symbols_in_regex{util::get_dummy_symbol()};
-        regex::extract_symbols(regex, m_util_s, symbols_in_regex);
-        regex::Alphabet alph(symbols_in_regex);
+        regex::Alphabet alph;
+        regex::extract_symbols(regex, m_util_s, alph);
+        alph.insert_dummy_if_not_full();
 
         mata::nfa::Nfa reg_nfa = regex::conv_to_nfa(to_app(regex), m_util_s, m, alph, false, false);
 
@@ -79,7 +79,7 @@ namespace smt::noodler {
         if (is_regex_positive) {
             word = reg_nfa.get_word().value();
         } else {
-            word = reg_nfa.get_word_from_complement(&alph.mata_alphabet).value();
+            word = reg_nfa.get_word_from_complement(&alph.get_mata_alphabet()).value();
         }
         return alph.get_string_from_mata_word(word);
     }
@@ -104,7 +104,7 @@ namespace smt::noodler {
             // Compute intersection L of all regexes that should not be complemented
             mata::nfa::Nfa intersection(1, {0}, {0});
             // initalize to universal automaton
-            for (const mata::Symbol& symb : alph.alphabet) {
+            for (const mata::Symbol& symb : alph) {
                 intersection.delta.add(0, symb, 0);
             }
 

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -52,7 +52,7 @@ namespace smt::noodler::regex {
         return current_symbol;
     }
 
-    void extract_symbols(expr* const ex, const seq_util& m_util_s, std::set<uint32_t>& alphabet) {
+    void extract_symbols(expr* const ex, const seq_util& m_util_s, Alphabet& alphabet) {
         if (m_util_s.str.is_string(ex)) {
             auto ex_app{ to_app(ex) };
             SASSERT(ex_app->get_num_parameters() == 1);
@@ -243,7 +243,7 @@ namespace smt::noodler::regex {
                         // According to make_complement, we do complement at the end, so we just invert it
                         make_complement = !make_complement;
                     } else {
-                        result = mata::nfa::complement(result, alphabet.mata_alphabet, {{"algorithm", "classical"}});
+                        result = mata::nfa::complement(result, alphabet.get_mata_alphabet(), {{"algorithm", "classical"}});
                     }
                 } else if (m_util_s.re.is_derivative(cur_expr)) { // Handle derivative.
                     util::throw_error("derivative is unsupported");
@@ -252,7 +252,7 @@ namespace smt::noodler::regex {
                 } else if (m_util_s.re.is_dot_plus(cur_expr)) { // Handle dot plus.
                     result.initial.insert(0);
                     result.final.insert(1);
-                    for (const auto& symbol : alphabet.alphabet) {
+                    for (const auto& symbol : alphabet) {
                         result.delta.add(0, symbol, 1);
                         result.delta.add(1, symbol, 1);
                     }
@@ -263,13 +263,13 @@ namespace smt::noodler::regex {
                 } else if (m_util_s.re.is_full_char(cur_expr)) { // Handle full char (single occurrence of any string symbol, '.').
                     result.initial.insert(0);
                     result.final.insert(1);
-                    for (const auto& symbol : alphabet.alphabet) {
+                    for (const auto& symbol : alphabet) {
                         result.delta.add(0, symbol, 1);
                     }
                 } else if (m_util_s.re.is_full_seq(cur_expr)) {
                     result.initial.insert(0);
                     result.final.insert(0);
-                    for (const auto& symbol : alphabet.alphabet) {
+                    for (const auto& symbol : alphabet) {
                         result.delta.add(0, symbol, 0);
                     }
                 } else if (m_util_s.re.is_intersection(cur_expr)) { // Handle intersection.
@@ -314,7 +314,7 @@ namespace smt::noodler::regex {
                             // ... or empty language
                             result = std::move(body_nfa);
                         }
-                    } else if(body_nfa.is_universal(alphabet.mata_alphabet)) {
+                    } else if(body_nfa.is_universal(alphabet.get_mata_alphabet())) {
                         result = std::move(body_nfa);
                     } else {
                         body_nfa.unify_final();
@@ -457,7 +457,7 @@ namespace smt::noodler::regex {
         // Whether to create complement of the final automaton.
         if (make_complement) {
             STRACE(str_create_nfa, tout << "Complemented NFA:" << std::endl;);
-            final_result = mata::nfa::complement(final_result, alphabet.mata_alphabet, { 
+            final_result = mata::nfa::complement(final_result, alphabet.get_mata_alphabet(), { 
                 {"algorithm", "classical"}, 
                 //{"minimize", "true"} // it seems that minimizing during complement causes more TOs in benchmarks
                 });
@@ -936,7 +936,7 @@ namespace smt::noodler::regex {
         return true;
     }
 
-    mata::nft::Nft ReplaceAllPrefixTree::create_transducer(mata::Alphabet* mata_alph) {
+    mata::nft::Nft ReplaceAllPrefixTree::create_transducer(const regex::Alphabet& alph) {
         // We will basically construct a product of prefix tree with identity transducer, but
         // for the matched finds in the prefix tree, we replace them with their corresponding replaces.
         // The state 0 is initial and final state that will have loops containing the replace operations
@@ -980,7 +980,7 @@ namespace smt::noodler::regex {
             //  - continue reading
             //  - finish reading and print the replacing word to second tape
             //  - fail reading (it does not match any replace operation) and print already read word to second tape
-            for (mata::Symbol symbol : mata_alph->get_alphabet_symbols()) {
+            for (mata::Symbol symbol : alph) {
                 auto symbol_transition_it = prefix_automaton.delta[prefix_state].find(symbol);
                 if (auto next_prefix_state = get_next_state(prefix_state, symbol)) {
                     // symbol is in the prefix tree
@@ -1026,7 +1026,7 @@ namespace smt::noodler::regex {
         return result;
     }
 
-    void gather_transducer_constraints(app* ex, ast_manager& m, const seq_util& m_util_s, obj_map<expr, expr*>& pred_replace, std::map<BasicTerm, expr_ref>& var_name, mata::Alphabet* mata_alph, Formula& transducer_preds) {
+    void gather_transducer_constraints(app* ex, ast_manager& m, const seq_util& m_util_s, obj_map<expr, expr*>& pred_replace, std::map<BasicTerm, expr_ref>& var_name, const regex::Alphabet& alph, Formula& transducer_preds) {
         if (m_util_s.str.is_string(ex)) { // Handle string literals.
             return;
         }
@@ -1034,7 +1034,7 @@ namespace smt::noodler::regex {
         if (util::is_variable(ex)) {
             for (const auto& key_value : pred_replace) {
                 if (to_app(key_value.m_value) == ex) {
-                    gather_transducer_constraints(to_app(key_value.m_key), m, m_util_s, pred_replace, var_name, mata_alph, transducer_preds);
+                    gather_transducer_constraints(to_app(key_value.m_key), m, m_util_s, pred_replace, var_name, alph, transducer_preds);
                 }
             }
             return;
@@ -1043,8 +1043,8 @@ namespace smt::noodler::regex {
         expr * a1 = nullptr, *a2 = nullptr, *a3 = nullptr;
 
         if (m_util_s.str.is_concat(ex, a1, a2)) {
-            gather_transducer_constraints(to_app(a1), m, m_util_s, pred_replace, var_name, mata_alph, transducer_preds);
-            gather_transducer_constraints(to_app(a2), m, m_util_s, pred_replace, var_name, mata_alph, transducer_preds);
+            gather_transducer_constraints(to_app(a1), m, m_util_s, pred_replace, var_name, alph, transducer_preds);
+            gather_transducer_constraints(to_app(a2), m, m_util_s, pred_replace, var_name, alph, transducer_preds);
             return;
         }
 
@@ -1083,9 +1083,6 @@ namespace smt::noodler::regex {
                 }
 
                 // construct NFA corresponding to the regex find
-                auto ov = mata_alph->get_alphabet_symbols();
-                std::set<mata::Symbol> syms(ov.begin(), ov.end());
-                Alphabet alph(syms);
                 mata::nfa::Nfa find_nfa = conv_to_nfa(to_app(a2), m_util_s, m, alph);
 
                 find_and_replace.emplace_back(find_nfa, replace);
@@ -1097,7 +1094,7 @@ namespace smt::noodler::regex {
 
         if (!find_and_replace.empty()) {
             // recursively call on nested parameters
-            gather_transducer_constraints(ex, m, m_util_s, pred_replace, var_name, mata_alph, transducer_preds);
+            gather_transducer_constraints(ex, m, m_util_s, pred_replace, var_name, alph, transducer_preds);
 
             // collect and replace replace_(re)_all argument with a concatenation of basic terms
             std::vector<BasicTerm> side {};
@@ -1106,7 +1103,7 @@ namespace smt::noodler::regex {
             // iterate backwards and construct transducer representing the replace operations
             auto backward_iterator = find_and_replace.rbegin();
             auto backward_iterator_end = find_and_replace.rend();
-            auto get_next_transducer = [&mata_alph,&backward_iterator,&backward_iterator_end]() {
+            auto get_next_transducer = [&alph, &backward_iterator, &backward_iterator_end]() {
                 auto backward_iterator_old = backward_iterator;
                 ReplaceAllPrefixTree prefix_tree;
                 while (backward_iterator != backward_iterator_end
@@ -1116,14 +1113,14 @@ namespace smt::noodler::regex {
                 }
 
                 if (backward_iterator != backward_iterator_old) {
-                    return mata::nft::reduce(prefix_tree.create_transducer(mata_alph)).trim();
+                    return mata::nft::reduce(prefix_tree.create_transducer(alph)).trim();
                 } else {
                     auto& find = backward_iterator->first;
                     zstring& replace = backward_iterator->second;
                     SASSERT(backward_iterator != backward_iterator_end);
                     mata::nft::Nft result = std::holds_alternative<zstring>(find) ?
-                                                mata::applications::strings::replace::replace_reluctant_literal(util::get_mata_word_zstring(std::get<zstring>(find)), util::get_mata_word_zstring(replace), mata_alph)
-                                              : mata::applications::strings::replace::replace_reluctant_regex(mata::nfa::determinize(std::get<mata::nfa::Nfa>(find)), util::get_mata_word_zstring(replace), mata_alph);
+                                                mata::applications::strings::replace::replace_reluctant_literal(util::get_mata_word_zstring(std::get<zstring>(find)), util::get_mata_word_zstring(replace), &alph.get_mata_alphabet())
+                                              : mata::applications::strings::replace::replace_reluctant_regex(mata::nfa::determinize(std::get<mata::nfa::Nfa>(find)), util::get_mata_word_zstring(replace), &alph.get_mata_alphabet());
                     ++backward_iterator;
                     return mata::nft::reduce(mata::nft::remove_epsilon(result).trim()).trim();
                 }

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -14,7 +14,7 @@ namespace {
 namespace smt::noodler::regex {
 
     mata::Symbol Alphabet::get_unused_symbol() const {
-        if (alphabet.size() == zstring::max_char()) {
+        if (is_full()) {
             // alphabet is full, we throw error (TODO: should probably return nullopt or something like that)
             util::throw_error("Trying to get a fresh symbol in full alphabet");
             return 0; // this is unreachable, return something so we can compile

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -116,8 +116,8 @@ namespace smt::noodler::regex {
         const_iterator cend() const { return alphabet.cend(); }
 
         bool is_full () const {
-            if (contains(util::get_dummy_symbol())) { return size() == zstring::max_char(); }
-            else { return size()+1 == zstring::max_char(); }
+            if (contains(util::get_dummy_symbol())) { return size() == zstring::max_char()+2; }
+            else { return size() == zstring::max_char()+1; }
         }
 
         bool insert_dummy_if_not_full() {

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -21,9 +21,7 @@
 #include "ast/rewriter/seq_rewriter.h"
 #include "ast/rewriter/th_rewriter.h"
 
-#include "formula.h"
 #include "util.h"
-#include "aut_assignment.h"
 
 // FIXME most if not all these functions should probably be in theory_str_noodler
 

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -53,7 +53,7 @@ namespace smt::noodler::regex {
      */
     struct Alphabet {
         std::set<mata::Symbol> alphabet;
-        mata::OnTheFlyAlphabet mata_alphabet;
+        mata::EnumAlphabet mata_alphabet;
 
         Alphabet() = default;
         Alphabet(const Alphabet&) = default;
@@ -61,17 +61,20 @@ namespace smt::noodler::regex {
         Alphabet& operator=(const Alphabet&) = default;
         Alphabet& operator=(Alphabet&&) = default;
 
-        Alphabet(mata::OnTheFlyAlphabet alph) : alphabet(), mata_alphabet(alph) {
+        Alphabet(mata::EnumAlphabet alph) : alphabet(), mata_alphabet(std::move(alph)) {
             for (const mata::Symbol& s : mata_alphabet.get_alphabet_symbols()) {
                 alphabet.insert(s);
             }
         }
         
-        Alphabet(std::set<mata::Symbol> alph) : alphabet(alph) {
+        Alphabet(std::set<mata::Symbol> alph) : alphabet(std::move(alph)) {
             for (const auto& symbol : alphabet) {
-                this->mata_alphabet.add_new_symbol(std::to_string(symbol), symbol);
+                this->mata_alphabet.add_new_symbol(symbol);
             }
         }
+
+        const std::set<mata::Symbol>& get_set_alphabet() const { return alphabet; }
+        const mata::EnumAlphabet& get_mata_alphabet() const { return mata_alphabet; }
 
         void clear() {
             alphabet.clear();
@@ -85,7 +88,7 @@ namespace smt::noodler::regex {
         void insert(const mata::Symbol s) {
             SASSERT(s <= zstring::max_char() || s != util::get_dummy_symbol());
             alphabet.insert(s);
-            mata_alphabet.add_new_symbol(std::to_string(s), s);
+            mata_alphabet.add_new_symbol(s);
         }
 
         template<class InputIt>
@@ -109,7 +112,6 @@ namespace smt::noodler::regex {
         const_iterator end() const { return alphabet.cend(); }
         const_iterator cbegin() const { return alphabet.cbegin(); }
         const_iterator cend() const { return alphabet.cend(); }
-
 
         /// @brief Returns any symbol that is not in the alphabet
         mata::Symbol get_unused_symbol() const;

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -54,12 +54,62 @@ namespace smt::noodler::regex {
     struct Alphabet {
         std::set<mata::Symbol> alphabet;
         mata::OnTheFlyAlphabet mata_alphabet;
+
+        Alphabet() = default;
+        Alphabet(const Alphabet&) = default;
+        Alphabet(Alphabet&&) = default;
+        Alphabet& operator=(const Alphabet&) = default;
+        Alphabet& operator=(Alphabet&&) = default;
+
+        Alphabet(mata::OnTheFlyAlphabet alph) : alphabet(), mata_alphabet(alph) {
+            for (const mata::Symbol& s : mata_alphabet.get_alphabet_symbols()) {
+                alphabet.insert(s);
+            }
+        }
         
-        Alphabet(const std::set<mata::Symbol>& alph) : alphabet(alph) {
-            for (const auto& symbol : alph) {
+        Alphabet(std::set<mata::Symbol> alph) : alphabet(alph) {
+            for (const auto& symbol : alphabet) {
                 this->mata_alphabet.add_new_symbol(std::to_string(symbol), symbol);
             }
         }
+
+        void clear() {
+            alphabet.clear();
+            mata_alphabet.clear();
+        }
+
+        size_t size() const { return alphabet.size(); }
+
+        bool empty() const { return alphabet.empty(); }
+
+        void insert(const mata::Symbol s) {
+            SASSERT(s <= zstring::max_char() || s != util::get_dummy_symbol());
+            alphabet.insert(s);
+            mata_alphabet.add_new_symbol(std::to_string(s), s);
+        }
+
+        template<class InputIt>
+        void insert(InputIt first, InputIt last) {
+            static_assert(std::is_convertible_v<typename std::iterator_traits<InputIt>::value_type, mata::Symbol>,
+                "Iterator must yield mata::Symbol or a type convertible to mata::Symbol");
+
+            for (; first != last; ++first) { insert(*first); }
+        }
+
+        bool contains(const mata::Symbol s) const { return alphabet.contains(s); }
+
+        void erase(const mata::Symbol s) {
+            alphabet.erase(s);
+            mata_alphabet.erase(s);
+        }
+
+        using const_iterator = std::set<mata::Symbol>::const_iterator;
+
+        const_iterator begin() const { return alphabet.cbegin(); }
+        const_iterator end() const { return alphabet.cend(); }
+        const_iterator cbegin() const { return alphabet.cbegin(); }
+        const_iterator cend() const { return alphabet.cend(); }
+
 
         /// @brief Returns any symbol that is not in the alphabet
         mata::Symbol get_unused_symbol() const;

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -51,10 +51,12 @@ namespace smt::noodler::regex {
     /**
      * @brief Alphabet wrapper for Z3 alphabet represented by std::set<mata::Symbol> and a Mata alphabet.
      */
-    struct Alphabet {
+    class Alphabet {
+    private:
         std::set<mata::Symbol> alphabet;
         mata::EnumAlphabet mata_alphabet;
 
+    public:
         Alphabet() = default;
         Alphabet(const Alphabet&) = default;
         Alphabet(Alphabet&&) = default;
@@ -113,6 +115,17 @@ namespace smt::noodler::regex {
         const_iterator cbegin() const { return alphabet.cbegin(); }
         const_iterator cend() const { return alphabet.cend(); }
 
+        bool is_full () const { return size() == zstring::max_char(); }
+
+        bool insert_dummy_if_not_full() {
+            if (is_full()) {
+                return false;
+            } else {
+                insert(util::get_dummy_symbol());
+                return true;
+            }
+        }
+
         /// @brief Returns any symbol that is not in the alphabet
         mata::Symbol get_unused_symbol() const;
 
@@ -131,7 +144,7 @@ namespace smt::noodler::regex {
      * @param[in] m_util_s Seq util for AST.
      * @param[out] alphabet A set of symbols with where found symbols are appended to.
      */
-    void extract_symbols(expr* const ex, const seq_util& m_util_s, std::set<uint32_t>& alphabet);
+    void extract_symbols(expr* const ex, const seq_util& m_util_s, Alphabet& alphabet);
 
     /**
      * Convert expression @p expr to NFA.
@@ -273,7 +286,7 @@ namespace smt::noodler::regex {
          * @param mata_alph The alphabet used for creating the transducer
          * @return The simultaneous transducer
          */
-        mata::nft::Nft create_transducer(mata::Alphabet* mata_alph);
+        mata::nft::Nft create_transducer(const Alphabet& mata_alph);
     };
 
     /**
@@ -289,7 +302,7 @@ namespace smt::noodler::regex {
      * @param[out] transducer_preds Newly created transducer constraints
      */
     void gather_transducer_constraints(app* ex, ast_manager& m, const seq_util& m_util_s, obj_map<expr, expr*>& pred_replace, 
-        std::map<BasicTerm, expr_ref>& var_name, mata::Alphabet* mata_alph, Formula& transducer_preds);
+        std::map<BasicTerm, expr_ref>& var_name, const Alphabet& mata_alph, Formula& transducer_preds);
 
 }
 

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -116,8 +116,8 @@ namespace smt::noodler::regex {
         const_iterator cend() const { return alphabet.cend(); }
 
         bool is_full () const {
-            if (contains(util::get_dummy_symbol())) { return size()-1 == zstring::max_char(); }
-            else { return size() == zstring::max_char(); }
+            if (contains(util::get_dummy_symbol())) { return size() == zstring::max_char(); }
+            else { return size()+1 == zstring::max_char(); }
         }
 
         bool insert_dummy_if_not_full() {

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -75,6 +75,8 @@ namespace smt::noodler::regex {
             }
         }
 
+        Alphabet(std::initializer_list<mata::Symbol> init) : Alphabet(std::set<mata::Symbol>(init)) { }
+
         const std::set<mata::Symbol>& get_set_alphabet() const { return alphabet; }
         const mata::EnumAlphabet& get_mata_alphabet() const { return mata_alphabet; }
 

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -115,7 +115,10 @@ namespace smt::noodler::regex {
         const_iterator cbegin() const { return alphabet.cbegin(); }
         const_iterator cend() const { return alphabet.cend(); }
 
-        bool is_full () const { return size() == zstring::max_char(); }
+        bool is_full () const {
+            if (contains(util::get_dummy_symbol())) { return size()-1 == zstring::max_char(); }
+            else { return size() == zstring::max_char(); }
+        }
 
         bool insert_dummy_if_not_full() {
             if (is_full()) {
@@ -132,8 +135,11 @@ namespace smt::noodler::regex {
         /// @brief Return zstring corresponding the the word @p word, where dummy symbol is replaced with some valid symbol not in the alphabet.
         zstring get_string_from_mata_word(mata::Word word) const {
             zstring res;
-            mata::Symbol unused_symbol = get_unused_symbol();
-            std::replace(word.begin(), word.end(), util::get_dummy_symbol(), unused_symbol);
+            if (std::ranges::find(word, util::get_dummy_symbol()) != word.end()) {
+                SASSERT(alphabet.contains(util::get_dummy_symbol()));
+                mata::Symbol unused_symbol = get_unused_symbol();
+                std::replace(word.begin(), word.end(), util::get_dummy_symbol(), unused_symbol);
+            }
             return zstring(word.size(), word.data());
         }
     };

--- a/src/smt/theory_str_noodler/solving_state.cpp
+++ b/src/smt/theory_str_noodler/solving_state.cpp
@@ -288,6 +288,7 @@ namespace smt::noodler {
     }
 
     void SolvingState::replace_dummy_symbol_in_transducers_with(std::set<mata::Symbol> replacements) {
+        if (replacements.empty()) { return; }
         for (const Predicate& trans : transducers) {
             util::replace_dummy_symbol_in_transducer_with(*trans.get_transducer(), replacements);
         }

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -439,18 +439,20 @@ namespace smt::noodler {
          * @param ex Equation
          * @return true <-> is temporary transducer constraint
          */
-        bool is_tmp_transducer_eq(app* const ex);
+        [[nodiscard]] bool is_tmp_transducer_eq(app* const ex);
 
         /**
          * @brief Creates noodler formula containing relevant word equations and disequations
          * 
          * @param alph Set of symbols of the current instance (for transducer constraints)
          */
-        Formula get_formula_from_relevant(const std::set<mata::Symbol>& alph);
+        [[nodiscard]] Formula get_formula_from_relevant(const regex::Alphabet& alph);
+
         /**
          * @brief Get all symbols used in relevant word (dis)equations and memberships
          */
-        std::set<mata::Symbol> get_symbols_from_relevant();
+        [[nodiscard]] regex::Alphabet get_symbols_from_relevant();
+
         /**
          * Get automata assignment for formula @p instance using relevant memberships in m_membership_todo_rel.
          * As a side effect updates mapping of variables (BasicTerm) to the corresponding z3 expr and adds
@@ -458,21 +460,20 @@ namespace smt::noodler {
          * @param instance Formula containing (dis)equations
          * @param noodler_alphabet Set of symbols occuring in the formula and memberships
          */
-        [[nodiscard]] AutAssignment create_aut_assignment_for_formula(
-                Formula& instance,
-                const std::set<mata::Symbol>& noodler_alphabet
-        );
+        [[nodiscard]] AutAssignment create_aut_assignment_for_formula(Formula& instance, const regex::Alphabet& noodler_alphabet);
+
         /**
          * Get initial length variables as a set of @c BasicTerm from their expressions.
          */
         std::unordered_set<BasicTerm> get_init_length_vars(AutAssignment& ass);
+
         /**
          * @brief Get the conversions (to/from_int/code) with noodler variables
          * 
          * Side effect: string variables in conversions which are not mapped in the automata
          * assignment @p ass will be mapped to sigma* after this.
          */
-        std::vector<TermConversion> get_conversions_as_basicterms(AutAssignment &ass, const std::set<mata::Symbol>& noodler_alphabet);
+        std::vector<TermConversion> get_conversions_as_basicterms(AutAssignment &ass);
 
         /**
          * Solves relevant language (dis)equations from m_lang_eq_or_diseq_todo_rel. If some of them

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -113,10 +113,6 @@ namespace smt::noodler {
         bool contains_word_equations = !this->m_word_eq_todo_rel.empty();
         bool contains_word_disequations = !this->m_word_diseq_todo_rel.empty();
         bool contains_conversions = !this->m_conversion_todo.empty();
-        bool contains_int_conversion = false;
-        for (const auto& c : m_conversion_todo) { if (c.type == ConversionType::FROM_INT || c.type == ConversionType::TO_INT) { contains_int_conversion = true; break; } }
-        bool contains_real_conversion = false;
-        for (const auto& c : m_conversion_todo) { if (c.type == ConversionType::FROM_REAL || c.type == ConversionType::TO_REAL) { contains_real_conversion = true; break; } }
         bool contains_eqs_and_diseqs_only = this->m_not_contains_todo_rel.empty() && this->m_conversion_todo.empty();
 
         // nothing is trivially SAT
@@ -166,16 +162,7 @@ namespace smt::noodler {
         }
 
         // Gather symbols from relevant (dis)equations and from regular expressions of relevant memberships
-        std::set<mata::Symbol> symbols_in_formula = get_symbols_from_relevant();
-
-        // If we have to_int/from_int/to_real/from_real, we keep digits (0-9) as explicit symbols, so that they are not represented by dummy_symbol and it is easier to handle the conversions
-        if (contains_int_conversion || contains_real_conversion) {
-            for (mata::Symbol s = AutAssignment::DIGIT_SYMBOL_START; s <= AutAssignment::DIGIT_SYMBOL_END; ++s) {
-                symbols_in_formula.insert(s);
-            }
-        }
-        // If we have to_real/from_real, we also add '.', so that decimal point is not represented by dummy symbol
-        if (contains_real_conversion) { symbols_in_formula.insert(AutAssignment::REAL_NUMBER_DELIMITER); }
+        regex::Alphabet symbols_in_formula = get_symbols_from_relevant();
 
         // Gather relevant word (dis)equations (and transducers that occur in them) to noodler formula
         Formula instance = get_formula_from_relevant(symbols_in_formula);
@@ -185,7 +172,7 @@ namespace smt::noodler {
 
         bool contains_transducers = instance.contains_pred_type(PredicateType::Transducer);
 
-        std::vector<TermConversion> conversions = get_conversions_as_basicterms(aut_assignment, symbols_in_formula);
+        std::vector<TermConversion> conversions = get_conversions_as_basicterms(aut_assignment);
 
         for (const auto& [var, nfa] : aut_assignment) {
             relevant_vars.insert(var);
@@ -506,13 +493,8 @@ namespace smt::noodler {
         return false;
     }
 
-    Formula theory_str_noodler::get_formula_from_relevant(const std::set<mata::Symbol>& alph) {
+    Formula theory_str_noodler::get_formula_from_relevant(const regex::Alphabet& alph) {
         Formula instance;
-        // create mata alphabet for transducer constraints
-        mata::EnumAlphabet mata_alph{};
-        for(const mata::Symbol& symb : alph) {
-            mata_alph.add_new_symbol(symb);
-        }
 
         for (const auto &we: this->m_word_eq_todo_rel) {
             // ignore trivial equations obtained from axiomatization of 
@@ -525,16 +507,16 @@ namespace smt::noodler {
             }
             Predicate inst = this->conv_eq_pred(ctx.mk_eq_atom(we.first, we.second));
             // gather transducer constraints occurring in the concatenation
-            regex::gather_transducer_constraints(to_app(we.first), m, this->m_util_s, this->predicate_replace, this->var_name, &mata_alph, instance);
-            regex::gather_transducer_constraints(to_app(we.second), m, this->m_util_s, this->predicate_replace, this->var_name, &mata_alph, instance);
+            regex::gather_transducer_constraints(to_app(we.first), m, this->m_util_s, this->predicate_replace, this->var_name, alph, instance);
+            regex::gather_transducer_constraints(to_app(we.second), m, this->m_util_s, this->predicate_replace, this->var_name, alph, instance);
             instance.add_predicate(inst);
         }
 
         for (const auto& wd : this->m_word_diseq_todo_rel) {
             Predicate inst = this->conv_eq_pred(m.mk_not(ctx.mk_eq_atom(wd.first, wd.second)));
             // gather transducer constraints occurring in the concatenation
-            regex::gather_transducer_constraints(to_app(wd.first), m, this->m_util_s, this->predicate_replace, this->var_name, &mata_alph, instance);
-            regex::gather_transducer_constraints(to_app(wd.second), m, this->m_util_s, this->predicate_replace, this->var_name, &mata_alph, instance);
+            regex::gather_transducer_constraints(to_app(wd.first), m, this->m_util_s, this->predicate_replace, this->var_name, alph, instance);
+            regex::gather_transducer_constraints(to_app(wd.second), m, this->m_util_s, this->predicate_replace, this->var_name, alph, instance);
             instance.add_predicate(inst);
         }
 
@@ -544,26 +526,26 @@ namespace smt::noodler {
             util::collect_terms(to_app(not_contains.first), m, this->m_util_s, this->predicate_replace, this->var_name, left);
             util::collect_terms(to_app(not_contains.second), m, this->m_util_s, this->predicate_replace, this->var_name, right);
             // gather transducer constraints occurring in the concatenation
-            regex::gather_transducer_constraints(to_app(not_contains.first), m, this->m_util_s, this->predicate_replace, this->var_name, &mata_alph, instance);
-            regex::gather_transducer_constraints(to_app(not_contains.second), m, this->m_util_s, this->predicate_replace, this->var_name, &mata_alph, instance);
+            regex::gather_transducer_constraints(to_app(not_contains.first), m, this->m_util_s, this->predicate_replace, this->var_name, alph, instance);
+            regex::gather_transducer_constraints(to_app(not_contains.second), m, this->m_util_s, this->predicate_replace, this->var_name, alph, instance);
             Predicate inst = Predicate::create_not_contains(left, right);
             instance.add_predicate(inst);
         }
 
         for (const auto& conv : this->m_conversion_todo) {
-            regex::gather_transducer_constraints(to_app(var_name.at(conv.string_var)), m, this->m_util_s, this->predicate_replace, this->var_name, &mata_alph, instance);
+            regex::gather_transducer_constraints(to_app(var_name.at(conv.string_var)), m, this->m_util_s, this->predicate_replace, this->var_name, alph, instance);
         }
 
         for (const auto& len: len_vars) {
-            regex::gather_transducer_constraints(to_app(len), m, this->m_util_s, this->predicate_replace, this->var_name, &mata_alph, instance);
+            regex::gather_transducer_constraints(to_app(len), m, this->m_util_s, this->predicate_replace, this->var_name, alph, instance);
         }
 
         return instance;
     }
 
-    std::set<mata::Symbol> theory_str_noodler::get_symbols_from_relevant() {
+    regex::Alphabet theory_str_noodler::get_symbols_from_relevant() {
         // start with symbol representing everything not in formula
-        std::set<mata::Symbol> symbols_in_formula{util::get_dummy_symbol()};
+        regex::Alphabet symbols_in_formula{};
 
         for (const auto &word_equation: m_word_eq_todo_rel) {
             regex::extract_symbols(word_equation.first, m_util_s, symbols_in_formula);
@@ -584,17 +566,29 @@ namespace smt::noodler {
             regex::extract_symbols(not_contains.second, m_util_s, symbols_in_formula);
         }
 
+        bool contains_int_conversion = false;
+        for (const auto& c : m_conversion_todo) { if (c.type == ConversionType::FROM_INT || c.type == ConversionType::TO_INT) { contains_int_conversion = true; break; } }
+        bool contains_real_conversion = false;
+        for (const auto& c : m_conversion_todo) { if (c.type == ConversionType::FROM_REAL || c.type == ConversionType::TO_REAL) { contains_real_conversion = true; break; } }
+
+        // If we have to_int/from_int/to_real/from_real, we keep digits (0-9) as explicit symbols, so that they are not represented by dummy_symbol and it is easier to handle the conversions
+        if (contains_int_conversion || contains_real_conversion) {
+            for (mata::Symbol s = AutAssignment::DIGIT_SYMBOL_START; s <= AutAssignment::DIGIT_SYMBOL_END; ++s) {
+                symbols_in_formula.insert(s);
+            }
+        }
+        // If we have to_real/from_real, we also add '.', so that decimal point is not represented by dummy symbol
+        if (contains_real_conversion) { symbols_in_formula.insert(AutAssignment::REAL_NUMBER_DELIMITER); }
+
+        // we also insert dummy symbol representing all symbols NOT occurring in formula (but only if we do not have ALL symbols in formula)
+        symbols_in_formula.insert_dummy_if_not_full();
+
         return symbols_in_formula;
     }
 
-    AutAssignment theory_str_noodler::create_aut_assignment_for_formula(
-            Formula& instance,
-            const std::set<mata::Symbol>& noodler_alphabet
-    ) {
-        AutAssignment aut_assignment{};
-        aut_assignment.set_alphabet(noodler_alphabet);
-        regex::Alphabet alph(noodler_alphabet);
-        mata::EnumAlphabet mata_alphabet(noodler_alphabet.begin(), noodler_alphabet.end());
+    AutAssignment theory_str_noodler::create_aut_assignment_for_formula(Formula& instance, const regex::Alphabet& noodler_alphabet) {
+        AutAssignment aut_assignment{noodler_alphabet};
+        const regex::Alphabet &alph = aut_assignment.get_alphabet();
         for (const auto &membership: m_membership_todo_rel) {
             const expr_ref& var_expr{ std::get<0>(membership) };
             assert(is_app(var_expr));
@@ -624,13 +618,11 @@ namespace smt::noodler {
             }
 
             // we also need to gather transducer constraints for the var
-            regex::gather_transducer_constraints(var_app, m, this->m_util_s, this->predicate_replace, this->var_name, &mata_alphabet, instance);
+            regex::gather_transducer_constraints(var_app, m, this->m_util_s, this->predicate_replace, this->var_name, alph, instance);
         }
 
         // create sigma star automaton for our alphabet
-        auto nfa_sigma_star = std::make_shared<mata::nfa::Nfa>(mata::nfa::builder::create_sigma_star_nfa(&mata_alphabet));
-        // remove the pointer to alphabet in the automaton, as it points to local variable (and we have the alphabet in aut_assignment)
-        nfa_sigma_star->alphabet = nullptr;
+        std::shared_ptr<mata::nfa::Nfa> nfa_sigma_star = std::make_shared<mata::nfa::Nfa>(aut_assignment.sigma_star_automaton());
 
         // some variables/literals are not assigned to anything yet, we need to fix that
         for (const auto &pred : instance.get_predicates()) {
@@ -670,9 +662,8 @@ namespace smt::noodler {
         return init_lengths;
     }
 
-    std::vector<TermConversion> theory_str_noodler::get_conversions_as_basicterms(AutAssignment& ass, const std::set<mata::Symbol>& noodler_alphabet) {
-        mata::EnumAlphabet mata_alphabet(noodler_alphabet.begin(), noodler_alphabet.end());
-        auto nfa_sigma_star = std::make_shared<mata::nfa::Nfa>(mata::nfa::builder::create_sigma_star_nfa(&mata_alphabet));
+    std::vector<TermConversion> theory_str_noodler::get_conversions_as_basicterms(AutAssignment& ass) {
+        std::shared_ptr<mata::nfa::Nfa> nfa_sigma_star = std::make_shared<mata::nfa::Nfa>(ass.sigma_star_automaton());
 
         std::vector<TermConversion> conversions;
         for (const auto& transf : m_conversion_todo) {
@@ -702,10 +693,9 @@ namespace smt::noodler {
             );
 
             // get symbols from both sides
-            std::set<uint32_t> alphabet;
-            regex::extract_symbols(left_side, m_util_s, alphabet);
-            regex::extract_symbols(right_side, m_util_s, alphabet);
-            regex::Alphabet alph(alphabet);
+            regex::Alphabet alph;
+            regex::extract_symbols(left_side, m_util_s, alph);
+            regex::extract_symbols(right_side, m_util_s, alph);
 
             // construct NFAs for both sides
             mata::nfa::Nfa nfa1 = regex::conv_to_nfa(to_app(left_side), m_util_s, m, alph, false );

--- a/src/smt/theory_str_noodler/util.cc
+++ b/src/smt/theory_str_noodler/util.cc
@@ -301,6 +301,7 @@ namespace smt::noodler::util {
     }
 
     void replace_dummy_symbol_in_transducer_with(mata::nft::Nft& transducer, const std::set<mata::Symbol>& symbols_to_replace_with) {
+        if (symbols_to_replace_with.empty()) { return; }
         if (symbols_to_replace_with.size() > 1) {
             // different transitions with dummy symbol can be connected, i.e. they should have the same symbol, if we would replace
             // by multiple symbols, it would allow situations where the transitions have different symbols on them

--- a/src/smt/theory_str_noodler/util.h
+++ b/src/smt/theory_str_noodler/util.h
@@ -24,7 +24,6 @@
 #include "ast/rewriter/th_rewriter.h"
 
 #include "formula.h"
-#include "aut_assignment.h"
 
 // FIXME most if not all these functions should probably be in theory_str_noodler
 


### PR DESCRIPTION
Should also fix #284. Depends on #283.