### PR TITLE
Fix: Release workflow after `autotag`

### DIFF
--- a/.github/workflows/noodler-auto-patch-release.yml
+++ b/.github/workflows/noodler-auto-patch-release.yml
@@ -81,3 +81,16 @@ jobs:
           bump: patch
           release-branch: devel
           with-v: true
+
+      - name: Trigger release workflow
+        if: steps.autotag.outputs.new-tag != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ steps.autotag.outputs.new-tag }}"
+          owner="${{ github.repository_owner }}"
+          repo="${{ github.event.repository.name }}"
+          
+          gh workflow run noodler-build-release.yml \
+            --repo "${owner}/${repo}" \
+            --ref "${tag}"

--- a/.github/workflows/noodler-build-release.yml
+++ b/.github/workflows/noodler-build-release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
 
 jobs:
   build-and-publish-binaries:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to automate the release process further. The key changes are the addition of a manual trigger for the build workflow and the automation of triggering the build workflow after a new patch release is tagged.