### PR TITLE
Fix: remove Ubuntu 22.04 from workflow

### DIFF
--- a/.github/workflows/noodler-build-release.yml
+++ b/.github/workflows/noodler-build-release.yml
@@ -30,11 +30,6 @@ jobs:
             variant: shared
             runner: ubuntu-24.04
           - os: ubuntu
-            os_version: 22.04
-            arch: x86_64
-            variant: shared
-            runner: ubuntu-22.04
-          - os: ubuntu
             os_version: 24.04
             arch: x86_64
             variant: static-libz3


### PR DESCRIPTION
This pull request makes a minor update to the build and release workflow by removing the configuration for Ubuntu 22.04 jobs. The workflow will now only run jobs for Ubuntu 24.04. Ubuntu 22.04 is not compatible with `mata`.