### PR TITLE
Rewriter rule for `replace_re` with nullable regex

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -2312,7 +2312,7 @@ br_status seq_rewriter::mk_seq_replace_re_all(expr* a, expr* b, expr* c, expr_re
 }
 
 br_status seq_rewriter::mk_seq_replace_re(expr* a, expr* b, expr* c, expr_ref& result) {
-    if (is_nullable(b)) {
+    if (m().is_true(is_nullable(b))) {
         result = str().mk_concat(c, a);
         return BR_REWRITE1;
     }

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -5659,36 +5659,16 @@ br_status seq_rewriter::mk_eq_core(expr * l, expr * r, expr_ref & result) {
     }
 #endif
 
-    // str.at ... = str where |str| > 1 --> false
-    if(zstring val; str().is_at(l) && str().is_string(r, val) && val.length() > 1) {
-        result = m().mk_false(); 
-        return BR_DONE;
-    }
-
-    // "a".x.u = x.w (where "a" is string of size 1) -> x in a* && "a".u = w
-    auto check_eq = [this](expr* l, expr* r, expr_ref& result) {
-        m_lhs.reset();
-        m_rhs.reset();
-        str().get_concat(l, m_lhs);
-        str().get_concat(r, m_rhs);
-        if (zstring val; m_lhs.size() >= 2 && str().is_string(m_lhs.get(0), val) && val.length() == 1 && !m_rhs.empty() && m_rhs.get(0) == m_lhs.get(1)) {
-            expr_ref in(re().mk_in_re(m_rhs.get(0), re().mk_star(re().mk_to_re(m_lhs.get(0)))), m());
-            m_lhs.erase(1);
-            m_rhs.erase(0u);
-            expr_ref lhs(str().mk_concat(m_lhs, m_lhs[0]->get_sort()), m());
-            expr_ref rhs(str().mk_concat(m_rhs, m_rhs[0]->get_sort()), m());
-            result = m().mk_and(in, m().mk_eq(lhs, rhs));
-            return true;
-        }
-        return false;
-    };
-    if (check_eq(l, r, result) || check_eq(r, l, result)) {
-        return BR_REWRITE3;
-    }
-
     if (!reduce_eq(l, r, new_eqs, changed)) {
         result = m().mk_false();
         TRACE(seq_verbose, tout << result << "\n";);
+        return BR_DONE;
+    }
+
+    // str.at ... = str where |str| > 1 --> false
+    zstring val;
+    if(str().is_at(l) && str().is_string(r, val) && val.length() > 1) {
+        result = m().mk_false(); 
         return BR_DONE;
     }
     if (!changed) {

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -2312,6 +2312,10 @@ br_status seq_rewriter::mk_seq_replace_re_all(expr* a, expr* b, expr* c, expr_re
 }
 
 br_status seq_rewriter::mk_seq_replace_re(expr* a, expr* b, expr* c, expr_ref& result) {
+    if (is_nullable(b)) {
+        result = str().mk_concat(c, a);
+        return BR_REWRITE1;
+    }
     return replace_re_version(a, b, c, result, false);
 }
 

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -5659,16 +5659,36 @@ br_status seq_rewriter::mk_eq_core(expr * l, expr * r, expr_ref & result) {
     }
 #endif
 
-    if (!reduce_eq(l, r, new_eqs, changed)) {
-        result = m().mk_false();
-        TRACE(seq_verbose, tout << result << "\n";);
+    // str.at ... = str where |str| > 1 --> false
+    if(zstring val; str().is_at(l) && str().is_string(r, val) && val.length() > 1) {
+        result = m().mk_false(); 
         return BR_DONE;
     }
 
-    // str.at ... = str where |str| > 1 --> false
-    zstring val;
-    if(str().is_at(l) && str().is_string(r, val) && val.length() > 1) {
-        result = m().mk_false(); 
+    // "a".x.u = x.w (where "a" is string of size 1) -> x in a* && "a".u = w
+    auto check_eq = [this](expr* l, expr* r, expr_ref& result) {
+        m_lhs.reset();
+        m_rhs.reset();
+        str().get_concat(l, m_lhs);
+        str().get_concat(r, m_rhs);
+        if (zstring val; m_lhs.size() >= 2 && str().is_string(m_lhs.get(0), val) && val.length() == 1 && !m_rhs.empty() && m_rhs.get(0) == m_lhs.get(1)) {
+            expr_ref in(re().mk_in_re(m_rhs.get(0), re().mk_star(re().mk_to_re(m_lhs.get(0)))), m());
+            m_lhs.erase(1);
+            m_rhs.erase(0u);
+            expr_ref lhs(str().mk_concat(m_lhs, m_lhs[0]->get_sort()), m());
+            expr_ref rhs(str().mk_concat(m_rhs, m_rhs[0]->get_sort()), m());
+            result = m().mk_and(in, m().mk_eq(lhs, rhs));
+            return true;
+        }
+        return false;
+    };
+    if (check_eq(l, r, result) || check_eq(r, l, result)) {
+        return BR_REWRITE3;
+    }
+
+    if (!reduce_eq(l, r, new_eqs, changed)) {
+        result = m().mk_false();
+        TRACE(seq_verbose, tout << result << "\n";);
         return BR_DONE;
     }
     if (!changed) {

--- a/src/test/noodler/e2e/issue344.smt2
+++ b/src/test/noodler/e2e/issue344.smt2
@@ -1,0 +1,5 @@
+(set-info :status unsat)
+(declare-const x Int)
+(declare-fun a () String)
+(assert (= (str.++ a (str.from_int x)) (str.replace_re (str.++ a (str.from_int 1)) (re.union (str.to_re "") (str.to_re (str.from_int 1))) (str.from_code 0))))
+(check-sat)

--- a/src/test/noodler/e2e/issue344.smt2
+++ b/src/test/noodler/e2e/issue344.smt2
@@ -1,5 +1,0 @@
-(set-info :status unsat)
-(declare-const x Int)
-(declare-fun a () String)
-(assert (= (str.++ a (str.from_int x)) (str.replace_re (str.++ a (str.from_int 1)) (re.union (str.to_re "") (str.to_re (str.from_int 1))) (str.from_code 0))))
-(check-sat)


### PR DESCRIPTION
Added following rewriter rules:
 - `(str.replace_re x R y)` -> `(str.++ y x)` if `R` is nullable (contains empty word)
 - `"a".x.v = x.w` -> `"a".v = w && x in a*`