### PR TITLE
`to_int` overapproximation check

### DIFF
--- a/src/smt/theory_str_noodler/conversion_handler.cpp
+++ b/src/smt/theory_str_noodler/conversion_handler.cpp
@@ -1,8 +1,154 @@
-#include <numeric> 
+#include <numeric>
+#include <functional>
 
 #include "conversion_handler.h"
 
 namespace smt::noodler {
+
+namespace {
+    /**
+     * @brief Compute the (min,max) numeric value achievable by words accepted by @p aut, where @p aut is a
+     * (trimmed) automaton accepting a finite, non-empty language of digit-only words that all have the same length
+     * (e.g. obtained by intersecting some digit-only language with AutAssignment::digit_automaton_of_length(l)).
+     *
+     * Because all accepted words have the same length, @p aut is guaranteed to be acyclic and "layered" (every
+     * state has a well-defined number of remaining digit positions until acceptance), so we can compute the
+     * min/max value bottom-up with a simple memoized recursion.
+     */
+    std::pair<rational,rational> digit_value_bounds_fixed_length(const mata::nfa::Nfa& aut) {
+        std::unordered_map<mata::nfa::State, std::tuple<rational,rational,unsigned>> memo;
+
+        std::function<std::tuple<rational,rational,unsigned>(mata::nfa::State)> dfs =
+            [&](mata::nfa::State st) -> std::tuple<rational,rational,unsigned> {
+            auto memo_it = memo.find(st);
+            if (memo_it != memo.end()) {
+                return memo_it->second;
+            }
+
+            std::tuple<rational,rational,unsigned> result;
+            if (aut.delta[st].empty()) {
+                // no further digits, must be an accepting state (aut is trimmed)
+                result = { rational(0), rational(0), 0u };
+            } else {
+                rational mn, mx;
+                unsigned remaining_len = 0;
+                bool first = true;
+                for (const auto& symbol_post : aut.delta[st]) {
+                    rational digit(symbol_post.symbol - AutAssignment::DIGIT_SYMBOL_START);
+                    for (const mata::nfa::State& target : symbol_post.targets) {
+                        auto [target_min, target_max, target_remaining_len] = dfs(target);
+                        rational place_value(1);
+                        for (unsigned i = 0; i < target_remaining_len; ++i) { place_value *= 10; }
+                        rational cand_min = digit*place_value + target_min;
+                        rational cand_max = digit*place_value + target_max;
+                        if (first) {
+                            mn = cand_min;
+                            mx = cand_max;
+                            remaining_len = target_remaining_len + 1;
+                            first = false;
+                        } else {
+                            mn = std::min(mn, cand_min);
+                            mx = std::max(mx, cand_max);
+                        }
+                    }
+                }
+                result = { mn, mx, remaining_len };
+            }
+            memo[st] = result;
+            return result;
+        };
+
+        rational overall_min, overall_max;
+        bool first = true;
+        for (const mata::nfa::State& init_state : aut.initial) {
+            auto [mn, mx, _len] = dfs(init_state);
+            if (first) {
+                overall_min = mn;
+                overall_max = mx;
+                first = false;
+            } else {
+                overall_min = std::min(overall_min, mn);
+                overall_max = std::max(overall_max, mx);
+            }
+        }
+        return { overall_min, overall_max };
+    }
+
+    /// Returns automaton accepting words of the form "0" followed by at least one more digit, i.e. digit words
+    /// that have a (semantically meaningless) leading zero. Used to detect whether shorter accepted words are
+    /// guaranteed to have smaller numeric value than longer ones.
+    mata::nfa::Nfa leading_zero_followed_by_digit_automaton() {
+        mata::nfa::Nfa aut(3, {0}, {2});
+        aut.delta.add(0, AutAssignment::DIGIT_SYMBOL_START, 1);
+        for (mata::Symbol digit = AutAssignment::DIGIT_SYMBOL_START; digit <= AutAssignment::DIGIT_SYMBOL_END; ++digit) {
+            aut.delta.add(1, digit, 2);
+            aut.delta.add(2, digit, 2);
+        }
+        return aut;
+    }
+}
+
+std::pair<rational, std::optional<rational>> ConversionHandler::get_to_int_value_bounds(const AutAssignment& aut_ass, const BasicTerm& x) {
+    const mata::nfa::Nfa& full_aut = *aut_ass.at(x);
+    const mata::nfa::Nfa only_digits_with_eps = AutAssignment::digit_automaton_with_epsilon();
+
+    mata::nfa::Nfa digit_part = mata::nfa::reduce(mata::nfa::intersection(full_aut, only_digits_with_eps).trim());
+    mata::nfa::Nfa non_digit_part = mata::nfa::reduce(mata::nfa::intersection(full_aut, aut_ass.complement_aut(only_digits_with_eps)).trim());
+
+    // to_int(x) == -1 is possible either if x can contain a non-digit symbol, or if x can be the empty string
+    bool minus_one_possible = !non_digit_part.is_lang_empty() || aut_ass.contains_epsilon(x);
+
+    if (digit_part.is_lang_empty()) {
+        // every word of x either is empty or contains a non-digit => to_int(x) is always -1
+        SASSERT(minus_one_possible);
+        return { rational(-1), rational(-1) };
+    }
+
+    // trivial (but always sound) baseline bounds
+    rational lower = minus_one_possible ? rational(-1) : rational(0);
+    std::optional<rational> upper = std::nullopt;
+
+    if (mata::nfa::intersection(digit_part, leading_zero_followed_by_digit_automaton()).is_lang_empty()) {
+        // digit_part never contains a word with a semantically meaningless leading zero (i.e. no accepted word of
+        // length >= 2 starts with '0'). This means that, numerically, shorter words are always strictly smaller
+        // than longer ones, so the global minimum value is attained at the shortest length (which is well-defined
+        // even if digit_part is an infinite/cyclic language).
+        // We cannot say anything sound about a finite upper bound this way (the language may contain arbitrarily
+        // long, and hence arbitrarily large, words), so upper is left as unknown.
+        auto lengths = mata::applications::strings::get_word_lengths(digit_part);
+        unsigned min_len = lengths.begin()->first;
+        for (const auto& [c1, c2] : lengths) { min_len = std::min(min_len, static_cast<unsigned>(c1)); }
+
+        mata::nfa::Nfa aut_of_min_length = mata::nfa::minimize(mata::nfa::intersection(digit_part, AutAssignment::digit_automaton_of_length(min_len)).trim());
+        if (!aut_of_min_length.is_lang_empty()) {
+            auto [mn, _mx] = digit_value_bounds_fixed_length(aut_of_min_length);
+            lower = minus_one_possible ? rational(-1) : mn;
+        }
+    }
+    // else: digit_part may contain meaningless leading zeros, we cannot soundly tighten the bounds beyond the
+    // trivial baseline computed above
+
+    return { lower, upper };
+}
+
+LenNode ConversionHandler::get_to_int_bounds_formula(const AutAssignment& aut_ass, const std::vector<TermConversion>& conversions) {
+    std::vector<LenNode> to_int_bounds;
+    for (const TermConversion& conv : conversions) {
+        if (conv.type != ConversionType::TO_INT) {
+            continue;
+        }
+        auto [lower, upper] = get_to_int_value_bounds(aut_ass, conv.string_var);
+        to_int_bounds.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{ LenNode(lower), conv.number_var });
+        if (upper.has_value()) {
+            to_int_bounds.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{ conv.number_var, LenNode(upper.value()) });
+        }
+    }
+
+    if (to_int_bounds.empty()) {
+        return LenNode(LenFormulaType::TRUE);
+    }
+    return LenNode(LenFormulaType::AND, to_int_bounds);
+}
 
 void ConversionHandler::initialize_solution(SolvingState solution) {
     conversions = solution.conversions;

--- a/src/smt/theory_str_noodler/conversion_handler.cpp
+++ b/src/smt/theory_str_noodler/conversion_handler.cpp
@@ -106,6 +106,8 @@ std::pair<rational, std::optional<rational>> ConversionHandler::get_to_int_value
 
     // trivial (but always sound) baseline bounds
     rational lower = minus_one_possible ? rational(-1) : rational(0);
+    // TODO: no attempt is currently made to derive a finite upper bound (a bit more complicated than the 
+    // lower bound---need a method for getting the longest strings from a finite language)
     std::optional<rational> upper = std::nullopt;
 
     if (mata::nfa::intersection(digit_part, leading_zero_followed_by_digit_automaton()).is_lang_empty()) {
@@ -115,15 +117,14 @@ std::pair<rational, std::optional<rational>> ConversionHandler::get_to_int_value
         // even if digit_part is an infinite/cyclic language).
         // We cannot say anything sound about a finite upper bound this way (the language may contain arbitrarily
         // long, and hence arbitrarily large, words), so upper is left as unknown.
-        auto lengths = mata::applications::strings::get_word_lengths(digit_part);
-        unsigned min_len = lengths.begin()->first;
-        for (const auto& [c1, c2] : lengths) { min_len = std::min(min_len, static_cast<unsigned>(c1)); }
+        unsigned min_len = static_cast<unsigned>(digit_part.get_shortest_word()->size());
 
+        // digit_part is non-empty (checked above) and min_len is the length of one of its shortest accepted words,
+        // so intersecting with digit_automaton_of_length(min_len) is guaranteed to be non-empty.
         mata::nfa::Nfa aut_of_min_length = mata::nfa::minimize(mata::nfa::intersection(digit_part, AutAssignment::digit_automaton_of_length(min_len)).trim());
-        if (!aut_of_min_length.is_lang_empty()) {
-            auto [mn, _mx] = digit_value_bounds_fixed_length(aut_of_min_length);
-            lower = minus_one_possible ? rational(-1) : mn;
-        }
+        SASSERT(!aut_of_min_length.is_lang_empty());
+        auto [mn, _mx] = digit_value_bounds_fixed_length(aut_of_min_length);
+        lower = minus_one_possible ? rational(-1) : mn;
     }
     // else: digit_part may contain meaningless leading zeros, we cannot soundly tighten the bounds beyond the
     // trivial baseline computed above
@@ -131,7 +132,7 @@ std::pair<rational, std::optional<rational>> ConversionHandler::get_to_int_value
     return { lower, upper };
 }
 
-LenNode ConversionHandler::get_to_int_bounds_formula(const AutAssignment& aut_ass, const std::vector<TermConversion>& conversions) {
+LenNode ConversionHandler::get_to_int_bounds_formula(const AutAssignment& aut_ass) const {
     std::vector<LenNode> to_int_bounds;
     for (const TermConversion& conv : conversions) {
         if (conv.type != ConversionType::TO_INT) {

--- a/src/smt/theory_str_noodler/conversion_handler.h
+++ b/src/smt/theory_str_noodler/conversion_handler.h
@@ -1,6 +1,8 @@
 #ifndef _NOODLER_CONVERSION_HANDLER_H_
 #define _NOODLER_CONVERSION_HANDLER_H_
 
+#include <optional>
+
 #include "solving_state.h"
 
 namespace smt::noodler {
@@ -197,6 +199,34 @@ namespace smt::noodler {
         std::vector<BasicTerm> get_arith_vars_needed_for_model();
 
         /// TODO: add function to handle model generation for substituting vars
+
+        /**
+         * @brief Get sound (but possibly not tight) bounds on the value of str.to_int(x) derivable just from the
+         * language of @p x, without running the full decision procedure.
+         *
+         * This is meant to be used as a cheap pre-check (added as an extra conjunct to a length formula) that can
+         * prune branches where the length/regex constraints on x already make the to_int(x) result impossible to
+         * satisfy some arithmetic constraint, without needing to noodlify/split x or enumerate its language.
+         *
+         * The returned lower bound is always a sound lower bound on to_int(x) (i.e., -1 if x's language may be
+         * empty or contain a non-digit symbol, 0 otherwise, possibly tightened further). The returned upper bound
+         * (if present) is a sound upper bound; if we cannot establish a finite upper bound (e.g. the digit language
+         * is infinite and might represent arbitrarily large numbers), std::nullopt is returned instead, meaning "no
+         * known finite upper bound".
+         *
+         * @param aut_ass Automata assignment giving the language of @p x (and the alphabet used for complementing)
+         * @param x The (unflattened, top-level) string variable occurring in "i = str.to_int(x)"
+         */
+        static std::pair<rational, std::optional<rational>> get_to_int_value_bounds(const AutAssignment& aut_ass, const BasicTerm& x);
+
+        /**
+         * @brief Get a LenNode formula conjoining sound bounds (see get_to_int_value_bounds) on the result of
+         * every TO_INT conversion in @p conversions, using the languages of the string variables in @p aut_ass.
+         *
+         * Meant to be conjoined to a length formula as a cheap pre-check, before running the full decision
+         * procedure. Returns LenNode(LenFormulaType::TRUE) if there are no TO_INT conversions.
+         */
+        static LenNode get_to_int_bounds_formula(const AutAssignment& aut_ass, const std::vector<TermConversion>& conversions);
     };
 };
 

--- a/src/smt/theory_str_noodler/conversion_handler.h
+++ b/src/smt/theory_str_noodler/conversion_handler.h
@@ -221,12 +221,13 @@ namespace smt::noodler {
 
         /**
          * @brief Get a LenNode formula conjoining sound bounds (see get_to_int_value_bounds) on the result of
-         * every TO_INT conversion in @p conversions, using the languages of the string variables in @p aut_ass.
+         * every TO_INT conversion handled by this ConversionHandler, using the languages of the string variables
+         * in @p aut_ass.
          *
          * Meant to be conjoined to a length formula as a cheap pre-check, before running the full decision
          * procedure. Returns LenNode(LenFormulaType::TRUE) if there are no TO_INT conversions.
          */
-        static LenNode get_to_int_bounds_formula(const AutAssignment& aut_ass, const std::vector<TermConversion>& conversions);
+        LenNode get_to_int_bounds_formula(const AutAssignment& aut_ass) const;
     };
 };
 

--- a/src/smt/theory_str_noodler/decision_procedure.cpp
+++ b/src/smt/theory_str_noodler/decision_procedure.cpp
@@ -526,13 +526,18 @@ namespace smt::noodler {
     }
 
     LenNode DecisionProcedure::get_initial_lengths(bool all_vars) {
+        // cheap pre-check: derive sound (but possibly loose) bounds on str.to_int(x) directly from the language of
+        // x (before any noodlification/splitting of x happens), so obviously infeasible combinations of
+        // length/regex constraints on x and arithmetic constraints on the to_int result can be pruned early
+        LenNode to_int_bounds_formula = conversion_handler.get_to_int_bounds_formula(init_aut_ass);
+
         if (init_length_sensitive_vars.empty()) {
-            // there are no length sensitive vars, so we can immediately say true
-            return LenNode(LenFormulaType::TRUE);
+            // there are no length sensitive vars, so we can immediately say true (except for possible to_int bounds)
+            return to_int_bounds_formula;
         }
 
         // start from length formula from preprocessing
-        std::vector<LenNode> conjuncts = {preprocessing_len_formula};
+        std::vector<LenNode> conjuncts = {preprocessing_len_formula, to_int_bounds_formula};
 
         SolvingState temp_state; // temporary solving state to get lengths
         temp_state.aut_ass = init_aut_ass;

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -185,6 +185,12 @@ namespace smt::noodler {
 
         std::vector<TermConversion> conversions = get_conversions_as_basicterms(aut_assignment);
 
+        // Cheap pre-check: derive sound (but possibly loose) bounds on str.to_int(x) directly from the language of
+        // x (before any noodlification/splitting of x happens), so obviously infeasible combinations of
+        // length/regex constraints on x and arithmetic constraints on the to_int result can be pruned early,
+        // without running the (potentially much more expensive) main decision procedure and conversion encoding.
+        LenNode to_int_bounds_formula = ConversionHandler::get_to_int_bounds_formula(aut_assignment, conversions);
+
         for (const auto& [var, nfa] : aut_assignment) {
             relevant_vars.insert(var);
         }
@@ -248,7 +254,7 @@ namespace smt::noodler {
         // we want to include all variables from the formula --> e.g.
         // s.t = u where u \in ab, |s| > 100. The only length variable is s, but we need
         // to include also length of |u| to propagate the value to |s|
-        expr_ref lengths = len_node_to_z3_formula(main_dec_proc->get_initial_lengths(true));
+        expr_ref lengths = len_node_to_z3_formula(LenNode(LenFormulaType::AND, {main_dec_proc->get_initial_lengths(true), to_int_bounds_formula}));
         if(check_len_sat(lengths, check_len_sat_with_context) == l_false) {
             STRACE(str, tout << "Unsat from initial lengths (1)" << std::endl);
 

--- a/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
+++ b/src/smt/theory_str_noodler/theory_str_noodler_final_check.cpp
@@ -185,12 +185,6 @@ namespace smt::noodler {
 
         std::vector<TermConversion> conversions = get_conversions_as_basicterms(aut_assignment);
 
-        // Cheap pre-check: derive sound (but possibly loose) bounds on str.to_int(x) directly from the language of
-        // x (before any noodlification/splitting of x happens), so obviously infeasible combinations of
-        // length/regex constraints on x and arithmetic constraints on the to_int result can be pruned early,
-        // without running the (potentially much more expensive) main decision procedure and conversion encoding.
-        LenNode to_int_bounds_formula = ConversionHandler::get_to_int_bounds_formula(aut_assignment, conversions);
-
         for (const auto& [var, nfa] : aut_assignment) {
             relevant_vars.insert(var);
         }
@@ -254,7 +248,7 @@ namespace smt::noodler {
         // we want to include all variables from the formula --> e.g.
         // s.t = u where u \in ab, |s| > 100. The only length variable is s, but we need
         // to include also length of |u| to propagate the value to |s|
-        expr_ref lengths = len_node_to_z3_formula(LenNode(LenFormulaType::AND, {main_dec_proc->get_initial_lengths(true), to_int_bounds_formula}));
+        expr_ref lengths = len_node_to_z3_formula(main_dec_proc->get_initial_lengths(true));
         if(check_len_sat(lengths, check_len_sat_with_context) == l_false) {
             STRACE(str, tout << "Unsat from initial lengths (1)" << std::endl);
 

--- a/src/test/noodler/e2e/to_int_length_bounds.smt2
+++ b/src/test/noodler/e2e/to_int_length_bounds.smt2
@@ -1,0 +1,11 @@
+(set-logic QF_SLIA)
+(set-info :status unsat)
+
+(declare-const x String)
+
+(assert (>= (str.to_int x) 0))
+(assert (str.in_re x (re.++ (re.+ (str.to_re "82")) (str.to_re "804"))))
+(assert (< (* 5 (str.to_int x)) 26))
+(assert (< (+ (* 10 (str.len x)) (* (- 7) (str.to_int x))) 44))
+
+(check-sat)


### PR DESCRIPTION
This pull request introduces a new pre-check mechanism to improve the efficiency of handling `str.to_int` constraints in the string theory solver. The main idea is to derive sound (but possibly loose) numeric bounds for `str.to_int(x)` directly from the regular language accepted by `x`, and use these as additional constraints in the length formula. This allows the solver to prune infeasible branches early, before running the more expensive main decision procedure.