### PR TITLE
Fix: Release workflow call

### DIFF
--- a/.github/workflows/noodler-auto-patch-release.yml
+++ b/.github/workflows/noodler-auto-patch-release.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: true
 
       - name: Find merged PR for this commit
         id: pr
@@ -82,15 +83,13 @@ jobs:
           release-branch: devel
           with-v: true
 
-      - name: Trigger release workflow
-        if: steps.autotag.outputs.new-tag != ''
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          tag="${{ steps.autotag.outputs.new-tag }}"
-          owner="${{ github.repository_owner }}"
-          repo="${{ github.event.repository.name }}"
-          
-          gh workflow run noodler-build-release.yml \
-            --repo "${owner}/${repo}" \
-            --ref "${tag}"
+    outputs:
+      new_tag: ${{ steps.autotag.outputs.new-tag }}
+
+  call-release:
+    name: Trigger release (reusable)
+    needs: tag-and-release
+    if: needs.tag-and-release.outputs.new_tag != ''
+    uses: ./.github/workflows/noodler-build-release.yml
+    with:
+      ref: ${{ needs.tag-and-release.outputs.new_tag }}

--- a/.github/workflows/noodler-build-release.yml
+++ b/.github/workflows/noodler-build-release.yml
@@ -5,6 +5,15 @@ on:
     tags:
       - "v*.*.*"
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref (tag or sha) to build/release"
+        required: true
+        type: string
+
+permissions:
+  contents: write
 
 jobs:
   build-and-publish-binaries:
@@ -46,6 +55,7 @@ jobs:
         uses: actions/checkout@v6
         with: 
           fetch-depth: 0
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Install dependencies (Ubuntu)
         if: matrix.os == 'ubuntu'
@@ -97,6 +107,6 @@ jobs:
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.ref_name }}
+          tag_name: ${{ inputs.ref || github.ref_name }}
           files: artifacts/z3-noodler-*
           generate_release_notes: true


### PR DESCRIPTION
This pull request refactors the release automation workflows to improve modularity and enable the use of reusable workflows with parameterized inputs. The main changes involve splitting the release process into separate jobs, allowing the release workflow to be triggered with a specific git reference, and updating permissions and input handling.
