### PR TITLE
Fix: Length procedure unsoundness

### DIFF
--- a/src/smt/theory_str_noodler/length_decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/length_decision_procedure.cpp
@@ -632,10 +632,7 @@ namespace smt::noodler {
             BasicTerm term = t.first;
             std::set<smt::noodler::BasicTerm> vars_in_eqs = this->formula.get_vars();    // Variables in all predicates
 
-            // term does not appear in any predicate
-            if (vars_in_eqs.find(term) == vars_in_eqs.end()) {
-                len_formula.succ.emplace_back(this->init_aut_ass.get_lengths(term));
-            }
+            len_formula.succ.emplace_back(this->init_aut_ass.get_lengths(term));
         }
 
         return {len_formula, this->precision};

--- a/src/test/noodler/e2e/flat_checker-094-4.smt2
+++ b/src/test/noodler/e2e/flat_checker-094-4.smt2
@@ -1,0 +1,7 @@
+(set-logic ALL)
+(set-info :status unsat)
+(declare-const s String)
+(assert (str.in_re s (re.opt (str.to_re "a"))))
+(assert (> (str.len s) 0))
+(assert (not (str.in_re (str.substr s 0 (- 1 0)) (re.opt (str.to_re "a")))))
+(check-sat)


### PR DESCRIPTION
This PR fixes a bug in the length-based procedure. For a particular case some LIA formula were missing making the formula `sat` despite it was `unsat`.