### PR TITLE
Support for additional string functions

### DIFF
--- a/ADDITIONAL_FUNCTIONS.md
+++ b/ADDITIONAL_FUNCTIONS.md
@@ -1,0 +1,82 @@
+# Additional string functions
+Other than the constraints defined in the [SMT-LIB theory of strings](https://smt-lib.org/theories-UnicodeStrings.shtml), Z3-Noodler can handle the following functions:
+
+## `(str.to_real String Real)`
+Converts a string representation of a (positive) real number to the corresponding number. The string representation can either be a positive integer with leading zeros (similarly as in `str.to_int`) or it can contain one decimal separator `.`. It evaluates to `-1.0` otherwise.  
+Examples:
+ - `(str.to_real "4562")` → `4562.0`
+ - `(str.to_real "-4562")` → `-1.0`
+ - `(str.to_real "45.62")` → `45.62`
+ - `(str.to_real "00045.620000")` → `45.62`
+ - `(str.to_real "")` → `-1.0`
+ - `(str.to_real ".456")` → `0.456`
+ - `(str.to_real "8494.")` → `8494.0`
+ - `(str.to_real ".")` → `-1.0`
+ - `(str.to_real "4564a")` → `-1.0`
+ - `(str.to_real "4564e3")` → `-1.0`
+
+## `(str.from_real Real Int String)`
+Transforms a positive real number `r` to a string `s` with a corresponding number of decimal places `n`. If either `n` or `r` is negative, it evaluates to the empty string.  
+Examples:
+ - `(str.from_real 4.56 5)` → `"4.56000"`
+ - `(str.from_real 4.56 0)` → `"4"`
+ - `(str.from_real 4.56 1)` → `"4.5"`
+ - `(str.from_real -4.56 -5)` → `""`
+ - `(str.from_real -4.56 5)` → `""`
+ - `(str.from_real 4.56 -5)` → `""`
+
+## `(str.to_lower String String)`
+Converts all uppercase ASCII characters (`0x41` - `0x5A`) to lowercase.
+This function is equivalent to [cvc5's `str.to_lower`](https://cvc5.github.io/docs-ci/docs-main/theories/strings.html).  
+Examples:
+ - `(str.to_lower "abcd")` → `"abcd"`
+ - `(str.to_lower "aBcD")` → `"abcd"`
+ - `(str.to_lower "AČĎ")` → `"aČĎ"`
+
+## `(str.to_upper String String)`
+Converts all lowercase ASCII characters (`0x61` - `0x7A`) to uppercase.
+This function is equivalent to [cvc5's `str.to_upper`](https://cvc5.github.io/docs-ci/docs-main/theories/strings.html).  
+Examples:
+ - `(str.to_upper "ABCD")` → `"ABCD"`
+ - `(str.to_upper "aBcD")` → `"ABCD"`
+ - `(str.to_upper "ačď")` → `"Ačď"`
+
+## `(str.update String Int String String)`
+Starts replacing characters in the first string by characters in the second string at the given index.
+The length of the resulting string will be the same as the first string.
+If the index is outside the first string, the first string gets returned.
+This function is equivalent to [cvc5's `str.update`](https://cvc5.github.io/docs-ci/docs-main/theories/strings.html).  
+Examples:
+ - `(str.update "123456" 2 "ab")` → `"12ab56"`
+ - `(str.update "1234" 2 "ab")` → `"12ab"`
+ - `(str.update "1234" 2 "abcd")` → `"12ab"`
+ - `(str.update "1234" -1 "ab")` → `"1234"`
+ - `(str.update "1234" 4 "ab")` → `"1234"`
+ - `(str.update "1234" 0 "abcd")` → `"abcd"`
+ - `(str.update "1234" 0 "abcdef")` → `"abcd"`
+
+## `(str.trim String String)`
+Trims the whitespace at the beginning and end of the given string.
+We consider the following characters as whitespace: space, form feed, line feed, carriage return, horizontal tab, vertical tab (ASCII `0x09` - `0x0D` and `0x20`).  
+Examples:
+ - `(str.trim "aa")` → `"aa"`
+ - `(str.trim "   aa")` → `"aa"`
+ - `(str.trim "aa   ")` → `"aa"`
+ - `(str.trim "     ")` → `""`
+ - `(str.trim "\u{9}\u{A}\u{B}\u{C}\u{D}  aa  \u{9}\u{A}\u{B}\u{C}\u{D}")` → `"aa"`
+ - `(str.trim "  a  a  ")` → `"a  a"`
+
+## `(str.delete String Int Int String)`
+Similar to `str.substr`, but it deletes the substring instead of returning it.
+The part to delete is given by an index and a length.
+If the index is outside the string or the length is non-positive, the original string gets returned.  
+Examples:
+ - `(str.delete "AAxxxxBB" 2 4)` → `"AABB"`
+ - `(str.delete "xxxxAABB" 0 4)` → `"AABB"`
+ - `(str.delete "AAxxxx" 2 99)` → `"AA"`
+ - `(str.delete "xxxx" 0 4)` → `""`
+ - `(str.delete "xxxx" 0 99)` → `""`
+ - `(str.delete "aaaa" -1 2)` → `"aaaa"`
+ - `(str.delete "aaaa" 2 0)` → `"aaaa"`
+ - `(str.delete "aaaa" 2 -1)` → `"aaaa"`
+ - `(str.delete "aaaa" 10 2)` → `"aaaa"`

--- a/README.md
+++ b/README.md
@@ -77,33 +77,16 @@ To run tests for Z3-Noodler:
 ./test-noodler
 ```
 
-## Aditional string functions
-Other than the constraints defined in the [SMT-LIB theory of strings](https://smt-lib.org/theories-UnicodeStrings.shtml), Z3-Noodler can handle the following functions:
-
-**`(str.to_real String Real)`**  
-Converts a string representation of a (positive) real number to the corresponding number. The string representation can either be a positive integer with leading zeros (similarly as in `str.to_int`) or it can contain one decimal separator `.`. It evaluates to `-1.0` otherwise.  
-Examples:
- - `(str.to_real "4562")` → `4562.0`
- - `(str.to_real "-4562")` → `-1.0`
- - `(str.to_real "45.62")` → `45.62`
- - `(str.to_real "00045.620000")` → `45.62`
- - `(str.to_real "")` → `-1.0`
- - `(str.to_real ".456")` → `0.456`
- - `(str.to_real "8494.")` → `8494.0`
- - `(str.to_real ".")` → `-1.0`
- - `(str.to_real "4564a")` → `-1.0`
- - `(str.to_real "4564e3")` → `-1.0`
-
-**`(str.from_real Real Int String)`**  
-Transforms a positive real number `r` to a string `s` with a corresponding number of decimal places `n`. If either `n` or `r` is negative, it evaluates to the empty string.  
-Examples:
- - `(str.from_real 4.56 5)` → `"4.56000"`
- - `(str.from_real 4.56 0)` → `"4"`
- - `(str.from_real 4.56 1)` → `"4.5"`
- - `(str.from_real -4.56 -5)` → `""`
- - `(str.from_real -4.56 5)` → `""`
- - `(str.from_real 4.56 -5)` → `""`
-
+## Additional string functions
+Other than the constraints defined in the [SMT-LIB theory of strings](https://smt-lib.org/theories-UnicodeStrings.shtml), Z3-Noodler can handle some additional functions
+(defined in [ADDITIONAL_FUNCTIONS.md](ADDITIONAL_FUNCTIONS.md)):
+ - `str.to_real`
+ - `str.from_real`
+ - `str.to_lower`
+ - `str.to_upper`
+ - `str.update`
+ - `str.trim`
+ - `str.delete`
 
 ## Publications
 - Y. Chen, V. Havlena, M.Hečko, L.Holík, and O. Lengál. [A Uniform Framework for Handling Position Constraints in String Solving](https://dl.acm.org/doi/10.1145/3729273). In *Proc. of PLDI'25*, volume 9, pages 550-575, 2025. ACM.

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -422,6 +422,10 @@ br_status seq_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * con
         SASSERT(num_args == 3);
         st = mk_str_update(args[0], args[1], args[2], result);
         break;
+    case OP_STRING_TRIM:
+        SASSERT(num_args == 1);
+        st = mk_str_trim(args[0], result);
+        break;
     case OP_STRING_IS_DIGIT:
         SASSERT(num_args == 1);
         st = mk_str_is_digit(args[0], result);
@@ -2437,6 +2441,29 @@ br_status seq_rewriter::mk_str_update(expr* a, expr* b, expr* c, expr_ref& resul
         }
         result = str().mk_string(r);
 
+        return BR_DONE;
+    }
+    return BR_FAILED;
+}
+
+br_status seq_rewriter::mk_str_trim(expr* a, expr_ref& result) {
+    zstring s;
+    const static std::set<uint32_t> whitespace_chars{ U' ', U'\f', U'\n', U'\r', U'\t', U'\v' };
+    if (str().is_string(a, s)) {
+        unsigned start, end;
+        for (start = 0; start < s.length(); start++) {
+            if (!whitespace_chars.contains(s[start])) break;
+        }
+        for (end = s.length(); end > 0; end--) {
+            if (!whitespace_chars.contains(s[end - 1])) break;
+        }
+        if (start >= end) {
+            result = str().mk_string("");
+            return BR_DONE;
+        }
+
+        unsigned length = end - start;
+        result = str().mk_string(s.extract(start, length));
         return BR_DONE;
     }
     return BR_FAILED;

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -418,6 +418,10 @@ br_status seq_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * con
         SASSERT(num_args == 1);
         st = mk_str_to_upper(args[0], result);
         break;
+    case OP_STRING_UPDATE:
+        SASSERT(num_args == 3);
+        st = mk_str_update(args[0], args[1], args[2], result);
+        break;
     case OP_STRING_IS_DIGIT:
         SASSERT(num_args == 1);
         st = mk_str_is_digit(args[0], result);
@@ -2406,6 +2410,36 @@ br_status seq_rewriter::mk_str_to_upper(expr* a, expr_ref& result) {
     }
     result = a;
     return BR_REWRITE_FULL;
+}
+
+br_status seq_rewriter::mk_str_update(expr* a, expr* b, expr* c, expr_ref& result) {
+    zstring s1, s2;
+    rational start;
+    if (str().is_string(a, s1) &&
+        m_autil.is_numeral(b, start) &&
+        start.is_int() &&
+        str().is_string(c, s2)) {
+
+        // index outside range
+        if (start.is_neg() || start >= s1.length()) {
+            result = str().mk_string(s1);
+            return BR_DONE;
+        }
+
+        zstring r;
+        unsigned start_u = start.get_unsigned();
+        for (unsigned i = 0; i < s1.length(); i++) {
+            if (i >= start_u && i - start_u < s2.length()) {
+                r += s2[i - start_u];
+            } else {
+                r += s1[i];
+            }
+        }
+        result = str().mk_string(r);
+
+        return BR_DONE;
+    }
+    return BR_FAILED;
 }
 
 br_status seq_rewriter::mk_str_is_digit(expr* a, expr_ref& result) {

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -426,6 +426,10 @@ br_status seq_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * con
         SASSERT(num_args == 1);
         st = mk_str_trim(args[0], result);
         break;
+    case OP_STRING_DELETE:
+        SASSERT(num_args == 3);
+        st = mk_str_delete(args[0], args[1], args[2], result);
+        break;
     case OP_STRING_IS_DIGIT:
         SASSERT(num_args == 1);
         st = mk_str_is_digit(args[0], result);
@@ -2464,6 +2468,38 @@ br_status seq_rewriter::mk_str_trim(expr* a, expr_ref& result) {
 
         unsigned length = end - start;
         result = str().mk_string(s.extract(start, length));
+        return BR_DONE;
+    }
+    return BR_FAILED;
+}
+
+br_status seq_rewriter::mk_str_delete(expr* a, expr* b, expr* c, expr_ref& result) {
+    zstring s;
+    rational start, len;
+    if (str().is_string(a, s) &&
+        m_autil.is_numeral(b, start) &&
+        start.is_int() &&
+        m_autil.is_numeral(c, len) &&
+        len.is_int()) {
+
+        if (start.is_neg() || start >= s.length() || len <= 0) {
+            result = str().mk_string(s);
+            return BR_DONE;
+        }
+
+        zstring r;
+        unsigned start_u = start.get_unsigned();
+        for (unsigned i = 0; i < s.length(); i++) {
+            if (i == start_u) {
+                // Skip the deleted part
+                if (len + i >= s.length()) break;
+                i += len.get_unsigned() - 1;
+                continue;
+            }
+            r += s[i];
+        }
+        result = str().mk_string(r);
+
         return BR_DONE;
     }
     return BR_FAILED;

--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -410,6 +410,14 @@ br_status seq_rewriter::mk_app_core(func_decl * f, unsigned num_args, expr * con
         SASSERT(num_args == 1);
         st = mk_str_to_code(args[0], result);
         break;
+    case OP_STRING_TO_LOWER:
+        SASSERT(num_args == 1);
+        st = mk_str_to_lower(args[0], result);
+        break;
+    case OP_STRING_TO_UPPER:
+        SASSERT(num_args == 1);
+        st = mk_str_to_upper(args[0], result);
+        break;
     case OP_STRING_IS_DIGIT:
         SASSERT(num_args == 1);
         st = mk_str_is_digit(args[0], result);
@@ -2342,6 +2350,62 @@ br_status seq_rewriter::mk_str_to_code(expr* a, expr_ref& result) {
         return BR_DONE;
     }    
     return BR_FAILED;
+}
+
+br_status seq_rewriter::mk_str_to_lower(expr* a, expr_ref& result) {
+    zstring s;
+
+    constexpr int case_diff = 'A' - 'a';
+
+    if (str().is_string(a, s)) {
+        zstring lowercase;
+        for(unsigned i = 0; i < s.length(); i++) {
+            auto ch = s[i];
+            if (ch >= 'A' && ch <= 'Z') {
+                ch -= case_diff;
+            }
+            lowercase += ch;
+        }
+        result = str().mk_string(lowercase);
+        return BR_DONE;
+    }
+
+    for (char ch = 'A'; ch <= 'Z'; ch++) {
+        a = str().mk_replace_all(
+                a,
+                str().mk_string(zstring(ch)),
+                str().mk_string(zstring(ch - case_diff)));
+    }
+    result = a;
+    return BR_REWRITE_FULL;
+}
+
+br_status seq_rewriter::mk_str_to_upper(expr* a, expr_ref& result) {
+    zstring s;
+
+    constexpr int case_diff = 'A' - 'a';
+
+    if (str().is_string(a, s)) {
+        zstring uppercase;
+        for(unsigned i = 0; i < s.length(); i++) {
+            auto ch = s[i];
+            if (ch >= 'a' && ch <= 'z') {
+                ch += case_diff;
+            }
+            uppercase += ch;
+        }
+        result = str().mk_string(uppercase);
+        return BR_DONE;
+    }
+
+    for (char ch = 'a'; ch <= 'z'; ch++) {
+        a = str().mk_replace_all(
+                a,
+                str().mk_string(zstring(ch)),
+                str().mk_string(zstring(ch + case_diff)));
+    }
+    result = a;
+    return BR_REWRITE_FULL;
 }
 
 br_status seq_rewriter::mk_str_is_digit(expr* a, expr_ref& result) {

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -256,6 +256,8 @@ class seq_rewriter {
     br_status mk_str_lt(expr* a, expr* b, expr_ref& result);
     br_status mk_str_from_code(expr* a, expr_ref& result);
     br_status mk_str_to_code(expr* a, expr_ref& result);
+    br_status mk_str_to_lower(expr* a, expr_ref& result);
+    br_status mk_str_to_upper(expr* a, expr_ref& result);
     br_status mk_str_is_digit(expr* a, expr_ref& result);
     br_status mk_re_concat(expr* a, expr* b, expr_ref& result);
     br_status mk_re_union(expr* a, expr* b, expr_ref& result);

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -259,6 +259,7 @@ class seq_rewriter {
     br_status mk_str_to_lower(expr* a, expr_ref& result);
     br_status mk_str_to_upper(expr* a, expr_ref& result);
     br_status mk_str_update(expr* a, expr* b, expr* c, expr_ref& result);
+    br_status mk_str_trim(expr* a, expr_ref& result);
     br_status mk_str_is_digit(expr* a, expr_ref& result);
     br_status mk_re_concat(expr* a, expr* b, expr_ref& result);
     br_status mk_re_union(expr* a, expr* b, expr_ref& result);

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -260,6 +260,7 @@ class seq_rewriter {
     br_status mk_str_to_upper(expr* a, expr_ref& result);
     br_status mk_str_update(expr* a, expr* b, expr* c, expr_ref& result);
     br_status mk_str_trim(expr* a, expr_ref& result);
+    br_status mk_str_delete(expr* a, expr* b, expr* c, expr_ref& result);
     br_status mk_str_is_digit(expr* a, expr_ref& result);
     br_status mk_re_concat(expr* a, expr* b, expr_ref& result);
     br_status mk_re_union(expr* a, expr* b, expr_ref& result);

--- a/src/ast/rewriter/seq_rewriter.h
+++ b/src/ast/rewriter/seq_rewriter.h
@@ -258,6 +258,7 @@ class seq_rewriter {
     br_status mk_str_to_code(expr* a, expr_ref& result);
     br_status mk_str_to_lower(expr* a, expr_ref& result);
     br_status mk_str_to_upper(expr* a, expr_ref& result);
+    br_status mk_str_update(expr* a, expr* b, expr* c, expr_ref& result);
     br_status mk_str_is_digit(expr* a, expr_ref& result);
     br_status mk_re_concat(expr* a, expr* b, expr_ref& result);
     br_status mk_re_union(expr* a, expr* b, expr_ref& result);

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -262,6 +262,7 @@ void seq_decl_plugin::init() {
     m_sigs[OP_STRING_TO_UPPER]   = alloc(psig, m, "str.to_upper", 0, 1, &strT, strT);
     m_sigs[OP_STRING_UPDATE]     = alloc(psig, m, "str.update", 0, 3, strTintTstrT, strT);
     m_sigs[OP_STRING_TRIM]       = alloc(psig, m, "str.trim", 0, 1, &strT, strT);
+    m_sigs[OP_STRING_DELETE]     = alloc(psig, m, "str.delete", 0, 3, strTint2T, strT);
     m_sigs[OP_STRING_IS_DIGIT]   = alloc(psig, m, "str.is_digit", 0, 1, &strT, boolT);
     m_sigs[OP_STRING_TO_CODE]    = alloc(psig, m, "str.to_code", 0, 1, &strT, intT);
     m_sigs[OP_STRING_FROM_CODE]  = alloc(psig, m, "str.from_code", 0, 1, &intT, strT);
@@ -434,6 +435,7 @@ func_decl* seq_decl_plugin::mk_func_decl(decl_kind k, unsigned num_parameters, p
     case OP_STRING_TO_UPPER:
     case OP_STRING_UPDATE:
     case OP_STRING_TRIM:
+    case OP_STRING_DELETE:
     case OP_STRING_IS_DIGIT:
     case OP_STRING_TO_CODE:
     case OP_STRING_FROM_CODE:

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -257,6 +257,8 @@ void seq_decl_plugin::init() {
     m_sigs[OP_STRING_STOR]		 = alloc(psig, m, "str.to_real", 0, 1, &strT, realT);
     m_sigs[OP_STRING_LT]         = alloc(psig, m, "str.<", 0, 2, str2T, boolT);
     m_sigs[OP_STRING_LE]         = alloc(psig, m, "str.<=", 0, 2, str2T, boolT);
+    m_sigs[OP_STRING_TO_LOWER]   = alloc(psig, m, "str.to_lower", 0, 1, &strT, strT);
+    m_sigs[OP_STRING_TO_UPPER]   = alloc(psig, m, "str.to_upper", 0, 1, &strT, strT);
     m_sigs[OP_STRING_IS_DIGIT]   = alloc(psig, m, "str.is_digit", 0, 1, &strT, boolT);
     m_sigs[OP_STRING_TO_CODE]    = alloc(psig, m, "str.to_code", 0, 1, &strT, intT);
     m_sigs[OP_STRING_FROM_CODE]  = alloc(psig, m, "str.from_code", 0, 1, &intT, strT);
@@ -425,6 +427,8 @@ func_decl* seq_decl_plugin::mk_func_decl(decl_kind k, unsigned num_parameters, p
 	case OP_STRING_STOR:
     case OP_STRING_LT:
     case OP_STRING_LE:
+    case OP_STRING_TO_LOWER:
+    case OP_STRING_TO_UPPER:
     case OP_STRING_IS_DIGIT:
     case OP_STRING_TO_CODE:
     case OP_STRING_FROM_CODE:

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -261,6 +261,7 @@ void seq_decl_plugin::init() {
     m_sigs[OP_STRING_TO_LOWER]   = alloc(psig, m, "str.to_lower", 0, 1, &strT, strT);
     m_sigs[OP_STRING_TO_UPPER]   = alloc(psig, m, "str.to_upper", 0, 1, &strT, strT);
     m_sigs[OP_STRING_UPDATE]     = alloc(psig, m, "str.update", 0, 3, strTintTstrT, strT);
+    m_sigs[OP_STRING_TRIM]       = alloc(psig, m, "str.trim", 0, 1, &strT, strT);
     m_sigs[OP_STRING_IS_DIGIT]   = alloc(psig, m, "str.is_digit", 0, 1, &strT, boolT);
     m_sigs[OP_STRING_TO_CODE]    = alloc(psig, m, "str.to_code", 0, 1, &strT, intT);
     m_sigs[OP_STRING_FROM_CODE]  = alloc(psig, m, "str.from_code", 0, 1, &intT, strT);
@@ -432,6 +433,7 @@ func_decl* seq_decl_plugin::mk_func_decl(decl_kind k, unsigned num_parameters, p
     case OP_STRING_TO_LOWER:
     case OP_STRING_TO_UPPER:
     case OP_STRING_UPDATE:
+    case OP_STRING_TRIM:
     case OP_STRING_IS_DIGIT:
     case OP_STRING_TO_CODE:
     case OP_STRING_FROM_CODE:

--- a/src/ast/seq_decl_plugin.cpp
+++ b/src/ast/seq_decl_plugin.cpp
@@ -203,6 +203,7 @@ void seq_decl_plugin::init() {
     sort* strTint2T[3] = { strT, intT, intT };
     sort* strTreT[2] = { strT, reT };
     sort* str2TintT[3] = { strT, strT, intT };
+    sort* strTintTstrT[3] = { strT, intT, strT };
     sort* seqAintT[2] = { seqA, intT };
     sort* seq3A[3] = { seqA, seqA, seqA };
     sort* realTintT[2] = { realT, intT };
@@ -259,6 +260,7 @@ void seq_decl_plugin::init() {
     m_sigs[OP_STRING_LE]         = alloc(psig, m, "str.<=", 0, 2, str2T, boolT);
     m_sigs[OP_STRING_TO_LOWER]   = alloc(psig, m, "str.to_lower", 0, 1, &strT, strT);
     m_sigs[OP_STRING_TO_UPPER]   = alloc(psig, m, "str.to_upper", 0, 1, &strT, strT);
+    m_sigs[OP_STRING_UPDATE]     = alloc(psig, m, "str.update", 0, 3, strTintTstrT, strT);
     m_sigs[OP_STRING_IS_DIGIT]   = alloc(psig, m, "str.is_digit", 0, 1, &strT, boolT);
     m_sigs[OP_STRING_TO_CODE]    = alloc(psig, m, "str.to_code", 0, 1, &strT, intT);
     m_sigs[OP_STRING_FROM_CODE]  = alloc(psig, m, "str.from_code", 0, 1, &intT, strT);
@@ -429,6 +431,7 @@ func_decl* seq_decl_plugin::mk_func_decl(decl_kind k, unsigned num_parameters, p
     case OP_STRING_LE:
     case OP_STRING_TO_LOWER:
     case OP_STRING_TO_UPPER:
+    case OP_STRING_UPDATE:
     case OP_STRING_IS_DIGIT:
     case OP_STRING_TO_CODE:
     case OP_STRING_FROM_CODE:

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -89,6 +89,8 @@ enum seq_op_kind {
     OP_STRING_SBVTOS,
     OP_STRING_LT,
     OP_STRING_LE,
+    OP_STRING_TO_LOWER,
+    OP_STRING_TO_UPPER,
     OP_STRING_IS_DIGIT,
     OP_STRING_TO_CODE,
     OP_STRING_FROM_CODE,
@@ -317,6 +319,7 @@ public:
         app* mk_index(expr* a, expr* b, expr* i) const { expr* es[3] = { a, b, i}; return m.mk_app(m_fid, OP_SEQ_INDEX, 3, es); }
         app* mk_last_index(expr* a, expr* b) const { expr* es[2] = { a, b}; return m.mk_app(m_fid, OP_SEQ_LAST_INDEX, 2, es); }
         app* mk_replace(expr* a, expr* b, expr* c) const { expr* es[3] = { a, b, c}; return m.mk_app(m_fid, OP_SEQ_REPLACE, 3, es); }
+        app* mk_replace_all(expr* a, expr* b, expr* c) const { expr* es[3] = { a, b, c}; return m.mk_app(m_fid, OP_SEQ_REPLACE_ALL, 3, es); }
         app* mk_unit(expr* u) const { return m.mk_app(m_fid, OP_SEQ_UNIT, 1, &u); }
         app* mk_char(zstring const& s, unsigned idx) const;
         app* mk_char_bit(expr* e, unsigned i);
@@ -331,6 +334,8 @@ public:
         app* mk_lex_le(expr* a, expr* b) const { expr* es[2] = { a, b }; return m.mk_app(m_fid, OP_STRING_LE, 2, es); }
         app* mk_to_code(expr* e) const { return m.mk_app(m_fid, OP_STRING_TO_CODE, 1, &e); }
         app* mk_from_code(expr* e) const { return m.mk_app(m_fid, OP_STRING_FROM_CODE, 1, &e); }
+        app* mk_to_lower(expr* e) const { return m.mk_app(m_fid, OP_STRING_TO_LOWER, 1, &e); }
+        app* mk_to_upper(expr* e) const { return m.mk_app(m_fid, OP_STRING_TO_UPPER, 1, &e); }
         app* mk_is_digit(expr* e) const { return m.mk_app(m_fid, OP_STRING_IS_DIGIT, 1, &e); }
 
 
@@ -376,6 +381,8 @@ public:
         bool is_unit(expr const* n)     const { return is_app_of(n, m_fid, OP_SEQ_UNIT); }
         bool is_lt(expr const* n)       const { return is_app_of(n, m_fid, OP_STRING_LT); }
         bool is_le(expr const* n)       const { return is_app_of(n, m_fid, OP_STRING_LE); }
+        bool is_to_lower(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_LOWER); }
+        bool is_to_upper(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_UPPER); }
         bool is_is_digit(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_IS_DIGIT); }
         bool is_from_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_FROM_CODE); }
         bool is_to_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_CODE); }
@@ -425,6 +432,8 @@ public:
         MATCH_UNARY(is_stor);
         MATCH_UNARY(is_ubv2s);
         MATCH_UNARY(is_sbv2s);
+        MATCH_UNARY(is_to_lower);
+        MATCH_UNARY(is_to_upper);
         MATCH_UNARY(is_is_digit);
         MATCH_UNARY(is_from_code);
         MATCH_UNARY(is_to_code);

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -91,6 +91,7 @@ enum seq_op_kind {
     OP_STRING_LE,
     OP_STRING_TO_LOWER,
     OP_STRING_TO_UPPER,
+    OP_STRING_UPDATE,
     OP_STRING_IS_DIGIT,
     OP_STRING_TO_CODE,
     OP_STRING_FROM_CODE,
@@ -336,6 +337,7 @@ public:
         app* mk_from_code(expr* e) const { return m.mk_app(m_fid, OP_STRING_FROM_CODE, 1, &e); }
         app* mk_to_lower(expr* e) const { return m.mk_app(m_fid, OP_STRING_TO_LOWER, 1, &e); }
         app* mk_to_upper(expr* e) const { return m.mk_app(m_fid, OP_STRING_TO_UPPER, 1, &e); }
+        app* mk_update(expr* a, expr* b, expr* c) const { expr* es[3] = { a, b, c }; return m.mk_app(m_fid, OP_STRING_UPDATE, 3, es); }
         app* mk_is_digit(expr* e) const { return m.mk_app(m_fid, OP_STRING_IS_DIGIT, 1, &e); }
 
 
@@ -383,6 +385,7 @@ public:
         bool is_le(expr const* n)       const { return is_app_of(n, m_fid, OP_STRING_LE); }
         bool is_to_lower(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_LOWER); }
         bool is_to_upper(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_UPPER); }
+        bool is_update(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_UPDATE); }
         bool is_is_digit(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_IS_DIGIT); }
         bool is_from_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_FROM_CODE); }
         bool is_to_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_CODE); }
@@ -434,6 +437,7 @@ public:
         MATCH_UNARY(is_sbv2s);
         MATCH_UNARY(is_to_lower);
         MATCH_UNARY(is_to_upper);
+        MATCH_TERNARY(is_update);
         MATCH_UNARY(is_is_digit);
         MATCH_UNARY(is_from_code);
         MATCH_UNARY(is_to_code);

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -94,6 +94,7 @@ enum seq_op_kind {
     OP_STRING_UPDATE,
     OP_STRING_TRIM,
     OP_STRING_IS_DIGIT,
+    OP_STRING_DELETE,
     OP_STRING_TO_CODE,
     OP_STRING_FROM_CODE,
 
@@ -340,6 +341,7 @@ public:
         app* mk_to_upper(expr* e) const { return m.mk_app(m_fid, OP_STRING_TO_UPPER, 1, &e); }
         app* mk_update(expr* a, expr* b, expr* c) const { expr* es[3] = { a, b, c }; return m.mk_app(m_fid, OP_STRING_UPDATE, 3, es); }
         app* mk_trim(expr* e) const { return m.mk_app(m_fid, OP_STRING_TRIM, 1, &e); }
+        app* mk_delete(expr* a, expr* b, expr* c) const { expr* es[3] = { a, b, c }; return m.mk_app(m_fid, OP_STRING_DELETE, 3, es); }
         app* mk_is_digit(expr* e) const { return m.mk_app(m_fid, OP_STRING_IS_DIGIT, 1, &e); }
 
 
@@ -389,6 +391,7 @@ public:
         bool is_to_upper(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_UPPER); }
         bool is_update(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_UPDATE); }
         bool is_trim(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TRIM); }
+        bool is_delete(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_DELETE); }
         bool is_is_digit(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_IS_DIGIT); }
         bool is_from_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_FROM_CODE); }
         bool is_to_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_CODE); }
@@ -442,6 +445,7 @@ public:
         MATCH_UNARY(is_to_upper);
         MATCH_TERNARY(is_update);
         MATCH_UNARY(is_trim);
+        MATCH_TERNARY(is_delete);
         MATCH_UNARY(is_is_digit);
         MATCH_UNARY(is_from_code);
         MATCH_UNARY(is_to_code);

--- a/src/ast/seq_decl_plugin.h
+++ b/src/ast/seq_decl_plugin.h
@@ -92,6 +92,7 @@ enum seq_op_kind {
     OP_STRING_TO_LOWER,
     OP_STRING_TO_UPPER,
     OP_STRING_UPDATE,
+    OP_STRING_TRIM,
     OP_STRING_IS_DIGIT,
     OP_STRING_TO_CODE,
     OP_STRING_FROM_CODE,
@@ -338,6 +339,7 @@ public:
         app* mk_to_lower(expr* e) const { return m.mk_app(m_fid, OP_STRING_TO_LOWER, 1, &e); }
         app* mk_to_upper(expr* e) const { return m.mk_app(m_fid, OP_STRING_TO_UPPER, 1, &e); }
         app* mk_update(expr* a, expr* b, expr* c) const { expr* es[3] = { a, b, c }; return m.mk_app(m_fid, OP_STRING_UPDATE, 3, es); }
+        app* mk_trim(expr* e) const { return m.mk_app(m_fid, OP_STRING_TRIM, 1, &e); }
         app* mk_is_digit(expr* e) const { return m.mk_app(m_fid, OP_STRING_IS_DIGIT, 1, &e); }
 
 
@@ -386,6 +388,7 @@ public:
         bool is_to_lower(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_LOWER); }
         bool is_to_upper(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_UPPER); }
         bool is_update(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_UPDATE); }
+        bool is_trim(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TRIM); }
         bool is_is_digit(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_IS_DIGIT); }
         bool is_from_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_FROM_CODE); }
         bool is_to_code(expr const* n) const { return is_app_of(n, m_fid, OP_STRING_TO_CODE); }
@@ -438,6 +441,7 @@ public:
         MATCH_UNARY(is_to_lower);
         MATCH_UNARY(is_to_upper);
         MATCH_TERNARY(is_update);
+        MATCH_UNARY(is_trim);
         MATCH_UNARY(is_is_digit);
         MATCH_UNARY(is_from_code);
         MATCH_UNARY(is_to_code);

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -206,12 +206,14 @@ namespace smt::noodler {
         // on higher decision level than 0 (otherwise the axioms are lost).
         // String propagation of the input formula works on level 0.
         if(init && (
-            m_util_s.str.is_index(ex) || 
+            m_util_s.str.is_index(ex) ||
             m_util_s.str.is_at(ex) ||
             m_util_s.str.is_extract(ex) ||
-            m_util_s.str.is_replace(ex) || 
+            m_util_s.str.is_replace(ex) ||
             m_util_s.str.is_replace_all(ex) ||
-            m_util_s.str.is_replace_re_all(ex)
+            m_util_s.str.is_replace_re_all(ex) ||
+            m_util_s.str.is_replace_re(ex) ||
+            m_util_s.str.is_update(ex)
         )) {
             ctx.mark_as_relevant(ex);
         }
@@ -433,6 +435,8 @@ namespace smt::noodler {
             handle_replace_re(n);
         } else if(m_util_s.str.is_replace_re_all(n)) { // str.replace_re_all
             handle_replace_re_all(n);
+        } else if(m_util_s.str.is_update(n)) {
+            handle_update(n);
         } else if (m_util_s.str.is_is_digit(n)) { // str.is_digit
             handle_is_digit(n);
         } else if (
@@ -1465,6 +1469,86 @@ namespace smt::noodler {
         VERIFY(m_util_s.str.is_replace_re_all(e, s, i, l));
 
         expr_ref v = get_fresh_var_for_string_function("replace_re_all", e);
+    }
+
+    /**
+     * @brief Handling of str.update(w, i, r)
+     * Starts replacing characters in w at index i with characters in r
+     * The resulting string will always have the same length as w,
+     * meaning if r is too long to fit into w, it will get truncated
+     * (e.g. str.update("aaaa", 2, "bbbb") = "aabb")
+     *
+     * 0 <= i < |w| && |r| > 0  ->  str.update(w, i, r) = u1 u2 u3
+     * 0 <= i < |w| && |r| > 0  ->  w = u1 x u3
+     * 0 <= i < |w| && |r| > 0  ->  |u1| = i
+     * 0 <= i < |w| && |r| > 0  ->  |x| = |u2|
+     * 0 <= i < |w| && |r| > 0  ->  r = u2 y
+     * 0 <= i < |w| && |r| > 0 && |r| >  |w| - i  ->  |u2| = |w| - i
+     * 0 <= i < |w| && |r| > 0 && |r| <= |w| - i  ->  |u2| = |r|
+     *
+     * i < 0   -> str.update(w, i, r) = w;
+     * i >=|w| -> str.update(w, i, r) = w;
+     * |r| <= 0 -> str.update = w (not completely necessary, helps z3)
+     *
+     * @param e The str.update(w, i, r) term
+     */
+    void theory_str_noodler::handle_update(expr *e) {
+        if (axiomatized_persist_terms.contains(e)) { return; }
+        axiomatized_persist_terms.insert(e);
+
+        expr *w = nullptr, *i = nullptr, *r = nullptr;
+        VERIFY(m_util_s.str.is_update(e, w, i, r));
+
+        expr_ref x = mk_str_var_fresh("update_removing");
+        expr_ref y = mk_str_var_fresh("update_overflow");
+        expr_ref u1 = mk_str_var_fresh("update_left");
+        expr_ref u2 = mk_str_var_fresh("update_center");
+        expr_ref u3 = mk_str_var_fresh("update_right");
+
+        expr_ref result = get_fresh_var_for_string_function("update", e);
+
+        expr_ref u1_x_u3 = mk_concat(u1, mk_concat(x, u3));
+        expr_ref u2_y = mk_concat(u2, y);
+        expr_ref u1_u2_u3 = mk_concat(u1, mk_concat(u2, u3));
+
+        // |r| > |w| - i
+        literal will_overflow = mk_literal(m_util_a.mk_gt(m_util_s.str.mk_length(r), m_util_a.mk_sub(m_util_s.str.mk_length(w), i)));
+
+        expr_ref zero(m_util_a.mk_int(0), m);
+        // i >= 0
+        literal i_ge_zero = mk_literal(m_util_a.mk_ge(i, zero));
+        // i < |w|
+        literal i_lt_len_w = mk_literal(m_util_a.mk_lt(i, m_util_s.str.mk_length(w)));
+        // |r| <= 0
+        literal r_len_le_zero = mk_literal(m_util_a.mk_le(m_util_s.str.mk_length(r), zero));
+
+        // 0 <= i < |w| && |r| > 0  ->  str.update(w, i, r) = u1 u2 u3
+        add_axiom({~i_ge_zero, ~i_lt_len_w, r_len_le_zero, mk_eq(u1_u2_u3, result, false)});
+        // 0 <= i < |w| && |r| > 0  ->  w = u1 x u3
+        add_axiom({~i_ge_zero, ~i_lt_len_w, r_len_le_zero, mk_eq(u1_x_u3, w, false)});
+        // 0 <= i < |w| && |r| > 0  ->  |u1| = i
+        add_axiom({~i_ge_zero, ~i_lt_len_w, r_len_le_zero, mk_eq(i, m_util_s.str.mk_length(u1), false)});
+        // 0 <= i < |w| && |r| > 0  ->  |x| = |u2|
+        add_axiom({~i_ge_zero, ~i_lt_len_w, r_len_le_zero, mk_eq(m_util_s.str.mk_length(x), m_util_s.str.mk_length(u2), false)});
+        // 0 <= i < |w| && |r| > 0  ->  r = u2 y
+        add_axiom({~i_ge_zero, ~i_lt_len_w, r_len_le_zero, mk_eq(u2_y, r, false)});
+        // 0 <= i < |w| && |r| > 0 && |r| >  |w| - i ->  |u2| = |w| - i
+        add_axiom({~i_ge_zero, ~i_lt_len_w, r_len_le_zero, ~will_overflow, mk_eq(m_util_s.str.mk_length(u2), m_util_a.mk_sub(m_util_s.str.mk_length(w), i), false)});
+        // 0 <= i < |w| && |r| > 0 && |r| <= |w| - i ->  |u2| = |r|
+        add_axiom({~i_ge_zero, ~i_lt_len_w, r_len_le_zero, will_overflow, mk_eq(m_util_s.str.mk_length(u2), m_util_s.str.mk_length(r) , false)});
+
+        // i < 0   -> str.update(w, i, r) = w;
+        add_axiom({i_ge_zero, mk_eq(result, w, false)});
+        // i >=|w| -> str.update(w, i, r) = w;
+        add_axiom({i_lt_len_w, mk_eq(result, w, false)});
+        // |r| <= 0 -> str.update = w (not completely necessary, helps z3)
+        add_axiom({~r_len_le_zero, mk_eq(result, w, false)});
+
+        mark_expression_as_length(u1);
+        mark_expression_as_length(x);
+        mark_expression_as_length(u2);
+        mark_expression_as_length(r);
+        mark_expression_as_length(w);
     }
 
     expr_ref theory_str_noodler::mk_concat(expr* e1, expr* e2) {

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -214,7 +214,8 @@ namespace smt::noodler {
             m_util_s.str.is_replace_re_all(ex) ||
             m_util_s.str.is_replace_re(ex) ||
             m_util_s.str.is_update(ex) ||
-            m_util_s.str.is_trim(ex)
+            m_util_s.str.is_trim(ex) ||
+            m_util_s.str.is_delete(ex)
         )) {
             ctx.mark_as_relevant(ex);
         }
@@ -440,6 +441,8 @@ namespace smt::noodler {
             handle_update(n);
         } else if(m_util_s.str.is_trim(n)) {
             handle_trim(n);
+        } else if(m_util_s.str.is_delete(n)) {
+            handle_delete(n);
         } else if (m_util_s.str.is_is_digit(n)) { // str.is_digit
             handle_is_digit(n);
         } else if (
@@ -1610,6 +1613,73 @@ namespace smt::noodler {
         add_axiom({mk_literal(m_util_s.re.mk_in_re(tr, ws_star))});
         // u does not begin and end with whitespace characters
         add_axiom({mk_literal(m_util_s.re.mk_in_re(u, middle_regex))});
+    }
+
+    /**
+     * @brief Handling of str.delete(w, i, l)
+     * Deletes a substring of length l from w at index i
+     *
+     * l <= 0   ->  str.delete(w, i, l) = w
+     * i <  0   ->  str.delete(w, i, l) = w
+     * i >= |w| ->  str.delete(w, i, l) = w
+     *
+     * 0 <= i < |w| && l > 0 -> str.delete(w, i, l) = u1 u2
+     * 0 <= i < |w| && l > 0 -> w = u1 x u2
+     * 0 <= i < |w| && l > 0 -> |u1| = i
+     * 0 <= i < |w| && l > 0 && i + l >= |w| -> u2 = ε
+     * 0 <= i < |w| && l > 0 && i + l <  |w| -> |x| = l
+     *
+     * @param e The str.delete(w, i, l) term
+     */
+    void theory_str_noodler::handle_delete(expr *e) {
+        if (axiomatized_persist_terms.contains(e)) { return; }
+        axiomatized_persist_terms.insert(e);
+
+        expr *w = nullptr, *i = nullptr, *l = nullptr;
+        VERIFY(m_util_s.str.is_delete(e, w, i, l));
+
+        STRACE(str, tout << "handle delete: " << mk_pp(e, m) << '\n';);
+
+        expr_ref u1 = mk_str_var_fresh("delete_left");
+        expr_ref u2 = mk_str_var_fresh("delete_right");
+        expr_ref x = mk_str_var_fresh("delete_remove");
+
+        expr_ref result = get_fresh_var_for_string_function("delete", e);
+
+        expr_ref u1_x_u2 = mk_concat(u1, mk_concat(x, u2));
+        expr_ref u1_u2 = mk_concat(u1, u2);
+
+        expr_ref zero(m_util_a.mk_int(0), m);
+        // i >= 0
+        literal i_ge_zero = mk_literal(m_util_a.mk_ge(i, zero));
+        // i < |w|
+        literal i_lt_len_w = mk_literal(m_util_a.mk_lt(i, m_util_s.str.mk_length(w)));
+        // l > 0
+        literal l_gt_zero = mk_literal(m_util_a.mk_gt(l, zero));
+        // i + l >= |w|
+        literal i_plus_l_ge_len_w = mk_literal(m_util_a.mk_ge(m_util_a.mk_add(i, l), m_util_s.str.mk_length(w)));
+
+        // l <= 0   ->  str.delete(w, i, l) = w
+        add_axiom({l_gt_zero, mk_eq(result, w, false)});
+        // i <  0   ->  str.delete(w, i, l) = w
+        add_axiom({i_ge_zero, mk_eq(result, w, false)});
+        // i >= |w| ->  str.delete(w, i, l) = w
+        add_axiom({i_lt_len_w, mk_eq(result, w, false)});
+
+        // 0 <= i < |w| && l > 0 -> str.delete(w, i, l) = u1 u2
+        add_axiom({~i_ge_zero, ~i_lt_len_w, ~l_gt_zero, mk_eq(result, u1_u2, false)});
+        // 0 <= i < |w| && l > 0 -> w = u1 x u2
+        add_axiom({~i_ge_zero, ~i_lt_len_w, ~l_gt_zero, mk_eq(w, u1_x_u2, false)});
+        // 0 <= i < |w| && l > 0 -> |u1| = i
+        add_axiom({~i_ge_zero, ~i_lt_len_w, ~l_gt_zero, mk_eq(m_util_s.str.mk_length(u1), i, false)});
+        // 0 <= i < |w| && l > 0 && i + l >= |w| -> u2 = ε
+        add_axiom({~i_ge_zero, ~i_lt_len_w, ~l_gt_zero, ~i_plus_l_ge_len_w, mk_eq(u2, m_util_s.str.mk_string(""), false)});
+        // 0 <= i < |w| && l > 0 && i + l <  |w| -> |x| = l
+        add_axiom({~i_ge_zero, ~i_lt_len_w, ~l_gt_zero, i_plus_l_ge_len_w, mk_eq(l, m_util_s.str.mk_length(x), false)});
+
+        mark_expression_as_length(w);
+        mark_expression_as_length(u1);
+        mark_expression_as_length(x);
     }
 
     expr_ref theory_str_noodler::mk_concat(expr* e1, expr* e2) {

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -1517,14 +1517,14 @@ namespace smt::noodler {
         expr_ref u2_y = mk_concat(u2, y);
         expr_ref u1_u2_u3 = mk_concat(u1, mk_concat(u2, u3));
 
-        // |r| > |w| - i
-        literal will_overflow = mk_literal(m_util_a.mk_gt(m_util_s.str.mk_length(r), m_util_a.mk_sub(m_util_s.str.mk_length(w), i)));
-
         expr_ref zero(m_util_a.mk_int(0), m);
+
+        // |r| > |w| - i
+        literal will_overflow = mk_literal(m_util_a.mk_gt(mk_sub(m_util_s.str.mk_length(r), m_util_a.mk_sub(m_util_s.str.mk_length(w), i)), zero));
         // i >= 0
         literal i_ge_zero = mk_literal(m_util_a.mk_ge(i, zero));
         // i < |w|
-        literal i_lt_len_w = mk_literal(m_util_a.mk_lt(i, m_util_s.str.mk_length(w)));
+        literal i_lt_len_w = mk_literal(m_util_a.mk_lt(mk_sub(i, m_util_s.str.mk_length(w)), zero));
         // |r| <= 0
         literal r_len_le_zero = mk_literal(m_util_a.mk_le(m_util_s.str.mk_length(r), zero));
 
@@ -1653,11 +1653,11 @@ namespace smt::noodler {
         // i >= 0
         literal i_ge_zero = mk_literal(m_util_a.mk_ge(i, zero));
         // i < |w|
-        literal i_lt_len_w = mk_literal(m_util_a.mk_lt(i, m_util_s.str.mk_length(w)));
+        literal i_lt_len_w = mk_literal(m_util_a.mk_lt(mk_sub(i, m_util_s.str.mk_length(w)), zero));
         // l > 0
         literal l_gt_zero = mk_literal(m_util_a.mk_gt(l, zero));
         // i + l >= |w|
-        literal i_plus_l_ge_len_w = mk_literal(m_util_a.mk_ge(m_util_a.mk_add(i, l), m_util_s.str.mk_length(w)));
+        literal i_plus_l_ge_len_w = mk_literal(m_util_a.mk_ge(mk_sub(m_util_a.mk_add(i, l), m_util_s.str.mk_length(w)), zero));
 
         // l <= 0   ->  str.delete(w, i, l) = w
         add_axiom({l_gt_zero, mk_eq(result, w, false)});

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -213,7 +213,8 @@ namespace smt::noodler {
             m_util_s.str.is_replace_all(ex) ||
             m_util_s.str.is_replace_re_all(ex) ||
             m_util_s.str.is_replace_re(ex) ||
-            m_util_s.str.is_update(ex)
+            m_util_s.str.is_update(ex) ||
+            m_util_s.str.is_trim(ex)
         )) {
             ctx.mark_as_relevant(ex);
         }
@@ -437,6 +438,8 @@ namespace smt::noodler {
             handle_replace_re_all(n);
         } else if(m_util_s.str.is_update(n)) {
             handle_update(n);
+        } else if(m_util_s.str.is_trim(n)) {
+            handle_trim(n);
         } else if (m_util_s.str.is_is_digit(n)) { // str.is_digit
             handle_is_digit(n);
         } else if (
@@ -1549,6 +1552,64 @@ namespace smt::noodler {
         mark_expression_as_length(u2);
         mark_expression_as_length(r);
         mark_expression_as_length(w);
+    }
+
+    /**
+     * @brief Handling of str.trim(w)
+     * Trims the whitespace at the edges of w
+     *
+     * str.trim(w) = u
+     * w = tl u tr
+     * tl, tr ∈ WS*
+     * u ∈ (Σ\WS)* + (Σ\WS)Σ*(Σ\WS) (u must not start and end with whitespace)
+     * WS = " " + "\f" + "\n" + "\r" + "\t" + "\v"
+     *
+     * @param e The str.trim(w) term
+     */
+    void theory_str_noodler::handle_trim(expr *e) {
+        if (axiomatized_persist_terms.contains(e)) { return; }
+        axiomatized_persist_terms.insert(e);
+
+        expr *w = nullptr;
+        VERIFY(m_util_s.str.is_trim(e, w));
+
+        expr_ref tl = mk_str_var_fresh("trim_left");
+        expr_ref tr = mk_str_var_fresh("trim_right");
+
+        expr_ref u = get_fresh_var_for_string_function("trim", e);
+
+        expr_ref tl_u_tr = mk_concat(tl, mk_concat(u, tr));
+
+        // WS = " " + "\f" + "\n" + "\r" + "\t" + "\v"
+        expr_ref whitespace_re(m_util_s.re.mk_to_re(m_util_s.str.mk_string(" ")), m);
+        for (auto ws : { "\f", "\n", "\r", "\t", "\v" }) {
+            whitespace_re = expr_ref(m_util_s.re.mk_union(
+                        whitespace_re,
+                        m_util_s.re.mk_to_re(m_util_s.str.mk_string(ws))), m);
+        }
+        // sigma \ WS
+        expr_ref sigma_minus_ws(m_util_s.re.mk_diff(m_util_s.re.mk_full_char(nullptr), whitespace_re), m);
+        // sigma*
+        expr_ref sigma_star(m_util_s.re.mk_star(m_util_s.re.mk_full_char(nullptr)), m);
+        // WS*
+        expr_ref ws_star(m_util_s.re.mk_star(whitespace_re), m);
+        // (sigma \ WS)* + ((sigma \ WS) . sigma_star . (sigma \ WS))
+        expr_ref middle_regex(m_util_s.re.mk_union(
+                    // u is either in (sigma\WS)* - covers if u is eps or one character long
+                    m_util_s.re.mk_star(sigma_minus_ws),
+                    // or u is in (sigma\WS)sigma*(sigma\WS) - sigma star surrounded with non whitespace characters
+                    m_util_s.re.mk_concat(sigma_minus_ws, m_util_s.re.mk_concat(sigma_star, sigma_minus_ws))
+                    ), m);
+
+
+        // w = tl u tr
+        add_axiom({mk_eq(w, tl_u_tr, false)});
+        // tl is whitespace
+        add_axiom({mk_literal(m_util_s.re.mk_in_re(tl, ws_star))});
+        // tr is whitespace
+        add_axiom({mk_literal(m_util_s.re.mk_in_re(tr, ws_star))});
+        // u does not begin and end with whitespace characters
+        add_axiom({mk_literal(m_util_s.re.mk_in_re(u, middle_regex))});
     }
 
     expr_ref theory_str_noodler::mk_concat(expr* e1, expr* e2) {

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -332,6 +332,7 @@ namespace smt::noodler {
         void handle_replace_all(expr *e);
         void handle_replace_re_all(expr *e);
         void handle_update(expr *e);
+        void handle_trim(expr *e);
 
         /**
          * @brief Marks a string term @p e as length-aware

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -333,6 +333,7 @@ namespace smt::noodler {
         void handle_replace_re_all(expr *e);
         void handle_update(expr *e);
         void handle_trim(expr *e);
+        void handle_delete(expr *e);
 
         /**
          * @brief Marks a string term @p e as length-aware

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -331,6 +331,7 @@ namespace smt::noodler {
         void handle_lex_lt(expr *e);
         void handle_replace_all(expr *e);
         void handle_replace_re_all(expr *e);
+        void handle_update(expr *e);
 
         /**
          * @brief Marks a string term @p e as length-aware

--- a/src/test/noodler/e2e/delete.smt2
+++ b/src/test/noodler/e2e/delete.smt2
@@ -1,0 +1,40 @@
+(set-logic QF_SLIA)
+(set-info :status sat)
+
+(declare-const x String)
+(declare-const a String)
+(declare-const b String)
+(assert (= x (str.++ a b)))
+(assert (str.in_re a (re.* (str.to_re "a"))))
+(assert (str.in_re b (re.* (str.to_re "b"))))
+(assert (= (str.len a) 4))
+(assert (= (str.len b) 4))
+
+; x = aaaabbbb
+
+(assert (= (str.delete x 2 4) "aabb"))
+(assert (= (str.delete x 2 10) "aa"))
+(assert (= (str.delete x 2 5) "aab"))
+(assert (= (str.delete x 2 6) "aa"))
+(assert (= (str.delete x 2 7) "aa"))
+(assert (= (str.delete x 0 8) ""))
+(assert (= (str.delete x 0 99) ""))
+(assert (= (str.delete x -1 4) "aaaabbbb"))
+(assert (= (str.delete x 8 2) "aaaabbbb"))
+(assert (= (str.delete x 9 2) "aaaabbbb"))
+(assert (= (str.delete x 2 -2) "aaaabbbb"))
+
+; rewriter
+(assert (= (str.delete "aaxxxxbb" 2 4) "aabb"))
+(assert (= (str.delete "xxxxaabb" 0 4) "aabb"))
+(assert (= (str.delete "aaxxxx" 2 99) "aa"))
+(assert (= (str.delete "aaxxxx" 2 4) "aa"))
+(assert (= (str.delete "xxxx" 0 4) ""))
+(assert (= (str.delete "xxxx" 0 5) ""))
+(assert (= (str.delete "xxxx" 0 99) ""))
+(assert (= (str.delete "aaaa" -1 2) "aaaa"))
+(assert (= (str.delete "aaaa" 2 0) "aaaa"))
+(assert (= (str.delete "aaaa" 2 -1) "aaaa"))
+(assert (= (str.delete "aaaa" 10 2) "aaaa"))
+
+(check-sat)

--- a/src/test/noodler/e2e/delete.smt2
+++ b/src/test/noodler/e2e/delete.smt2
@@ -24,6 +24,14 @@
 (assert (= (str.delete x 9 2) "aaaabbbb"))
 (assert (= (str.delete x 2 -2) "aaaabbbb"))
 
+; variable index and length
+(declare-const i Int)
+(declare-const j Int)
+(declare-const u String)
+(assert (= u (str.++ a b)))
+; u = aaaabbbb
+(assert (= (str.delete u i j) "aabb"))
+
 ; rewriter
 (assert (= (str.delete "aaxxxxbb" 2 4) "aabb"))
 (assert (= (str.delete "xxxxaabb" 0 4) "aabb"))

--- a/src/test/noodler/e2e/to_lower_to_upper.smt2
+++ b/src/test/noodler/e2e/to_lower_to_upper.smt2
@@ -1,0 +1,42 @@
+(set-logic QF_SLIA)
+(set-info :status sat)
+
+; to lower
+(declare-const x String)
+(assert (= (str.to_lower x) "aaa"))
+(assert (str.in_re x (re.* (str.to_re "A"))))
+; to lower rewriter
+(declare-const y String)
+(assert (= y (str.to_lower "AAa")))
+(assert (str.in_re y (re.* (str.to_re "a"))))
+
+; to upper
+(declare-const a String)
+(assert (= (str.to_upper a) "AAA"))
+(assert (str.in_re a (re.* (str.to_re "a"))))
+; to upper rewriter
+(declare-const b String)
+(assert (= b (str.to_upper "aAa")))
+(assert (str.in_re b (re.* (str.to_re "A"))))
+
+; to upper more complicated
+(declare-const u String)
+(assert (= u (str.to_upper "aAamMmzZz")))
+(assert (str.in_re u (re.++ (re.* (str.to_re "A")) (re.* (str.to_re "M")) (re.* (str.to_re "Z")))))
+(declare-const v String)
+(assert (= (str.to_upper v) "AAAMMMZZZ"))
+(assert (str.in_re v (re.++ (re.* (str.to_re "a")) (re.* (str.to_re "m")) (re.* (str.to_re "z")))))
+
+; to lower more complicated
+(declare-const z String)
+(assert (= z (str.to_lower "aAamMmzZz")))
+(assert (str.in_re z (re.++ (re.* (str.to_re "a")) (re.* (str.to_re "m")) (re.* (str.to_re "z")))))
+(declare-const zz String)
+(assert (= (str.to_lower zz) "aaammmzzz"))
+(assert (str.in_re zz (re.++ (re.* (str.to_re "A")) (re.* (str.to_re "M")) (re.* (str.to_re "Z")))))
+
+; non-ASCII characters
+(assert (= (str.to_upper "ač ď") "Ač ď"))
+(assert (= (str.to_lower "AČ Ď") "aČ Ď"))
+
+(check-sat)

--- a/src/test/noodler/e2e/to_lower_unsat.smt2
+++ b/src/test/noodler/e2e/to_lower_unsat.smt2
@@ -1,0 +1,8 @@
+(set-logic QF_SLIA)
+(set-info :status unsat)
+
+(declare-const zz String)
+(assert (= (str.to_lower zz) "AAAMMMZZZ"))
+(assert (str.in_re zz (re.++ (re.* (str.to_re "A")) (re.* (str.to_re "M")) (re.* (str.to_re "Z")))))
+
+(check-sat)

--- a/src/test/noodler/e2e/to_upper_unsat.smt2
+++ b/src/test/noodler/e2e/to_upper_unsat.smt2
@@ -1,0 +1,8 @@
+(set-logic QF_SLIA)
+(set-info :status unsat)
+
+(declare-const zz String)
+(assert (= (str.to_upper zz) "aaammmzzz"))
+(assert (str.in_re zz (re.++ (re.* (str.to_re "a")) (re.* (str.to_re "m")) (re.* (str.to_re "z")))))
+
+(check-sat)

--- a/src/test/noodler/e2e/trim.smt2
+++ b/src/test/noodler/e2e/trim.smt2
@@ -1,0 +1,37 @@
+(set-logic QF_SLIA)
+(set-info :status sat)
+
+; trim
+(declare-const x String)
+(declare-const y String)
+(declare-const z String)
+(assert (= (str.trim x) "a"))
+(assert (= (str.++ z y z) x))
+(assert (= y "\u{9}\u{A}\u{B}\u{C}\u{D}a\u{9}\u{A}\u{B}\u{C}\u{D}"))
+(assert (str.in_re z (re.* (str.to_re " "))))
+(assert (> (str.len x) 20))
+(assert (> (str.len z) 1))
+
+(assert (= (str.trim (str.++ z "aaa")) "aaa"))
+(assert (= (str.trim (str.++ "aaa" z)) "aaa"))
+(assert (= (str.trim (str.++ z "aaa" z)) "aaa"))
+(assert (= (str.trim z) ""))
+
+(declare-const empty String)
+(assert (str.in_re empty (str.to_re "")))
+(assert (= (str.trim empty) ""))
+
+; Rewriter
+(assert (= (str.trim "a") "a"))
+(assert (= (str.trim " a") "a"))
+(assert (= (str.trim "a ") "a"))
+(assert (= (str.trim " a ") "a"))
+(assert (= (str.trim "aa") "aa"))
+(assert (= (str.trim "   aa") "aa"))
+(assert (= (str.trim "aa   ") "aa"))
+(assert (= (str.trim "     ") ""))
+(assert (= (str.trim "") ""))
+(assert (= (str.trim "\u{9}\u{A}\u{B}\u{C}\u{D}  aa  \u{9}\u{A}\u{B}\u{C}\u{D}") "aa"))
+(assert (= (str.trim "  a a  ") "a a"))
+
+(check-sat)

--- a/src/test/noodler/e2e/update.smt2
+++ b/src/test/noodler/e2e/update.smt2
@@ -1,0 +1,43 @@
+(set-logic QF_SLIA)
+(set-info :status sat)
+
+; update
+(declare-const u String)
+(assert (= (str.update u 3 "bb") "aaabbaaa"))
+(assert (str.in_re u (re.* (str.to_re "a"))))
+(assert (= (str.len u) 8))
+
+; overflow
+(declare-const x String)
+(assert (= (str.update x 3 "bcdefghijklmn") "aaabcdef"))
+(assert (str.in_re x (re.* (str.to_re "a"))))
+(assert (= (str.len x) 8))
+
+; index too big
+(declare-const y String)
+(assert (= (str.update y 8 "bcdefghijklmn") "aaaaaaaa"))
+(assert (str.in_re y (re.* (str.to_re "a"))))
+(assert (= (str.len y) 8))
+
+; index too small
+(declare-const z String)
+(assert (= (str.update z -1 "bcdefghijklmn") "aaaaaaaa"))
+(assert (str.in_re z (re.* (str.to_re "a"))))
+(assert (= (str.len z) 8))
+
+; empty update string
+(declare-const v String)
+(assert (= (str.update v 3 "") "aaaaaaaa"))
+(assert (str.in_re v (re.* (str.to_re "a"))))
+(assert (= (str.len v) 8))
+
+; rewriter
+(assert (= (str.update "aaaaaaaa" 3 "bb") "aaabbaaa"))
+(assert (= (str.update "aaaaaaaa" 3 "bcdefghijklmn") "aaabcdef"))
+(assert (= (str.update "aaaaaaaa" 8 "bcdefghijklmn") "aaaaaaaa"))
+(assert (= (str.update "aaaaaaaa" 9 "bcdefghijklmn") "aaaaaaaa"))
+(assert (= (str.update "aaaaaaaa" 0 "bcdefghijklmn") "bcdefghi"))
+(assert (= (str.update "aaaaaaaa" -1 "bcdefghijklmn") "aaaaaaaa"))
+(assert (= (str.update "aaaaaaaa" 3 "") "aaaaaaaa"))
+
+(check-sat)

--- a/src/test/noodler/e2e/update.smt2
+++ b/src/test/noodler/e2e/update.smt2
@@ -31,6 +31,18 @@
 (assert (str.in_re v (re.* (str.to_re "a"))))
 (assert (= (str.len v) 8))
 
+; more complicated example
+(declare-const i Int)
+(declare-const o String)
+(declare-const res String)
+(declare-const p String)
+(assert (str.in_re o (re.* (str.to_re "a"))))
+(assert (= (str.len o) 8))
+(assert (= (str.len p) 20))
+(assert (> i 3))
+(assert (= (str.update o (div i 2) p) res))
+(assert (str.in_re res (re.++ (re.* (str.to_re "a")) (re.+ (str.to_re "b")) (str.to_re "aa"))))
+
 ; rewriter
 (assert (= (str.update "aaaaaaaa" 3 "bb") "aaabbaaa"))
 (assert (= (str.update "aaaaaaaa" 3 "bcdefghijklmn") "aaabcdef"))


### PR DESCRIPTION
Adds support for
- [X] `str.to_lower`
- [x] `str.to_upper`
- [x] `str.update`
- [x] `str.trim`
- [x] `str.delete`
- [ ] ~`str.indexof_re`~ ?

As mentioned in #306 