### PR TITLE
Input rewriter

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -2182,6 +2182,7 @@ public:
 
     MATCH_UNARY(is_not);
     MATCH_BINARY(is_eq);
+    MATCH_BINARY(is_distinct);
     MATCH_BINARY(is_implies);
     MATCH_BINARY(is_and);
     MATCH_BINARY(is_or);

--- a/src/ast/rewriter/CMakeLists.txt
+++ b/src/ast/rewriter/CMakeLists.txt
@@ -25,6 +25,7 @@ z3_add_component(rewriter
     fpa_rewriter.cpp
     func_decl_replace.cpp
     inj_axiom.cpp
+    input_rewriter.cpp
     label_rewriter.cpp
     macro_replacer.cpp
     maximize_ac_sharing.cpp

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -104,10 +104,10 @@ std::optional<expr_ref> input_rewriter::rewrite_to_int(expr *e) {
     // .*[^0-9].*
     expr_ref non_valid_number_regex(
                 m_util_s.re.mk_concat(
-                    m_util_s.re.mk_full_seq(m_util_s.re.mk_re(m_util_s.re.mk_re(m_util_s.mk_string_sort()))),
+                    m_util_s.re.mk_full_seq(m_util_s.re.mk_re(m_util_s.mk_string_sort())),
                     m_util_s.re.mk_concat(
                         m_util_s.re.mk_complement(digits_regex),
-                        m_util_s.re.mk_full_seq(m_util_s.re.mk_re(m_util_s.re.mk_re(m_util_s.mk_string_sort())))
+                        m_util_s.re.mk_full_seq(m_util_s.re.mk_re(m_util_s.mk_string_sort()))
                     )
                 ), m);
 

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -1,0 +1,24 @@
+/*++
+Copyright (c) 2026 Microsoft Corporation
+
+Module Name:
+
+    input_rewriter.cpp
+
+Abstract:
+
+    Rewriter for processing expressions only when they are loaded from input.
+
+Author:
+
+    Z3 Team 2026
+
+--*/
+#include "ast/rewriter/input_rewriter.h"
+#include "smt/theory_str_noodler/expr_cases.h"
+
+expr_ref input_rewriter::rewrite_input(expr* e) {
+    return expr_ref(e, m);
+}
+
+

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -17,8 +17,86 @@ Author:
 #include "ast/rewriter/input_rewriter.h"
 #include "smt/theory_str_noodler/expr_cases.h"
 
+std::optional<expr_ref> input_rewriter::rewrite_to_code(expr* e) {
+    expr_ref full_char(m_util_s.re.mk_full_char(m_util_s.re.mk_re(m_util_s.mk_string_sort())), m);
+    expr_ref not_full_char(m_util_s.re.mk_complement(full_char), m);
+
+    expr* to_code_arg; bool is_num_larger, is_eq; rational num;
+    if (smt::noodler::expr_cases::is_to_code_leq_or_geq(e, m, m_util_s, m_util_a, to_code_arg, num, is_num_larger)) {
+        if (is_num_larger) {
+            // we have (str.to_code to_code_arg) <= num
+            if (num >= zstring::max_char()) {
+                return expr_ref(m.mk_true(), m);
+            } else if (num < -1) {
+                return expr_ref(m.mk_false(), m);
+            } else {
+                expr_ref regex(not_full_char); // encoding the case that to_code == -1
+                if (num >= 0) {
+                    unsigned num_unsigned = num.get_unsigned();
+                    if (num_unsigned <= zstring::max_char()/2) {
+                        // code point of to_code_arg is between [0, num] -> we can replace with regex to_code_arg \in range from 0 to num
+                        // we only do it if [0, num] is smaller than [num+1, maxchar]
+                        regex = expr_ref(m_util_s.re.mk_union(regex, m_util_s.re.mk_range(m_util_s.str.mk_string(zstring(unsigned(0))), m_util_s.str.mk_string(zstring(num_unsigned)))), m);
+                    } else {
+                        // [num+1, maxchar] is smaller -> we replace with regex allchar AND complement of range from 0 to num-1
+                        expr_ref range(m_util_s.re.mk_inter(full_char, m_util_s.re.mk_complement(m_util_s.re.mk_range(m_util_s.str.mk_string(zstring(num_unsigned+1)), m_util_s.str.mk_string(zstring::max_char())))), m);
+                        regex = expr_ref(m_util_s.re.mk_union(regex, range), m);
+                    }
+                }
+                return expr_ref(m_util_s.re.mk_in_re(to_code_arg, regex), m);
+            }
+        } else {
+            // we have (str.to_code to_code_arg) >= num
+            if (num <= -1) {
+                return expr_ref(m.mk_true(), m);
+            } else if (num > zstring::max_char()) {
+                return expr_ref(m.mk_false(), m);
+            } else {
+                unsigned num_unsigned = num.get_unsigned();
+                if (num_unsigned == 0) {
+                    return expr_ref(m_util_s.re.mk_in_re(to_code_arg, full_char), m);
+                } else if (num_unsigned == zstring::max_char()) {
+                    return expr_ref(m.mk_eq(to_code_arg, m_util_s.str.mk_string(zstring(zstring::max_char()))), m);
+                } else if (num_unsigned > zstring::max_char()/2) {
+                    // code point of to_code_arg is between [num, maxchar] -> we can replace with regex to_code_arg \in range from num to maxchar
+                    // we only do it if [num, maxchar] is smaller than [0, num-1]
+                    return expr_ref(m_util_s.re.mk_in_re(to_code_arg, m_util_s.re.mk_range(m_util_s.str.mk_string(zstring(num_unsigned)), m_util_s.str.mk_string(zstring(zstring::max_char())))), m);
+                } else {
+                    // [0, num-1] is smaller -> we replace with regex to_code_arg \in allchar AND to_code_arg \not\in range from 0 to num-1
+                    return expr_ref(
+                        m.mk_and(
+                            m_util_s.re.mk_in_re(to_code_arg, full_char), // to_code_arg \in allchar
+                            m.mk_not(m_util_s.re.mk_in_re(to_code_arg, m_util_s.re.mk_range(m_util_s.str.mk_string(zstring(unsigned(0))), m_util_s.str.mk_string(zstring(num_unsigned-1))))) // to_code_arg \not\in range from 0 to num-1
+                        ), m);
+                }
+            }
+        }
+    } else if (smt::noodler::expr_cases::is_to_code_num_eq(e, m, m_util_s, m_util_a, to_code_arg, num, is_eq)) {
+        if (is_eq) {
+            if (num == -1) {
+                return expr_ref(m_util_s.re.mk_in_re(to_code_arg, not_full_char), m);
+            } else if (0 <= num && num <= zstring::max_char()) {
+                return expr_ref(m.mk_eq(to_code_arg, m_util_s.str.mk_string(zstring(num.get_unsigned()))), m);
+            } else {
+                return expr_ref(m.mk_false(), m);
+            }
+        } else {
+            if (num == -1) {
+                return expr_ref(m_util_s.re.mk_in_re(to_code_arg, full_char), m);
+            } else if (0 <= num && num <= zstring::max_char()) {
+                return expr_ref(m.mk_not(m.mk_eq(to_code_arg, m_util_s.str.mk_string(zstring(num.get_unsigned())))), m);
+            } else {
+                return expr_ref(m.mk_true(), m);
+            }
+        }
+    } else {
+        return std::nullopt;
+    }
+}
+
 expr_ref input_rewriter::rewrite_input(expr* e) {
-    return expr_ref(e, m);
+    if (auto res = rewrite_to_code(e); res) { return *res; }
+    else { return expr_ref(e, m); }
 }
 
 

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -180,7 +180,7 @@ std::optional<expr_ref> input_rewriter::rewrite_to_int(expr *e) {
 
                 // all numbers whose lenght in decimal representation is longer than num
                 // 0*[1-9][0-9]{length_of_num,}
-                expr_ref re_longer(m_util_s.re.mk_concat(zero_star, m_util_s.re.mk_concat(m_util_s.re.mk_range(m_util_s.str.mk_string("1"), m_util_s.str.mk_string("9")), m_util_s.re.mk_loop(digits_regex, length_of_num+1))), m);
+                expr_ref re_longer(m_util_s.re.mk_concat(zero_star, m_util_s.re.mk_concat(m_util_s.re.mk_range(m_util_s.str.mk_string("1"), m_util_s.str.mk_string("9")), m_util_s.re.mk_loop(digits_regex, length_of_num))), m);
 
                 expr_ref final_re = re_longer;
                 // we now encode all numbers of length of num >= num

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -1,19 +1,3 @@
-/*++
-Copyright (c) 2026 Microsoft Corporation
-
-Module Name:
-
-    input_rewriter.cpp
-
-Abstract:
-
-    Rewriter for processing expressions only when they are loaded from input.
-
-Author:
-
-    Z3 Team 2026
-
---*/
 #include "ast/rewriter/input_rewriter.h"
 #include "smt/theory_str_noodler/expr_cases.h"
 

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -114,7 +114,7 @@ std::optional<expr_ref> input_rewriter::rewrite_to_int(expr *e) {
     expr* to_int_arg;
     rational num;
     bool is_num_larger, is_eq;
-    if (smt::noodler::expr_cases::is_to_code_leq_or_geq(e, m, m_util_s, m_util_a, to_int_arg, num, is_num_larger)) {
+    if (smt::noodler::expr_cases::is_to_int_leq_or_geq(e, m, m_util_s, m_util_a, to_int_arg, num, is_num_larger)) {
         if (is_num_larger) {
             // (str.to_int to_int_arg) <= num
             if (num < -1) {

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -1,21 +1,82 @@
-/*++
-Copyright (c) 2026 Microsoft Corporation
+#include <unordered_set>
 
-Module Name:
-
-    input_rewriter.cpp
-
-Abstract:
-
-    Rewriter for processing expressions only when they are loaded from input.
-
-Author:
-
-    Z3 Team 2026
-
---*/
 #include "ast/rewriter/input_rewriter.h"
 #include "smt/theory_str_noodler/expr_cases.h"
+
+/**
+ * @brief Add special axioms for length (in)equations. In particular
+ * - for (len s) == 10 create s \in \Sigma^10
+ * - for (len s) <= 10 create s \in re.loop(0, 10)
+ * - for 10 <= (len s) create s \in re.loop(10, \inf)
+ * (len s) can be potentially any LIA formula where the "variables" are length constraints and there is no minus
+ */
+std::optional<expr_ref> input_rewriter::rewrite_len(expr* e) {
+    // number bound for the conversion of length constraints into regex constraints.
+    // For higher values this conversion could not be beneficial as we would work with 
+    // big automata in the decision procedure.
+    const int MAX_NUM = 64; 
+    const unsigned MAX_VARS = 4;
+
+    expr_ref full_char(m_util_s.re.mk_full_char(m_util_s.re.mk_re(m_util_s.mk_string_sort())), m);
+    auto create_and_of_equals_to_empty_string = [this](expr_ref_vector& len_vars_with_repetition) {
+        std::unordered_set<expr*> used_len_vars;
+        expr_ref_vector eqs(m);
+        for (expr* var : len_vars_with_repetition) {
+            if (!used_len_vars.contains(var)) {
+                eqs.push_back(m.mk_eq(var, m_util_s.str.mk_string(zstring())));
+                used_len_vars.insert(var);
+            }
+        }
+        return expr_ref(m.mk_and(eqs), m);
+    };
+
+    rational val;
+    bool val_is_larger;
+    expr_ref_vector len_arg(m);
+    if (smt::noodler::expr_cases::is_len_num_eq(e, m, m_util_s, m_util_a, len_arg, val) && val < MAX_NUM) {
+        if (val < 0) {
+            // The sum of lengths should be equal to negative number, which is not possible.
+            return expr_ref(m.mk_false(), m);
+        } else if (val == 0) {
+            // we know that concatenation of vars in len_arg must be empty string,
+            // which means every variable in len_arg must be equal to empty string
+            create_and_of_equals_to_empty_string(len_arg);
+        } else if (len_arg.size() <= MAX_VARS) {
+            expr_ref re(full_char, m);
+            for(rational i{1}; i < val; i++) {
+                re = m_util_s.re.mk_concat(re, full_char);
+            }
+            return expr_ref(m_util_s.re.mk_in_re(m_util_s.str.mk_concat(len_arg, nullptr), re), m);
+        }
+    } else if (smt::noodler::expr_cases::is_len_num_leq_or_geq(e, m, m_util_s, m_util_a, len_arg, val, val_is_larger) && val < MAX_NUM) {
+        if (val < 0) {
+            if (val_is_larger) {
+                // The sum of lengths should be less than or equal than negative number, which is not possible.
+                return expr_ref(m.mk_false(), m);
+            } else {
+                // if val is smaller than len_arg, then this expression just say that the length of len_arg is larger than minus number -> it is useless
+                return expr_ref(m.mk_true(), m);
+            }
+        } else if (val == 0) {
+            if (val_is_larger) {
+                // the sum of lengths <= 0 --> every var must be equal to empty string
+                create_and_of_equals_to_empty_string(len_arg);
+            } else {
+                // if val is smaller than len_arg, then this expression just say that the length of len_arg is larger or equal than 0 -> it is useless
+                return expr_ref(m.mk_true(), m);
+            }
+        } else if (len_arg.size() <= MAX_VARS) {
+            expr_ref re(
+                val_is_larger ? 
+                    m_util_s.re.mk_loop(m_util_s.re.mk_full_char(nullptr), m_util_a.mk_int(0), m_util_a.mk_int(val)) :
+                    m_util_s.re.mk_loop(m_util_s.re.mk_full_char(nullptr), m_util_a.mk_int(val)),
+                m
+            );
+            return expr_ref(m_util_s.re.mk_in_re(m_util_s.str.mk_concat(len_arg, nullptr), re), m);
+        }
+    }
+    return std::nullopt;
+}
 
 std::optional<expr_ref> input_rewriter::rewrite_to_code(expr* e) {
     expr_ref full_char(m_util_s.re.mk_full_char(m_util_s.re.mk_re(m_util_s.mk_string_sort())), m);
@@ -96,6 +157,7 @@ std::optional<expr_ref> input_rewriter::rewrite_to_code(expr* e) {
 
 expr_ref input_rewriter::rewrite_input(expr* e) {
     if (auto res = rewrite_to_code(e); res) { return *res; }
+    else if (auto res = rewrite_len(e); res) { return *res; }
     else { return expr_ref(e, m); }
 }
 

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -95,16 +95,144 @@ std::optional<expr_ref> input_rewriter::rewrite_to_code(expr* e) {
     }
 }
 
-/// For n = to_int(x) generate n = to_int(x) -> x \in 0*to_string(n)).
+/// Rewrites <, <=, >, >=, ==, !=, where one side is str.to_int and other a numeral to str.in_re predicate
 std::optional<expr_ref> input_rewriter::rewrite_to_int(expr *e) {
-    expr* to_int_arg;
-    rational val;
-    if(smt::noodler::expr_cases::is_to_int_num_eq(e, m, m_util_s, m_util_a, to_int_arg, val) && val.is_nonneg()) {
-        expr_ref re(m_util_s.re.mk_concat(m_util_s.re.mk_star(m_util_s.re.mk_to_re(m_util_s.str.mk_string("0"))), m_util_s.re.mk_to_re(m_util_s.str.mk_string(val.to_string()))), m);
-        return expr_ref(m_util_s.re.mk_in_re(to_int_arg, re), m);
-    }
+    // [0-9]
+    expr_ref digits_regex(m_util_s.re.mk_range(m_util_s.str.mk_string("0"), m_util_s.str.mk_string("9")), m);
+    // 0*
+    expr_ref zero_star(m_util_s.re.mk_star(m_util_s.re.mk_to_re(m_util_s.str.mk_string("0"))), m);
+    // .*[^0-9].*
+    expr_ref non_valid_number_regex(
+                m_util_s.re.mk_concat(
+                    m_util_s.re.mk_full_seq(m_util_s.re.mk_re(m_util_s.re.mk_re(m_util_s.mk_string_sort()))),
+                    m_util_s.re.mk_concat(
+                        m_util_s.re.mk_complement(digits_regex),
+                        m_util_s.re.mk_full_seq(m_util_s.re.mk_re(m_util_s.re.mk_re(m_util_s.mk_string_sort())))
+                    )
+                ), m);
 
-    return std::nullopt;
+    expr* to_int_arg;
+    rational num;
+    bool is_num_larger, is_eq;
+    if (smt::noodler::expr_cases::is_to_code_leq_or_geq(e, m, m_util_s, m_util_a, to_int_arg, num, is_num_larger)) {
+        if (is_num_larger) {
+            // (str.to_int to_int_arg) <= num
+            if (num < -1) {
+                return expr_ref(m.mk_false(), m);
+            } else {
+                expr_ref final_re = non_valid_number_regex; // case when num is -1
+                if (num >= 0) {
+                    std::string string_representation_of_num = num.to_string();
+                    size_t length_of_num = string_representation_of_num.size();
+
+                    if (length_of_num > 1) {
+                        // all numbers whose lenght in decimal representation is shorter than num
+                        // 0*[0-9]{1,length_of_num-1}
+                        expr_ref re_shorter(m_util_s.re.mk_concat(zero_star, m_util_s.re.mk_loop(digits_regex, 1, length_of_num-1)), m);
+                        final_re = m_util_s.re.mk_union(final_re, re_shorter);
+                    }
+
+                    // we now encode all numbers of length of num <= num
+                    // for example, for num == 4601, we encode (by iterating for all positions):
+                    //        - 0*[1-3][0-9][0-9][0-9]
+                    //        - 0*4[0-5][0-9][0-9]
+                    //        - third position ('0') is skipped
+                    //        - 0*460[0-1]
+                    // or for num == 190:
+                    //        - first position ('1') is skipped
+                    //        - 0*1[0-8][0-9]
+                    //        - 0*19[0-0]
+                    for (size_t pos = 0; pos < length_of_num; ++pos) {
+                        char char_on_pos = string_representation_of_num[pos];
+                        if (pos == 0 && pos != length_of_num-1 && char_on_pos == '1') { continue; }
+                        if (pos != length_of_num-1 && char_on_pos == '0') { continue; }
+
+                        std::string prefix = string_representation_of_num.substr(0, pos); // take the substring before the position pos
+                        // 0*<prefix>
+                        expr_ref re_case(m_util_s.re.mk_concat(zero_star, m_util_s.re.mk_to_re(m_util_s.str.mk_string(prefix))), m);
+                        if (pos == length_of_num-1) {
+                            // last position (can be also first): we add [0-<char_on_pos>]
+                            re_case = m_util_s.re.mk_concat(re_case, m_util_s.re.mk_range(m_util_s.str.mk_string("0"), m_util_s.str.mk_string(char_on_pos)));
+                        } else {
+                            if (pos == 0) {
+                                // first (but not last) position: we add [1-<char_on_pos-1>]
+                                re_case = m_util_s.re.mk_concat(re_case, m_util_s.re.mk_range(m_util_s.str.mk_string("1"), m_util_s.str.mk_string(char_on_pos-1)));
+                            } else {
+                                // middle position: we add [0-<char_on_pos-1>]
+                                re_case = m_util_s.re.mk_concat(re_case, m_util_s.re.mk_range(m_util_s.str.mk_string("0"), m_util_s.str.mk_string(char_on_pos-1)));
+                            }
+                            // we also add [0-9]^(length of string after pos)
+                            re_case = m_util_s.re.mk_concat(re_case, m_util_s.re.mk_loop_proper(digits_regex, length_of_num-1-pos, length_of_num-1-pos));
+                        }
+                        final_re = m_util_s.re.mk_union(final_re, re_case);
+                    }
+                }
+
+                return expr_ref(m_util_s.re.mk_in_re(to_int_arg, final_re), m);
+            }
+        } else {
+            // (str.to_int to_int_arg) >= num
+            if (num <= -1) {
+                return expr_ref(m.mk_true(), m);
+            } else {
+                std::string string_representation_of_num = num.to_string();
+                size_t length_of_num = string_representation_of_num.size();
+
+                // all numbers whose lenght in decimal representation is longer than num
+                // 0*[1-9][0-9]{length_of_num,}
+                expr_ref re_longer(m_util_s.re.mk_concat(zero_star, m_util_s.re.mk_concat(m_util_s.re.mk_range(m_util_s.str.mk_string("1"), m_util_s.str.mk_string("9")), m_util_s.re.mk_loop(digits_regex, length_of_num+1))), m);
+
+                expr_ref final_re = re_longer;
+                // we now encode all numbers of length of num >= num
+                // for example, for num == 4901, we encode (by iterating for all positions):
+                //        - 0*[5-9][0-9][0-9][0-9]
+                //        - second position ('9') is skipped
+                //        - 0*49[1-9][0-9]
+                //        - 0*490[1-9]
+                // or for num == 995:
+                //        - first position ('9') is skipped
+                //        - second position ('9') is skipped
+                //        - 0*99[5-9]
+                for (size_t pos = 0; pos < length_of_num; ++pos) {
+                    char char_on_pos = string_representation_of_num[pos];
+                    if (pos != length_of_num-1 && char_on_pos == '9') { continue; }
+
+                    std::string prefix = string_representation_of_num.substr(0, pos); // take the substring before the position pos
+                    // 0*<prefix>
+                    expr_ref re_case(m_util_s.re.mk_concat(zero_star, m_util_s.re.mk_to_re(m_util_s.str.mk_string(prefix))), m);
+                    if (pos == length_of_num-1) {
+                        // last position: we add [<char_on_pos>-9]
+                        re_case = m_util_s.re.mk_concat(re_case, m_util_s.re.mk_range(m_util_s.str.mk_string(char_on_pos), m_util_s.str.mk_string("9")));
+                    } else {
+                        // before last position: we add [<char_on_pos+1>-9][0-9]^(length of string after pos)
+                        re_case = m_util_s.re.mk_concat(re_case, m_util_s.re.mk_range(m_util_s.str.mk_string(char_on_pos+1), m_util_s.str.mk_string("9")));
+                        re_case = m_util_s.re.mk_concat(re_case, m_util_s.re.mk_loop_proper(digits_regex, length_of_num-1-pos, length_of_num-1-pos));
+                    }
+                    final_re = m_util_s.re.mk_union(final_re, re_case);
+                }
+
+                return expr_ref(m_util_s.re.mk_in_re(to_int_arg, final_re), m);
+            }
+        }
+    } else if(smt::noodler::expr_cases::is_to_int_num_eq(e, m, m_util_s, m_util_a, to_int_arg, num, is_eq)) {
+        expr_ref re(m);
+        if (num < -1) {
+            // values smaller than -1 cannot be results of str.to_int
+            if (is_eq) { return expr_ref(m.mk_false(), m); }
+            else { return expr_ref(m.mk_true(), m); }
+        } else if (num == -1) {
+            // create .*[^0-9].*
+            re = non_valid_number_regex;
+        } else {
+            // 0*<num>
+            re = m_util_s.re.mk_concat(zero_star, m_util_s.re.mk_to_re(m_util_s.str.mk_string(num.to_string())));
+        }
+        expr_ref in_re(m_util_s.re.mk_in_re(to_int_arg, re), m);
+        if (!is_eq) { in_re = m.mk_not(in_re); }
+        return in_re;
+    } else {
+        return std::nullopt;
+    }
 }
 
 expr_ref input_rewriter::rewrite_input(expr* e) {

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -101,15 +101,8 @@ std::optional<expr_ref> input_rewriter::rewrite_to_int(expr *e) {
     expr_ref digits_regex(m_util_s.re.mk_range(m_util_s.str.mk_string("0"), m_util_s.str.mk_string("9")), m);
     // 0*
     expr_ref zero_star(m_util_s.re.mk_star(m_util_s.re.mk_to_re(m_util_s.str.mk_string("0"))), m);
-    // .*[^0-9].*
-    expr_ref non_valid_number_regex(
-                m_util_s.re.mk_concat(
-                    m_util_s.re.mk_full_seq(m_util_s.re.mk_re(m_util_s.mk_string_sort())),
-                    m_util_s.re.mk_concat(
-                        m_util_s.re.mk_complement(digits_regex),
-                        m_util_s.re.mk_full_seq(m_util_s.re.mk_re(m_util_s.mk_string_sort()))
-                    )
-                ), m);
+    // complement of [0-9]+
+    expr_ref non_valid_number_regex(m_util_s.re.mk_complement(m_util_s.re.mk_plus(digits_regex)), m);
 
     expr* to_int_arg;
     rational num;
@@ -221,7 +214,6 @@ std::optional<expr_ref> input_rewriter::rewrite_to_int(expr *e) {
             if (is_eq) { return expr_ref(m.mk_false(), m); }
             else { return expr_ref(m.mk_true(), m); }
         } else if (num == -1) {
-            // create .*[^0-9].*
             re = non_valid_number_regex;
         } else {
             // 0*<num>

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -17,6 +17,7 @@ Author:
 #include "ast/rewriter/input_rewriter.h"
 #include "smt/theory_str_noodler/expr_cases.h"
 
+/// Rewrites <, <=, >, >=, ==, !=, where one side is str.to_code and other a numeral to str.in_re predicate
 std::optional<expr_ref> input_rewriter::rewrite_to_code(expr* e) {
     expr_ref full_char(m_util_s.re.mk_full_char(m_util_s.re.mk_re(m_util_s.mk_string_sort())), m);
     expr_ref not_full_char(m_util_s.re.mk_complement(full_char), m);
@@ -94,8 +95,21 @@ std::optional<expr_ref> input_rewriter::rewrite_to_code(expr* e) {
     }
 }
 
+/// For n = to_int(x) generate n = to_int(x) -> x \in 0*to_string(n)).
+std::optional<expr_ref> input_rewriter::rewrite_to_int(expr *e) {
+    expr* to_int_arg;
+    rational val;
+    if(smt::noodler::expr_cases::is_to_int_num_eq(e, m, m_util_s, m_util_a, to_int_arg, val) && val.is_nonneg()) {
+        expr_ref re(m_util_s.re.mk_concat(m_util_s.re.mk_star(m_util_s.re.mk_to_re(m_util_s.str.mk_string("0"))), m_util_s.re.mk_to_re(m_util_s.str.mk_string(val.to_string()))), m);
+        return expr_ref(m_util_s.re.mk_in_re(to_int_arg, re), m);
+    }
+
+    return std::nullopt;
+}
+
 expr_ref input_rewriter::rewrite_input(expr* e) {
     if (auto res = rewrite_to_code(e); res) { return *res; }
+    if (auto res = rewrite_to_int(e); res) { return *res; }
     else { return expr_ref(e, m); }
 }
 

--- a/src/ast/rewriter/input_rewriter.cpp
+++ b/src/ast/rewriter/input_rewriter.cpp
@@ -1,82 +1,21 @@
-#include <unordered_set>
+/*++
+Copyright (c) 2026 Microsoft Corporation
 
+Module Name:
+
+    input_rewriter.cpp
+
+Abstract:
+
+    Rewriter for processing expressions only when they are loaded from input.
+
+Author:
+
+    Z3 Team 2026
+
+--*/
 #include "ast/rewriter/input_rewriter.h"
 #include "smt/theory_str_noodler/expr_cases.h"
-
-/**
- * @brief Add special axioms for length (in)equations. In particular
- * - for (len s) == 10 create s \in \Sigma^10
- * - for (len s) <= 10 create s \in re.loop(0, 10)
- * - for 10 <= (len s) create s \in re.loop(10, \inf)
- * (len s) can be potentially any LIA formula where the "variables" are length constraints and there is no minus
- */
-std::optional<expr_ref> input_rewriter::rewrite_len(expr* e) {
-    // number bound for the conversion of length constraints into regex constraints.
-    // For higher values this conversion could not be beneficial as we would work with 
-    // big automata in the decision procedure.
-    const int MAX_NUM = 64; 
-    const unsigned MAX_VARS = 4;
-
-    expr_ref full_char(m_util_s.re.mk_full_char(m_util_s.re.mk_re(m_util_s.mk_string_sort())), m);
-    auto create_and_of_equals_to_empty_string = [this](expr_ref_vector& len_vars_with_repetition) {
-        std::unordered_set<expr*> used_len_vars;
-        expr_ref_vector eqs(m);
-        for (expr* var : len_vars_with_repetition) {
-            if (!used_len_vars.contains(var)) {
-                eqs.push_back(m.mk_eq(var, m_util_s.str.mk_string(zstring())));
-                used_len_vars.insert(var);
-            }
-        }
-        return expr_ref(m.mk_and(eqs), m);
-    };
-
-    rational val;
-    bool val_is_larger;
-    expr_ref_vector len_arg(m);
-    if (smt::noodler::expr_cases::is_len_num_eq(e, m, m_util_s, m_util_a, len_arg, val) && val < MAX_NUM) {
-        if (val < 0) {
-            // The sum of lengths should be equal to negative number, which is not possible.
-            return expr_ref(m.mk_false(), m);
-        } else if (val == 0) {
-            // we know that concatenation of vars in len_arg must be empty string,
-            // which means every variable in len_arg must be equal to empty string
-            create_and_of_equals_to_empty_string(len_arg);
-        } else if (len_arg.size() <= MAX_VARS) {
-            expr_ref re(full_char, m);
-            for(rational i{1}; i < val; i++) {
-                re = m_util_s.re.mk_concat(re, full_char);
-            }
-            return expr_ref(m_util_s.re.mk_in_re(m_util_s.str.mk_concat(len_arg, nullptr), re), m);
-        }
-    } else if (smt::noodler::expr_cases::is_len_num_leq_or_geq(e, m, m_util_s, m_util_a, len_arg, val, val_is_larger) && val < MAX_NUM) {
-        if (val < 0) {
-            if (val_is_larger) {
-                // The sum of lengths should be less than or equal than negative number, which is not possible.
-                return expr_ref(m.mk_false(), m);
-            } else {
-                // if val is smaller than len_arg, then this expression just say that the length of len_arg is larger than minus number -> it is useless
-                return expr_ref(m.mk_true(), m);
-            }
-        } else if (val == 0) {
-            if (val_is_larger) {
-                // the sum of lengths <= 0 --> every var must be equal to empty string
-                create_and_of_equals_to_empty_string(len_arg);
-            } else {
-                // if val is smaller than len_arg, then this expression just say that the length of len_arg is larger or equal than 0 -> it is useless
-                return expr_ref(m.mk_true(), m);
-            }
-        } else if (len_arg.size() <= MAX_VARS) {
-            expr_ref re(
-                val_is_larger ? 
-                    m_util_s.re.mk_loop(m_util_s.re.mk_full_char(nullptr), m_util_a.mk_int(0), m_util_a.mk_int(val)) :
-                    m_util_s.re.mk_loop(m_util_s.re.mk_full_char(nullptr), m_util_a.mk_int(val)),
-                m
-            );
-            return expr_ref(m_util_s.re.mk_in_re(m_util_s.str.mk_concat(len_arg, nullptr), re), m);
-        }
-    }
-    return std::nullopt;
-}
 
 std::optional<expr_ref> input_rewriter::rewrite_to_code(expr* e) {
     expr_ref full_char(m_util_s.re.mk_full_char(m_util_s.re.mk_re(m_util_s.mk_string_sort())), m);
@@ -157,7 +96,6 @@ std::optional<expr_ref> input_rewriter::rewrite_to_code(expr* e) {
 
 expr_ref input_rewriter::rewrite_input(expr* e) {
     if (auto res = rewrite_to_code(e); res) { return *res; }
-    else if (auto res = rewrite_len(e); res) { return *res; }
     else { return expr_ref(e, m); }
 }
 

--- a/src/ast/rewriter/input_rewriter.h
+++ b/src/ast/rewriter/input_rewriter.h
@@ -20,19 +20,10 @@ Abstract:
  * \brief Input rewriter: applies rewrite rules only to expressions loaded from input.
  *
  * This class is designed to be used at expression load time (in cmd_context::assert_expr)
- * to rewrite expressions exactly once when they are parsed from input. This prevents
- * rewriting overhead during the solving process since expressions created internally
- * during solving will not be rewritten.
- *
- * Usage:
- *   input_rewriter rewriter(manager);
- *   expr_ref input_expr = ...;  // expression from parsed input
- *   rewriter.rewrite_input(input_expr);
- *
- * To add custom input-only rewriting rules:
- *   1. Add a method to apply your custom rules
- *   2. Call it from rewrite_input() when appropriate parameter is set
- *   3. Extend this class for domain-specific rewriting
+ * to rewrite expressions exactly once when they are parsed from input. This allows to
+ * define rules that should not be used for rewriting internal formulas, such as a rule
+ * to replace (= (str.to_code x) 100) with (= x "d"), which would cause problems for
+ * noodler string solver if it was applied always.
  */
 class input_rewriter {
 protected:

--- a/src/ast/rewriter/input_rewriter.h
+++ b/src/ast/rewriter/input_rewriter.h
@@ -54,4 +54,7 @@ public:
      * \param e  The expression to rewrite
      */
     expr_ref rewrite_input(expr* e);
+
+private:
+    std::optional<expr_ref> rewrite_to_code(expr* e);
 };

--- a/src/ast/rewriter/input_rewriter.h
+++ b/src/ast/rewriter/input_rewriter.h
@@ -1,0 +1,57 @@
+/*++
+Module Name:
+
+    input_rewriter.h
+
+Abstract:
+
+    Rewriter for processing expressions only when they are loaded from input.
+    This ensures that custom rewriting rules are applied exactly once to input
+    expressions and not to expressions created internally during solving.
+
+--*/
+#pragma once
+
+#include "ast/ast.h"
+#include "ast/seq_decl_plugin.h"
+#include "ast/arith_decl_plugin.h"
+
+/**
+ * \brief Input rewriter: applies rewrite rules only to expressions loaded from input.
+ *
+ * This class is designed to be used at expression load time (in cmd_context::assert_expr)
+ * to rewrite expressions exactly once when they are parsed from input. This prevents
+ * rewriting overhead during the solving process since expressions created internally
+ * during solving will not be rewritten.
+ *
+ * Usage:
+ *   input_rewriter rewriter(manager);
+ *   expr_ref input_expr = ...;  // expression from parsed input
+ *   rewriter.rewrite_input(input_expr);
+ *
+ * To add custom input-only rewriting rules:
+ *   1. Add a method to apply your custom rules
+ *   2. Call it from rewrite_input() when appropriate parameter is set
+ *   3. Extend this class for domain-specific rewriting
+ */
+class input_rewriter {
+protected:
+    ast_manager&    m;
+    seq_util        m_util_s;
+    arith_util      m_util_a;
+
+public:
+    /**
+     * \brief Create an input rewriter with the given manager and parameters.
+     *
+     * \param m      The AST manager
+     */
+    input_rewriter(ast_manager& m) : m(m), m_util_s(m), m_util_a(m) { }
+
+    /**
+     * \brief Rewrite an expression that came from input.
+     *
+     * \param e  The expression to rewrite
+     */
+    expr_ref rewrite_input(expr* e);
+};

--- a/src/ast/rewriter/input_rewriter.h
+++ b/src/ast/rewriter/input_rewriter.h
@@ -12,6 +12,8 @@ Abstract:
 --*/
 #pragma once
 
+#include <optional>
+
 #include "ast/ast.h"
 #include "ast/seq_decl_plugin.h"
 #include "ast/arith_decl_plugin.h"
@@ -48,4 +50,5 @@ public:
 
 private:
     std::optional<expr_ref> rewrite_to_code(expr* e);
+    std::optional<expr_ref> rewrite_len(expr* e);
 };

--- a/src/ast/rewriter/input_rewriter.h
+++ b/src/ast/rewriter/input_rewriter.h
@@ -48,4 +48,5 @@ public:
 
 private:
     std::optional<expr_ref> rewrite_to_code(expr* e);
+    std::optional<expr_ref> rewrite_to_int(expr *e);
 };

--- a/src/ast/rewriter/input_rewriter.h
+++ b/src/ast/rewriter/input_rewriter.h
@@ -12,8 +12,6 @@ Abstract:
 --*/
 #pragma once
 
-#include <optional>
-
 #include "ast/ast.h"
 #include "ast/seq_decl_plugin.h"
 #include "ast/arith_decl_plugin.h"
@@ -50,5 +48,4 @@ public:
 
 private:
     std::optional<expr_ref> rewrite_to_code(expr* e);
-    std::optional<expr_ref> rewrite_len(expr* e);
 };

--- a/src/cmd_context/cmd_context.cpp
+++ b/src/cmd_context/cmd_context.cpp
@@ -40,6 +40,7 @@ Notes:
 #include "ast/well_sorted.h"
 #include "ast/for_each_expr.h"
 #include "ast/rewriter/th_rewriter.h"
+#include "ast/rewriter/input_rewriter.h"
 #include "ast/rewriter/recfun_replace.h"
 #include "ast/polymorphism_util.h"
 #include "model/model_evaluator.h"
@@ -898,6 +899,13 @@ void cmd_context::init_external_manager() {
     init_manager_core(false);
 }
 
+void cmd_context::init_input_rewriter() {
+    if (!m_input_rewriter) {
+        init_manager();
+        m_input_rewriter = alloc(input_rewriter, m());
+    }
+}
+
 bool cmd_context::set_logic(symbol const & s) {
     TRACE(cmd_context, tout << s << "\n";);
     if (has_logic())
@@ -1586,12 +1594,18 @@ void cmd_context::assert_expr(expr * t) {
     if (!m_check_logic(t))
         throw cmd_exception(m_check_logic.get_last_error());
     m_check_sat_result = nullptr;
-    m().inc_ref(t);
-    m_assertions.push_back(t);
+    
+    // Apply input-only rewriting to expressions as they are loaded
+    // TODO: proof generation might not work correctly (do rewriter rules even add proofs?)
+    init_input_rewriter();
+    expr_ref rewritten(m_input_rewriter->rewrite_input(t));
+    
+    m().inc_ref(rewritten);
+    m_assertions.push_back(rewritten);
     if (produce_unsat_cores())
         m_assertion_names.push_back(nullptr);
     if (m_solver)
-        m_solver->assert_expr(t);
+        m_solver->assert_expr(rewritten);
 }
 
 void cmd_context::assert_expr(symbol const & name, expr * t) {
@@ -1604,13 +1618,19 @@ void cmd_context::assert_expr(symbol const & name, expr * t) {
     scoped_rlimit no_limit(m().limit(), 0);
 
     m_check_sat_result = nullptr;
-    m().inc_ref(t);
-    m_assertions.push_back(t);
+    
+    // Apply input-only rewriting to expressions as they are loaded
+    // TODO: proof generation might not work correctly (do rewriter rules even add proofs?)
+    init_input_rewriter();
+    expr_ref rewritten(m_input_rewriter->rewrite_input(t));
+    
+    m().inc_ref(rewritten);
+    m_assertions.push_back(rewritten);
     app * ans  = m().mk_skolem_const(name, m().mk_bool_sort());
     m().inc_ref(ans);
     m_assertion_names.push_back(ans);
     if (m_solver)
-        m_solver->assert_expr(t, ans);
+        m_solver->assert_expr(rewritten, ans);
 }
 
 void cmd_context::push() {

--- a/src/cmd_context/cmd_context.h
+++ b/src/cmd_context/cmd_context.h
@@ -34,6 +34,7 @@ Notes:
 #include "ast/recfun_decl_plugin.h"
 #include "ast/rewriter/seq_rewriter.h"
 #include "ast/rewriter/var_subst.h"
+#include "ast/rewriter/input_rewriter.h"
 #include "ast/converters/generic_model_converter.h"
 #include "solver/solver.h"
 #include "solver/check_logic.h"
@@ -288,6 +289,7 @@ protected:
     std::vector<std::string>     m_assertion_strings;
     ptr_vector<expr>             m_assertion_names; // named assertions are represented using boolean variables.
     scoped_ptr<var_subst>        m_std_subst, m_rev_subst;
+    scoped_ptr<input_rewriter>   m_input_rewriter;
     simplifier_factory           m_simplifier_factory;
 
     struct scope {
@@ -439,6 +441,7 @@ public:
 
     void set_solver_factory(solver_factory * s);
     void set_simplifier_factory(simplifier_factory& sf) { m_simplifier_factory = sf; }
+    void init_input_rewriter();
     void set_check_sat_result(check_sat_result * r) { m_check_sat_result = r; }
     check_sat_result * get_check_sat_result() const { return m_check_sat_result.get(); }
     check_sat_state cs_state() const;

--- a/src/smt/theory_str_noodler/expr_cases.cpp
+++ b/src/smt/theory_str_noodler/expr_cases.cpp
@@ -1,13 +1,8 @@
 #include <cassert>
 
-#include "util.h"
-#include "theory_str_noodler.h"
-#include "inclusion_graph.h"
-#include "aut_assignment.h"
+#include "ast/ast_pp.h"
 
-namespace {
-    using mata::nfa::Nfa;
-}
+#include "expr_cases.h"
 
 namespace smt::noodler::expr_cases {
 
@@ -67,14 +62,33 @@ bool is_one_add_indexof_string(expr* e, expr* index_str, ast_manager& m, seq_uti
 bool is_to_int_num_eq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_int_arg, rational& num) {
     expr* left = nullptr, *right = nullptr;
     if(m.is_eq(e, left, right)) {
-        if(m_util_a.is_numeral(left, num) && m_util_s.str.is_stoi(right, to_int_arg)) {
+        if(m_util_a.is_numeral(left, num) && num.is_int() && m_util_s.str.is_stoi(right, to_int_arg)) {
             return true;
         }
-        if(m_util_a.is_numeral(right, num) && m_util_s.str.is_stoi(left, to_int_arg)) {
+        if(m_util_a.is_numeral(right, num) && num.is_int() && m_util_s.str.is_stoi(left, to_int_arg)) {
             return true;
         }
     }
     return false;
+}
+
+bool is_to_code_num_eq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_code_arg, rational& num, bool& is_eq) {
+    expr* left = nullptr, *right = nullptr, *not_argument = nullptr;
+    if(m.is_eq(e, left, right)) {
+        is_eq = true;
+    } else if (m.is_distinct(e, left, right) || (m.is_not(e, not_argument) && m.is_eq(not_argument, left, right))) {
+        is_eq = false;
+    } else {
+        return false;
+    }
+
+    if(m_util_a.is_numeral(left, num) && num.is_int() && m_util_s.str.is_to_code(right, to_code_arg)) {
+        return true;
+    } else if(m_util_a.is_numeral(right, num) && num.is_int() && m_util_s.str.is_to_code(left, to_code_arg)) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 bool is_sum_of_lens(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr_ref_vector& len_vars) {
@@ -149,13 +163,13 @@ bool is_len_num_leq_or_geq(expr* e, ast_manager& m, seq_util& m_util_s, arith_ut
         return false;
     }
     
-    if (m_util_a.is_numeral(more, num) && is_sum_of_lens(less, m, m_util_s, m_util_a, len_arg)) {
+    if (m_util_a.is_numeral(more, num) && num.is_int() && is_sum_of_lens(less, m, m_util_s, m_util_a, len_arg)) {
         if (strictly_less) {
             --num;
         }
         num_is_larger = true;
         return true;
-    } else if (m_util_a.is_numeral(less, num) && is_sum_of_lens(more, m, m_util_s, m_util_a, len_arg)) {
+    } else if (m_util_a.is_numeral(less, num) && num.is_int() && is_sum_of_lens(more, m, m_util_s, m_util_a, len_arg)) {
         if (strictly_less) {
             ++num;
         }
@@ -177,6 +191,36 @@ bool is_indexof_at(expr * index_param, expr* index_str, ast_manager& m, seq_util
 bool is_num_plus_len(expr* val, expr* s, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, rational& num_res) {
     expr *num, *len, *str;
     return (m_util_a.is_add(val, num, len) && m_util_s.str.is_length(len, str) && str == s && m_util_a.is_numeral(num, num_res));
+}
+
+bool is_to_code_leq_or_geq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_code_arg, rational& num, bool& num_is_larger) {
+    expr* less = nullptr, *more = nullptr, *e_not = nullptr;
+    bool strictly_less;
+    if (m_util_a.is_lt(e, less, more) || (m.is_not(e, e_not) && m_util_a.is_ge(e_not, less, more)) ||
+        m_util_a.is_gt(e, more, less) || (m.is_not(e, e_not) && m_util_a.is_le(e_not, more, less))) {
+        strictly_less = true;
+    } else if (m_util_a.is_le(e, less, more) || (m.is_not(e, e_not) && m_util_a.is_gt(e_not, less, more)) ||
+               m_util_a.is_ge(e, more, less) || (m.is_not(e, e_not) && m_util_a.is_lt(e_not, more, less))) {
+        strictly_less = false;
+    } else {
+        return false;
+    }
+
+    if (m_util_a.is_numeral(more, num) && num.is_int() && m_util_s.str.is_to_code(less, to_code_arg)) {
+        if (strictly_less) {
+            --num;
+        }
+        num_is_larger = true;
+        return true;
+    } else if (m_util_a.is_numeral(less, num) && num.is_int() && m_util_s.str.is_to_code(more, to_code_arg)) {
+        if (strictly_less) {
+            ++num;
+        }
+        num_is_larger = false;
+        return true;
+    } else {
+        return false;
+    }
 }
 
 bool has_quantifier(expr* e, ast_manager& m) {

--- a/src/smt/theory_str_noodler/expr_cases.cpp
+++ b/src/smt/theory_str_noodler/expr_cases.cpp
@@ -59,17 +59,23 @@ bool is_one_add_indexof_string(expr* e, expr* index_str, ast_manager& m, seq_uti
     return (is_indexof_add(e, index_str, m, m_util_s, m_util_a, val, ind_find_expr) && m_util_a.is_one(val) && m_util_s.str.is_string(ind_find_expr, ind_find));
 }
 
-bool is_to_int_num_eq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_int_arg, rational& num) {
-    expr* left = nullptr, *right = nullptr;
+bool is_to_int_num_eq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_int_arg, rational& num, bool& is_eq) {
+    expr* left = nullptr, *right = nullptr, *not_argument = nullptr;
     if(m.is_eq(e, left, right)) {
-        if(m_util_a.is_numeral(left, num) && num.is_int() && m_util_s.str.is_stoi(right, to_int_arg)) {
-            return true;
-        }
-        if(m_util_a.is_numeral(right, num) && num.is_int() && m_util_s.str.is_stoi(left, to_int_arg)) {
-            return true;
-        }
+        is_eq = true;
+    } else if (m.is_distinct(e, left, right) || (m.is_not(e, not_argument) && m.is_eq(not_argument, left, right))) {
+        is_eq = false;
+    } else {
+        return false;
     }
-    return false;
+
+    if(m_util_a.is_numeral(left, num) && num.is_int() && m_util_s.str.is_stoi(right, to_int_arg)) {
+        return true;
+    } else if(m_util_a.is_numeral(right, num) && num.is_int() && m_util_s.str.is_stoi(left, to_int_arg)) {
+        return true;
+    } else {
+        return false;
+    }
 }
 
 bool is_to_code_num_eq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_code_arg, rational& num, bool& is_eq) {
@@ -213,6 +219,36 @@ bool is_to_code_leq_or_geq(expr* e, ast_manager& m, seq_util& m_util_s, arith_ut
         num_is_larger = true;
         return true;
     } else if (m_util_a.is_numeral(less, num) && num.is_int() && m_util_s.str.is_to_code(more, to_code_arg)) {
+        if (strictly_less) {
+            ++num;
+        }
+        num_is_larger = false;
+        return true;
+    } else {
+        return false;
+    }
+}
+
+bool is_to_int_leq_or_geq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_int_arg, rational& num, bool& num_is_larger) {
+    expr* less = nullptr, *more = nullptr, *e_not = nullptr;
+    bool strictly_less;
+    if (m_util_a.is_lt(e, less, more) || (m.is_not(e, e_not) && m_util_a.is_ge(e_not, less, more)) ||
+        m_util_a.is_gt(e, more, less) || (m.is_not(e, e_not) && m_util_a.is_le(e_not, more, less))) {
+        strictly_less = true;
+    } else if (m_util_a.is_le(e, less, more) || (m.is_not(e, e_not) && m_util_a.is_gt(e_not, less, more)) ||
+               m_util_a.is_ge(e, more, less) || (m.is_not(e, e_not) && m_util_a.is_lt(e_not, more, less))) {
+        strictly_less = false;
+    } else {
+        return false;
+    }
+
+    if (m_util_a.is_numeral(more, num) && num.is_int() && m_util_s.str.is_stoi(less, to_int_arg)) {
+        if (strictly_less) {
+            --num;
+        }
+        num_is_larger = true;
+        return true;
+    } else if (m_util_a.is_numeral(less, num) && num.is_int() && m_util_s.str.is_stoi(more, to_int_arg)) {
         if (strictly_less) {
             ++num;
         }

--- a/src/smt/theory_str_noodler/expr_cases.h
+++ b/src/smt/theory_str_noodler/expr_cases.h
@@ -70,17 +70,18 @@ bool is_one_add_indexof_string(expr* e, expr* index_str, ast_manager& m, seq_uti
 bool is_indexof_at(expr * index_param, expr* index_str, ast_manager& m, seq_util& m_util_s);
 
 /**
- * @brief Check if the expression @p e is of the form to_int(x) = num (or num = to_int(x)) where num is a number.
+ * @brief Check if the expression @p e is of the form to_int(x) = num or to_code(x) != num (or swapped) where num is a number.
  * 
  * @param e Expression to be checked
  * @param m Ast manager
  * @param m_util_s string ast util
  * @param m_util_a arith ast util
- * @param[out] to_int_arg Argument of to_int (x)
+ * @param[out] to_int_arg Argument of to_int
  * @param[out] num Number on the opposite side
+ * @param[out] is_eq true if @p e is equation, false if it is disequation
  * @return true <-> if of the particular form.
  */
-bool is_to_int_num_eq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_int_arg, rational& num);
+bool is_to_int_num_eq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_int_arg, rational& num, bool& is_eq);
 
 /**
  * @brief Check if the expression @p e is of the form to_code(x) = num or to_code(x) != num (or swapped) where num is a number.
@@ -166,6 +167,22 @@ bool is_num_plus_len(expr* val, expr* s, ast_manager& m, seq_util& m_util_s, ari
  * @return true <-> if of the particular form.
  */
 bool is_to_code_leq_or_geq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_code_arg, rational& num, bool& num_is_larger);
+
+/**
+ * @brief Check if the expression @p e is of the form (str.to_int arg) <= num with num a constant number.
+ * 
+ * Can check all directions <, <=, >, >=, with possible negation in front.
+ * 
+ * @param e Expression to be checked
+ * @param m Ast manager
+ * @param m_util_s string ast util
+ * @param m_util_a arith ast util
+ * @param[out] to_int_arg Argument of to_int
+ * @param[out] num Number on the opposite side of the comparison (for < and >, it is incremented/decremented so that it represents <= or >=)
+ * @param num_is_larger Whether num is on the side representing larger part (i.e. it is true if we have the form "... <= num")
+ * @return true <-> if of the particular form.
+ */
+bool is_to_int_leq_or_geq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_int_arg, rational& num, bool& num_is_larger);
 
 /**
  * @brief Check if the formula @p e contains a quantifier.

--- a/src/smt/theory_str_noodler/expr_cases.h
+++ b/src/smt/theory_str_noodler/expr_cases.h
@@ -1,25 +1,8 @@
 #ifndef _NOODLER_EXPR_CASES_H_
 #define _NOODLER_EXPR_CASES_H_
 
-#include <functional>
-#include <list>
-#include <set>
-#include <stack>
-#include <map>
-#include <memory>
-#include <queue>
-#include <unordered_map>
-#include <unordered_set>
-#include <vector>
-
-#include "params/smt_params.h"
 #include "ast/arith_decl_plugin.h"
 #include "ast/seq_decl_plugin.h"
-#include "ast/rewriter/seq_rewriter.h"
-#include "ast/rewriter/th_rewriter.h"
-
-#include "formula.h"
-#include "aut_assignment.h"
 
 namespace smt::noodler::expr_cases {
 
@@ -87,7 +70,7 @@ bool is_one_add_indexof_string(expr* e, expr* index_str, ast_manager& m, seq_uti
 bool is_indexof_at(expr * index_param, expr* index_str, ast_manager& m, seq_util& m_util_s);
 
 /**
- * @brief Check if the expression @p e is of the form to_int(x) = num (or num = to_int(x)) where num is a number .
+ * @brief Check if the expression @p e is of the form to_int(x) = num (or num = to_int(x)) where num is a number.
  * 
  * @param e Expression to be checked
  * @param m Ast manager
@@ -98,6 +81,20 @@ bool is_indexof_at(expr * index_param, expr* index_str, ast_manager& m, seq_util
  * @return true <-> if of the particular form.
  */
 bool is_to_int_num_eq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_int_arg, rational& num);
+
+/**
+ * @brief Check if the expression @p e is of the form to_code(x) = num or to_code(x) != num (or swapped) where num is a number.
+ * 
+ * @param e Expression to be checked
+ * @param m Ast manager
+ * @param m_util_s string ast util
+ * @param m_util_a arith ast util
+ * @param[out] to_code_arg Argument of to_code
+ * @param[out] num Number on the opposite side
+ * @param[out] is_eq true if @p e is equation, false if it is disequation
+ * @return true <-> if of the particular form
+ */
+bool is_to_code_num_eq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_code_arg, rational& num, bool& is_eq);
 
 /**
  * @brief Checks if the expression @p e is of the form N1*len(x1) + N2*len(x2) + ... with each Ni > 0. 
@@ -153,6 +150,22 @@ bool is_len_num_leq_or_geq(expr* e, ast_manager& m, seq_util& m_util_s, arith_ut
  * @return Is of the form.
  */
 bool is_num_plus_len(expr* val, expr* s, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, rational& num_res);
+
+/**
+ * @brief Check if the expression @p e is of the form (str.to_code arg) <= num with num a constant number.
+ * 
+ * Can check all directions <, <=, >, >=, with possible negation in front.
+ * 
+ * @param e Expression to be checked
+ * @param m Ast manager
+ * @param m_util_s string ast util
+ * @param m_util_a arith ast util
+ * @param[out] to_code_arg Argument of to_code
+ * @param[out] num Number on the opposite side of the comparison (for < and >, it is incremented/decremented so that it represents <= or >=)
+ * @param num_is_larger Whether num is on the side representing larger part (i.e. it is true if we have the form "... <= num")
+ * @return true <-> if of the particular form.
+ */
+bool is_to_code_leq_or_geq(expr* e, ast_manager& m, seq_util& m_util_s, arith_util& m_util_a, expr*& to_code_arg, rational& num, bool& num_is_larger);
 
 /**
  * @brief Check if the formula @p e contains a quantifier.

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -159,7 +159,6 @@ namespace smt::noodler {
         if(this->input_has_quantifiers) {
             const_cast<theory_str_noodler_params&>(m_params).m_produce_models = true;
         }
-        add_conversion_num_axioms();
         STRACE(str, tout << __LINE__ << " leave " << __FUNCTION__ << std::endl;);
 
     }
@@ -2212,24 +2211,6 @@ namespace smt::noodler {
         add_axiom({~mk_literal(e), mk_literal(s_in_digit)});
         // ~is_digit(s) -> ~(s \in [0-9])
         add_axiom({mk_literal(e), ~mk_literal(s_in_digit)});
-    }
-
-    /**
-     * @brief Add special axioms for conversions.
-     * In particular, for n = to_int(x) generate n = to_int(x) -> x \in 0*to_string(n)).
-     */
-    void theory_str_noodler::add_conversion_num_axioms() {
-        unsigned nFormulas = ctx.get_num_asserted_formulas();
-        for (unsigned i = 0; i < nFormulas; ++i) {
-            expr *ex = ctx.get_asserted_formula(i);
-            rational val;
-            expr* to_int_arg = nullptr;
-            if(expr_cases::is_to_int_num_eq(ex, m, m_util_s, m_util_a, to_int_arg, val) && val.is_nonneg()) {
-                expr_ref re(m_util_s.re.mk_concat(m_util_s.re.mk_star(m_util_s.re.mk_to_re(m_util_s.str.mk_string("0"))), m_util_s.re.mk_to_re(m_util_s.str.mk_string(val.to_string()))), m);
-                expr_ref in_re(m_util_s.re.mk_in_re(to_int_arg, re), m);
-                add_axiom({~mk_literal(ex), mk_literal(in_re)});
-            }
-        }
     }
 
     /**

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -141,15 +141,16 @@ namespace smt::noodler {
             STRACE(str_init_formula, tout << "Initial asserted formula " << i << ": " << expr_ref(ctx.get_asserted_formula(i), m) << std::endl;);
             expr *ex = ctx.get_asserted_formula(i);
             this->input_has_quantifiers |= util::has_quantifiers(m, ex);
-            if (!add_len_num_axioms(ex)) {
-                obj_hashtable<app> lens;
-                util::get_len_exprs(ctx.get_asserted_formula(i), m_util_s, m, lens);
-                for (app* const a : lens) {
-                    expr* len_arg;
-                    VERIFY(m_util_s.str.is_length(a, len_arg));
-                    mark_expression_as_length(len_arg);
-                }
+
+            // find (str.len e) expressions and mark e as length-aware (for decision procedure)
+            obj_hashtable<app> lens;
+            util::get_len_exprs(ctx.get_asserted_formula(i), m_util_s, m, lens);
+            for (app* const a : lens) {
+                expr* len_arg;
+                VERIFY(m_util_s.str.is_length(a, len_arg));
+                mark_expression_as_length(len_arg);
             }
+
             ctx.mark_as_relevant(ex);
             string_theory_propagation(ex, true, false);  
         }
@@ -2231,75 +2232,6 @@ namespace smt::noodler {
             }
         }
     }
-
-    /**
-     * @brief Add special axioms for length (in)equations. In particular
-     * - for (len s) == 10 create (len s) == 10 -> s \in \Sigma^10
-     * - for (len s) <= 10 create (len s) <= 10 -> s \in re.loop(0, 10)
-     * - for 10 <= (len s) create 10 <= (len s) -> s \in re.loop(10, \inf)
-     * (len s) can be potentially any LIA formula where the "variables" are length constraints and there is no minus
-     */
-    bool theory_str_noodler::add_len_num_axioms(expr* ex) {
-        // number bound for the conversion of length constraints into regex constraints.
-        // For higher values this conversion could not be beneficial as we would work with 
-        // big automata in the decision procedure.
-        const int MAX_NUM = 64; 
-        const unsigned MAX_VARS = 4;
-        rational val;
-        bool val_is_larger;
-        expr_ref_vector len_arg(m);
-        if(expr_cases::is_len_num_eq(ex, m, m_util_s, m_util_a, len_arg, val) && val < MAX_NUM) {
-            if (val < 0) {
-                // The sum of lengths should be equal negative number, which is not possible.
-                // We cannot use the following line (that says this equation cannot hold), as it becomes inconsistent for Z3 (see https://github.com/VeriFIT/z3-noodler/issues/242),
-                // instead it will be handled by the axioms saying that lengths need to be nonnegative.
-                // add_axiom({~mk_literal(ex)});
-                return true;
-            } else if (val == 0) {
-                // we know that concatenation of vars in len_arg must be empty string,
-                // but it doesn't work for some reason, it resulted in some unknowns
-                // even though decision procedure finished, so we better give up
-                return false;
-            } else if (len_arg.size() <= MAX_VARS) {
-                expr_ref re(m_util_s.re.mk_full_char(nullptr), m);
-                for(rational i{1}; i < val; i++) {
-                    re = m_util_s.re.mk_concat(re, m_util_s.re.mk_full_char(nullptr));
-                }
-                expr_ref in_re(m_util_s.re.mk_in_re(m_util_s.str.mk_concat(len_arg, nullptr), re), m);
-                add_axiom({~mk_literal(ex), mk_literal(in_re)});
-                return true;
-            }
-        } else if(expr_cases::is_len_num_leq_or_geq(ex, m, m_util_s, m_util_a, len_arg, val, val_is_larger) && val < MAX_NUM) {
-            if (val < 0) {
-                if (val_is_larger) {
-                    // The sum of lengths should be less than or equal than negative number, which is not possible.
-                    // We cannot use the following line (that says this inequation cannot hold), as it becomes inconsistent for Z3 (see https://github.com/VeriFIT/z3-noodler/issues/242),
-                    // instead it will be handled by the axioms saying that lengths need to be nonnegative.
-                    // add_axiom({~mk_literal(ex)});
-                }
-                // if val is smaller than len_arg, then this expression just say that the length of len_arg is larger than minus number -> it is useless
-                return true;
-            } else if (val == 0) {
-                if (val_is_larger) {
-                    return false;
-                }
-                // if val is smaller than len_arg, then this expression just say that the length of len_arg is larger or equal than 0 -> it is useless
-                return true;
-            } else if (len_arg.size() <= MAX_VARS) {
-                expr_ref re(
-                    val_is_larger ? 
-                        m_util_s.re.mk_loop(m_util_s.re.mk_full_char(nullptr), m_util_a.mk_int(0), m_util_a.mk_int(val)) :
-                        m_util_s.re.mk_loop(m_util_s.re.mk_full_char(nullptr), m_util_a.mk_int(val)),
-                    m
-                );
-                expr_ref in_re(m_util_s.re.mk_in_re(m_util_s.str.mk_concat(len_arg, nullptr), re), m);
-                add_axiom({~mk_literal(ex), mk_literal(in_re)});
-                return true;
-            }
-        }
-        return false;
-    }
-
 
     /**
      * @brief Handle to_code, from_code, to_int, from_int

--- a/src/smt/theory_str_noodler/theory_str_noodler.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler.cpp
@@ -141,16 +141,15 @@ namespace smt::noodler {
             STRACE(str_init_formula, tout << "Initial asserted formula " << i << ": " << expr_ref(ctx.get_asserted_formula(i), m) << std::endl;);
             expr *ex = ctx.get_asserted_formula(i);
             this->input_has_quantifiers |= util::has_quantifiers(m, ex);
-
-            // find (str.len e) expressions and mark e as length-aware (for decision procedure)
-            obj_hashtable<app> lens;
-            util::get_len_exprs(ctx.get_asserted_formula(i), m_util_s, m, lens);
-            for (app* const a : lens) {
-                expr* len_arg;
-                VERIFY(m_util_s.str.is_length(a, len_arg));
-                mark_expression_as_length(len_arg);
+            if (!add_len_num_axioms(ex)) {
+                obj_hashtable<app> lens;
+                util::get_len_exprs(ctx.get_asserted_formula(i), m_util_s, m, lens);
+                for (app* const a : lens) {
+                    expr* len_arg;
+                    VERIFY(m_util_s.str.is_length(a, len_arg));
+                    mark_expression_as_length(len_arg);
+                }
             }
-
             ctx.mark_as_relevant(ex);
             string_theory_propagation(ex, true, false);  
         }
@@ -2232,6 +2231,75 @@ namespace smt::noodler {
             }
         }
     }
+
+    /**
+     * @brief Add special axioms for length (in)equations. In particular
+     * - for (len s) == 10 create (len s) == 10 -> s \in \Sigma^10
+     * - for (len s) <= 10 create (len s) <= 10 -> s \in re.loop(0, 10)
+     * - for 10 <= (len s) create 10 <= (len s) -> s \in re.loop(10, \inf)
+     * (len s) can be potentially any LIA formula where the "variables" are length constraints and there is no minus
+     */
+    bool theory_str_noodler::add_len_num_axioms(expr* ex) {
+        // number bound for the conversion of length constraints into regex constraints.
+        // For higher values this conversion could not be beneficial as we would work with 
+        // big automata in the decision procedure.
+        const int MAX_NUM = 64; 
+        const unsigned MAX_VARS = 4;
+        rational val;
+        bool val_is_larger;
+        expr_ref_vector len_arg(m);
+        if(expr_cases::is_len_num_eq(ex, m, m_util_s, m_util_a, len_arg, val) && val < MAX_NUM) {
+            if (val < 0) {
+                // The sum of lengths should be equal negative number, which is not possible.
+                // We cannot use the following line (that says this equation cannot hold), as it becomes inconsistent for Z3 (see https://github.com/VeriFIT/z3-noodler/issues/242),
+                // instead it will be handled by the axioms saying that lengths need to be nonnegative.
+                // add_axiom({~mk_literal(ex)});
+                return true;
+            } else if (val == 0) {
+                // we know that concatenation of vars in len_arg must be empty string,
+                // but it doesn't work for some reason, it resulted in some unknowns
+                // even though decision procedure finished, so we better give up
+                return false;
+            } else if (len_arg.size() <= MAX_VARS) {
+                expr_ref re(m_util_s.re.mk_full_char(nullptr), m);
+                for(rational i{1}; i < val; i++) {
+                    re = m_util_s.re.mk_concat(re, m_util_s.re.mk_full_char(nullptr));
+                }
+                expr_ref in_re(m_util_s.re.mk_in_re(m_util_s.str.mk_concat(len_arg, nullptr), re), m);
+                add_axiom({~mk_literal(ex), mk_literal(in_re)});
+                return true;
+            }
+        } else if(expr_cases::is_len_num_leq_or_geq(ex, m, m_util_s, m_util_a, len_arg, val, val_is_larger) && val < MAX_NUM) {
+            if (val < 0) {
+                if (val_is_larger) {
+                    // The sum of lengths should be less than or equal than negative number, which is not possible.
+                    // We cannot use the following line (that says this inequation cannot hold), as it becomes inconsistent for Z3 (see https://github.com/VeriFIT/z3-noodler/issues/242),
+                    // instead it will be handled by the axioms saying that lengths need to be nonnegative.
+                    // add_axiom({~mk_literal(ex)});
+                }
+                // if val is smaller than len_arg, then this expression just say that the length of len_arg is larger than minus number -> it is useless
+                return true;
+            } else if (val == 0) {
+                if (val_is_larger) {
+                    return false;
+                }
+                // if val is smaller than len_arg, then this expression just say that the length of len_arg is larger or equal than 0 -> it is useless
+                return true;
+            } else if (len_arg.size() <= MAX_VARS) {
+                expr_ref re(
+                    val_is_larger ? 
+                        m_util_s.re.mk_loop(m_util_s.re.mk_full_char(nullptr), m_util_a.mk_int(0), m_util_a.mk_int(val)) :
+                        m_util_s.re.mk_loop(m_util_s.re.mk_full_char(nullptr), m_util_a.mk_int(val)),
+                    m
+                );
+                expr_ref in_re(m_util_s.re.mk_in_re(m_util_s.str.mk_concat(len_arg, nullptr), re), m);
+                add_axiom({~mk_literal(ex), mk_literal(in_re)});
+                return true;
+            }
+        }
+        return false;
+    }
+
 
     /**
      * @brief Handle to_code, from_code, to_int, from_int

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -225,10 +225,6 @@ namespace smt::noodler {
          * @brief Add special axioms for conversions.
          */
         void add_conversion_num_axioms();
-        /**
-         * @brief Add special axioms for length (in)equations.
-         */
-        bool add_len_num_axioms(expr* ex);
 
         /**
          * @brief Get concatenation of e1 and e2

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -225,6 +225,10 @@ namespace smt::noodler {
          * @brief Add special axioms for conversions.
          */
         void add_conversion_num_axioms();
+        /**
+         * @brief Add special axioms for length (in)equations.
+         */
+        bool add_len_num_axioms(expr* ex);
 
         /**
          * @brief Get concatenation of e1 and e2

--- a/src/smt/theory_str_noodler/theory_str_noodler.h
+++ b/src/smt/theory_str_noodler/theory_str_noodler.h
@@ -222,10 +222,6 @@ namespace smt::noodler {
 
         void add_length_axiom(expr* n);
         /**
-         * @brief Add special axioms for conversions.
-         */
-        void add_conversion_num_axioms();
-        /**
          * @brief Add special axioms for length (in)equations.
          */
         bool add_len_num_axioms(expr* ex);


### PR DESCRIPTION
This PR implements a framework for rewriting formulas from input (only once). This allows to apply rewriting rules which are not desirable to be applied always. One example is the rule rewriting `(<= (str.to_int x) NUM)` (where `NUM` is some number) to `str.to_re` constraint.

There are also two rules rewriting formulas of the form
`conv(x) OP NUM`
where `conv` is either `str.to_int` or `str.to_code` and `NUM` is a number. They rewrite them into `str.to_re` constraints, hopefully limiting the conversion handling in Noodler.

The rules for `str.to_int` are an extension from the rules implemented in `theory_str_noodler::add_conversion_num_axioms()`, which I fully moved to the input rewriter. It helps with one case of `stringfuzz` where we gave `unknown` before (from conversions).

The rules for `str.to_code` were implemented for a new benchmark `symcc` coming from https://link.springer.com/chapter/10.1007/978-3-032-22749-2_8 (`mosca_assertions` is the older version of these benchmarks).
In these, there are a lot of formulas of the form
`(!= (str.to_code x) 123)`
or
`(<= (str.to_code x) 256)`.
It seems that the rewriter rules can a help a little bit, but not much, mostly because they lead to large alphabets (`(<= (str.to_code x) 256)` results in alphabet of size 255). It would be helpful if we had minterms, then I think it would be faster.