### PR TITLE
Update Ubuntu version in workflow to 22.04

### DIFF
--- a/.github/workflows/noodler-build-release.yml
+++ b/.github/workflows/noodler-build-release.yml
@@ -30,10 +30,10 @@ jobs:
             variant: shared
             runner: ubuntu-24.04
           - os: ubuntu
-            os_version: 20.04
+            os_version: 22.04
             arch: x86_64
             variant: shared
-            runner: ubuntu-20.04
+            runner: ubuntu-22.04
           - os: ubuntu
             os_version: 24.04
             arch: x86_64


### PR DESCRIPTION
This pull request updates the Ubuntu version used in the GitHub Actions workflow for the build and release process. The workflow now uses Ubuntu 22.04 instead of 20.04 for one of the build matrix entries. The reusable release workflow requested a GitHub-hosted runner label ubuntu-20.04, which is no longer available.