### PR TITLE
Fix: incorrect overapproximation information with premature LIA checks

### DIFF
--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -15,10 +15,10 @@
 namespace smt::noodler {
     lbool DecisionProcedure::compute_next_solution() {
         // We call the one with length checks but don't check them
-        return compute_next_solution_with_len_checks(nullptr).first;
+        return compute_next_solution_with_len_checks(nullptr);
     }
 
-    std::pair<lbool, bool> DecisionProcedure::compute_next_solution_with_len_checks(
+    lbool DecisionProcedure::compute_next_solution_with_len_checks(
         std::function<lbool(bool)> check_lens
     ) {
         // iteratively select next state of solving that can lead to solution and
@@ -32,8 +32,6 @@ namespace smt::noodler {
                                   !conversion_handler.are_there_any_conversions() &&
                                   not_contains.get_predicates().empty() &&
                                   (!this->m_params.m_postpone_diseqs_stabilization || !this->input_contains_disequations);
-        bool some_skipped = false;
-
         while (!is_worklist_empty()) {
             util::check_limit(m);
             SolvingState element_to_process = pop_from_worklist();
@@ -53,7 +51,7 @@ namespace smt::noodler {
 
                 if (lens_sat == l_false) {
                     // Lengths were unsat, we don't have to process this solving state
-                    some_skipped = true;
+                    this->skipped_some_with_len_checks = true;
                     continue;
                 }
             }
@@ -72,7 +70,7 @@ namespace smt::noodler {
                         element_to_process.translate_postponed_disequations_to_equations();
                     } else if (underapprox_sat == l_true) {
                         solution = std::move(element_to_process);
-                        return { l_true, false };
+                        return l_true;
                     } else {
                         // underapprox_sat == l_undef: length under-approximation is inconclusive.
                         // Do not assume satisfiability; instead, solve postponed disequations precisely.
@@ -106,7 +104,7 @@ namespace smt::noodler {
                     }
                 );
                 STRACE(str_noodle_dot, tout << solution.DOT_name << " [style=filled,fillcolor=\"aqua\"];\n";);
-                return { l_true, some_skipped };
+                return l_true;
             }
 
             // we will now process one inclusion from the inclusion graph which is at front
@@ -124,7 +122,7 @@ namespace smt::noodler {
 
         // there are no solving states left, which means nothing led to solution -> it must be unsatisfiable
         STRACE(str_noodle_dot, tout << "}\n";);
-        return { l_false, some_skipped };
+        return l_false;
     }
 
     void DecisionProcedure::process_inclusion(const Predicate& inclusion_to_process, SolvingState& solving_state) {

--- a/src/smt/theory_str_noodler/decision_procedure.h
+++ b/src/smt/theory_str_noodler/decision_procedure.h
@@ -135,6 +135,9 @@ namespace smt::noodler {
         // remembers whether the input formula passed to init_computation() contained any disequation
         bool input_contains_disequations = false;
 
+        // Becomes true if some solving states get skipped because their premature length checks are unsat
+        bool skipped_some_with_len_checks = false;
+
         std::set<BasicTerm> code_subst_vars_handled_by_parikh;
 
         const theory_str_noodler_params& m_params;
@@ -475,16 +478,21 @@ namespace smt::noodler {
          * Same as compute_next_solution, but checks length constraints while running
          * to potentionally skip processing some noodles which are found unsat.
          *
+         * NOTE: If some noodles get skipped, will set skipped_some_with_len_checks
+         *
          * @param check_lens length check function; the boolean argument indicates whether
          *                   the formula should be added to the blocking formula (true) or
          *                   only satisfiability should be checked without blocking (false).
          *
-         * @return first: True if there is a satisfiable element in the worklist.
-         *         second: if any solving states were skipped (the length check was unsat)
+         * @return True if there is a satisfiable element in the worklist.
          */
-        std::pair<lbool, bool> compute_next_solution_with_len_checks(
+        lbool compute_next_solution_with_len_checks(
             std::function<lbool(bool)> check_lens
         );
+
+        inline bool get_skipped_some_with_len_checks() const {
+            return this->skipped_some_with_len_checks;
+        }
 
         LenNode get_initial_lengths(bool all_vars = false) override;
 

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -344,7 +344,7 @@ namespace smt::noodler {
 
         while (true) {
             util::check_limit(m);
-            auto [result, some_skipped] = main_dec_proc->compute_next_solution_with_len_checks(check_lens);
+            result = main_dec_proc->compute_next_solution_with_len_checks(check_lens);
             if (result == l_true) {
                 auto [is_lengths_sat, precision] = check_lens_with_precision();
 
@@ -380,7 +380,9 @@ namespace smt::noodler {
                     block_curr_len(expr_ref(m.mk_false(), m));
                 } else {
                     // If some solving states were skipped, an overapproximation was added to block_len
-                    block_curr_len(block_len, true, some_skipped);
+                    const bool overapprox = main_dec_proc->get_skipped_some_with_len_checks();
+
+                    block_curr_len(block_len, true, overapprox);
                 }
                 this->statistics.at("stabilization").num_finish++;
                 return FC_CONTINUE;
@@ -773,7 +775,7 @@ namespace smt::noodler {
             return check_len_sat(lengths, check_with_context);
         };
 
-        while(main_dec_proc->compute_next_solution_with_len_checks(check_lens).first == l_true) {
+        while(main_dec_proc->compute_next_solution_with_len_checks(check_lens) == l_true) {
             expr_ref lengths = len_node_to_z3_formula(dec_proc->get_lengths().first);
             if(check_len_sat(lengths, check_with_context) == l_true) { // if there are no length vars in the current string formula, we do not need to check with context
                 sat_handling(lengths);

--- a/src/test/noodler/e2e/issue395.smt2
+++ b/src/test/noodler/e2e/issue395.smt2
@@ -1,0 +1,25 @@
+(set-logic ALL)
+(set-info :status unsat)
+
+(declare-const s String)
+(declare-const i@3 Int)
+(assert (str.in_re s (re.++ (re.++ (re.* (str.to_re "a")) (re.* (str.to_re "b"))) (re.* (str.to_re "c")))))
+(assert
+    (or
+        (<= (str.len s) i@3)
+        (not (<= (str.len s) i@3))
+    )
+)
+(assert (distinct (str.at s i@3) "a"))
+(assert (<= 0 i@3))
+(assert (<= i@3 (ite (str.contains s "b") (str.indexof s "b" 0) (ite (str.contains s "c") (str.indexof s "c" 0) (str.len s)))))
+(assert
+    ; (not
+        (or
+            (< i@3 (ite (str.contains s "b") (str.indexof s "b" 0) (ite (str.contains s "c") (str.indexof s "c" 0) (str.len s))))
+            (> i@3 (ite (str.contains s "c") (str.indexof s "c" 0) (str.len s)))
+        )
+    ; )
+)
+(check-sat)
+(exit)


### PR DESCRIPTION
When solving states got skipped because their premature LIA checks were unsat, we sometimes did not mark the formula put into `block_curr_len` as an overapproximation, because the information about skipping solving states was not retained between multiple runs of `compute_next_solution_with_len_checks`. 

I also tried to run experiments on it, because I was afraid that it may cause some changes (I remember we had some issues with more things suddenly being overapproximations), but there was no effect.
<img width="2000" height="1200" alt="image" src="https://github.com/user-attachments/assets/134f3e4f-4a24-40cf-84b4-76f4ed4c7ff1" />

