### PR TITLE
Better loop concatenation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -314,7 +314,7 @@ else()
 	FetchContent_Declare(
     mata
     GIT_REPOSITORY https://github.com/VeriFIT/mata
-    GIT_TAG        1.32.0 # needs to be updated manually when new mata version is needed
+    GIT_TAG        1.32.7 # needs to be updated manually when new mata version is needed
   )
 
   FetchContent_MakeAvailable(mata)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If Mata is not found on your system, it will be **automatically fetched and buil
 
 However, if you plan to **develop or frequently rebuild Z3-Noodler**, it is recommended to install Mata manually. This avoids repeatedly downloading and rebuilding Mata and significantly speeds up development workflows.
 
-The minimum required Mata version is `v1.32.0`.
+The minimum required Mata version is `v1.32.7`.
 
 To install mata, run:
 ```shell

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -326,7 +326,7 @@ namespace smt::noodler::regex {
                         body_nfa.unify_initial();
 
                         body_nfa = mata::nfa::reduce(body_nfa);
-                        result = mata::nfa::concatenate_exponent(body_nfa, low);
+                        result = mata::nfa::concatenate_nth_power(body_nfa, low);
                         result.trim();
 
                         // we will now either repeat body_nfa high-low times (if is_high_set) or
@@ -342,7 +342,7 @@ namespace smt::noodler::regex {
 
                         if (is_high_set) {
                             // if high is set, we repeat body_nfa another high-low times
-                            result.concatenate(concatenate_exponent(std::move(body_nfa), high - low));
+                            result.concatenate(concatenate_nth_power(std::move(body_nfa), high - low));
                             result.trim();
                         } else {
                             // if high is not set, we can repeat body_nfa unlimited more times

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -326,17 +326,7 @@ namespace smt::noodler::regex {
                         body_nfa.unify_initial();
 
                         body_nfa = mata::nfa::reduce(body_nfa);
-                        result = mata::nfa::builder::create_empty_string_nfa();
-                    
-                        if(low >= LOOP_BOUND) {
-                            result = create_large_concat(body_nfa, low);
-                        } else {
-                            // we need to repeat body_nfa at least low times
-                            for (unsigned i = 0; i < low; ++i) {
-                                result.concatenate(body_nfa);
-                                result.trim();
-                            }
-                        }
+                        result = mata::nfa::concatenate_exponent(body_nfa, low);
 
                         // we will now either repeat body_nfa high-low times (if is_high_set) or
                         // unlimited times (if it is not set), but we have to accept after each loop,
@@ -350,10 +340,7 @@ namespace smt::noodler::regex {
 
                         if (is_high_set) {
                             // if high is set, we repeat body_nfa another high-low times
-                            for (unsigned i = 0; i < high - low; ++i) {
-                                result.concatenate(body_nfa);
-                                result.trim();
-                            }
+                            result.concatenate(concatenate_exponent(std::move(body_nfa), high - low));
                         } else {
                             // if high is not set, we can repeat body_nfa unlimited more times
                             // so we do star operation on body_nfa and add it to end of nfa

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -326,7 +326,17 @@ namespace smt::noodler::regex {
                         body_nfa.unify_initial();
 
                         body_nfa = mata::nfa::reduce(body_nfa);
-                        result = mata::nfa::concatenate_exponent(body_nfa, low);
+
+                        if(low >= LOOP_BOUND) {
+                            result = mata::nfa::concatenate_exponent(body_nfa, low);
+                        } else {
+                            result = mata::nfa::builder::create_empty_string_nfa();
+                            // we need to repeat body_nfa at least low times
+                            for (unsigned i = 0; i < low; ++i) {
+                                result.concatenate(body_nfa);
+                                result.trim();
+                            }
+                        }
 
                         // we will now either repeat body_nfa high-low times (if is_high_set) or
                         // unlimited times (if it is not set), but we have to accept after each loop,
@@ -340,7 +350,14 @@ namespace smt::noodler::regex {
 
                         if (is_high_set) {
                             // if high is set, we repeat body_nfa another high-low times
-                            result.concatenate(concatenate_exponent(std::move(body_nfa), high - low));
+                            if(high - low >= LOOP_BOUND) {
+                                result.concatenate(concatenate_exponent(std::move(body_nfa), high - low));
+                            } else {
+                                for (unsigned i = 0; i < high - low; ++i) {
+                                    result.concatenate(body_nfa);
+                                    result.trim();
+                                }
+                            }
                         } else {
                             // if high is not set, we can repeat body_nfa unlimited more times
                             // so we do star operation on body_nfa and add it to end of nfa

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -326,17 +326,7 @@ namespace smt::noodler::regex {
                         body_nfa.unify_initial();
 
                         body_nfa = mata::nfa::reduce(body_nfa);
-
-                        if(low >= LOOP_BOUND) {
-                            result = mata::nfa::concatenate_exponent(body_nfa, low);
-                        } else {
-                            result = mata::nfa::builder::create_empty_string_nfa();
-                            // we need to repeat body_nfa at least low times
-                            for (unsigned i = 0; i < low; ++i) {
-                                result.concatenate(body_nfa);
-                                result.trim();
-                            }
-                        }
+                        result = mata::nfa::concatenate_exponent(body_nfa, low);
 
                         // we will now either repeat body_nfa high-low times (if is_high_set) or
                         // unlimited times (if it is not set), but we have to accept after each loop,
@@ -350,14 +340,7 @@ namespace smt::noodler::regex {
 
                         if (is_high_set) {
                             // if high is set, we repeat body_nfa another high-low times
-                            if(high - low >= LOOP_BOUND) {
-                                result.concatenate(concatenate_exponent(std::move(body_nfa), high - low));
-                            } else {
-                                for (unsigned i = 0; i < high - low; ++i) {
-                                    result.concatenate(body_nfa);
-                                    result.trim();
-                                }
-                            }
+                            result.concatenate(concatenate_exponent(std::move(body_nfa), high - low));
                         } else {
                             // if high is not set, we can repeat body_nfa unlimited more times
                             // so we do star operation on body_nfa and add it to end of nfa

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -673,29 +673,6 @@ namespace smt::noodler::regex {
         return RegexInfo{.min_length = 0, .universal = l_undef, .empty = l_undef};
     }
 
-    mata::nfa::Nfa create_large_concat(const mata::nfa::Nfa& body_nfa, unsigned count) {
-        mata::nfa::Nfa nfa_part = mata::nfa::builder::create_empty_string_nfa();
-        mata::nfa::Nfa nfa = mata::nfa::builder::create_empty_string_nfa();
-        const unsigned CONCAT = 100;
-
-        for(unsigned i = 0; i < CONCAT; i++) {
-            nfa_part.concatenate(body_nfa);
-            nfa_part.trim();
-        }
-        unsigned cnt = 0;
-        for(unsigned i = 0; i < count / CONCAT; i++) {
-            nfa.concatenate(nfa_part);
-            nfa.trim();
-            cnt += CONCAT;
-        }
-        for(; cnt <= count; cnt++) {
-            nfa.concatenate(body_nfa);
-            nfa.trim();
-        }
-
-        return nfa;
-    }
-
     unsigned get_loop_sum(const app* reg, const seq_util& m_util_s) {
         expr* body;
         unsigned lo, hi;

--- a/src/smt/theory_str_noodler/regex.cpp
+++ b/src/smt/theory_str_noodler/regex.cpp
@@ -327,6 +327,7 @@ namespace smt::noodler::regex {
 
                         body_nfa = mata::nfa::reduce(body_nfa);
                         result = mata::nfa::concatenate_exponent(body_nfa, low);
+                        result.trim();
 
                         // we will now either repeat body_nfa high-low times (if is_high_set) or
                         // unlimited times (if it is not set), but we have to accept after each loop,
@@ -337,10 +338,12 @@ namespace smt::noodler::regex {
 
                         body_nfa.unify_initial();
                         body_nfa = mata::nfa::reduce(body_nfa);
+                        body_nfa.trim();
 
                         if (is_high_set) {
                             // if high is set, we repeat body_nfa another high-low times
                             result.concatenate(concatenate_exponent(std::move(body_nfa), high - low));
+                            result.trim();
                         } else {
                             // if high is not set, we can repeat body_nfa unlimited more times
                             // so we do star operation on body_nfa and add it to end of nfa

--- a/src/smt/theory_str_noodler/regex.h
+++ b/src/smt/theory_str_noodler/regex.h
@@ -28,8 +28,6 @@ namespace smt::noodler::regex {
     using expr_pair = std::pair<expr_ref, expr_ref>;
     using expr_pair_flag = std::tuple<expr_ref, expr_ref, bool>;
 
-    // bound for loop (above this number an optimized construction is used)
-    const unsigned LOOP_BOUND = 5000;
     // simulation reduction bound in states (bigger automata are not reduced)
     const unsigned RED_BOUND = 1000;
 
@@ -175,15 +173,6 @@ namespace smt::noodler::regex {
      * @return RegexInfo 
      */
     RegexInfo get_regex_info(const app *expression, const seq_util& m_util_s);
-
-    /**
-     * @brief Create bounded iteration of a given automaton. 
-     * 
-     * @param body_nfa Core NFA
-     * @param count Number of concatenations
-     * @return mata::nfa::Nfa NFA
-     */
-    mata::nfa::Nfa create_large_concat(const mata::nfa::Nfa& body_nfa, unsigned count);
 
     /**
      * @brief Get the sum of loops of a regex (loop inside a loop is multiplied)


### PR DESCRIPTION
Change the construction of the `re.loop` by using a new mata function that does "binary" exponentiation.