### PR TITLE
Use mata for regex matching instead of derivatives

### DIFF
--- a/src/ast/rewriter/seq_rewriter.cpp
+++ b/src/ast/rewriter/seq_rewriter.cpp
@@ -4692,6 +4692,17 @@ br_status seq_rewriter::mk_str_in_regexp(expr* a, expr* b, expr_ref& result) {
 
     zstring s;
     if (str().is_string(a, s) && re().is_ground(b)) {
+        smt::noodler::regex::Alphabet alph;
+        smt::noodler::regex::extract_symbols(a, u(), alph);
+        smt::noodler::regex::extract_symbols(b, u(), alph);
+        mata::nfa::Nfa regex_nfa = *smt::noodler::regex::NfaConstructor().conv_to_nfa(to_app(b), u(), m(), alph);
+        if (regex_nfa.is_in_lang(smt::noodler::util::get_mata_word_zstring(s))) {
+            result = m().mk_true();
+        } else {
+            result = m().mk_false();
+        }
+        return BR_DONE;
+
         // Just check membership and replace by true/false
         expr_ref r(b, m());
         for (unsigned i = 0; i < s.length(); ++i) {


### PR DESCRIPTION
For `(str.in_re s R)` where `s` is a string literal and `R` is a ground regex, currently, string rewriter uses derivative-based regex matching to rewrite it into false/true. This PR replaces it with mata-based one (construct the full automaton for `R` and check if `s` is an accepting word).

The reason for this PR is that there seems to be a degradation in the performance of derivative-based matching in Z3 v5.0.0, especially in ecma benchmark: 
<img width="1600" height="1200" alt="image" src="https://github.com/user-attachments/assets/7ffae5f2-1826-4c7b-9066-28eafeb35e7b" />
`bf5cc34-f4ef1e4` is current devel, `31db3ff-f4ef1e4` is from #408 and the cause for the degradation is exactly in the regex matching rewriter rule, it gets slower for some specific instances (counting loops that are transformed into long concatenations).
