### PR TITLE
Fix assertion failure in ConversionHandler::get_to_int_value_bounds

### DIFF
--- a/src/smt/theory_str_noodler/conversion_handler.cpp
+++ b/src/smt/theory_str_noodler/conversion_handler.cpp
@@ -90,6 +90,11 @@ namespace {
 
 std::pair<rational, std::optional<rational>> ConversionHandler::get_to_int_value_bounds(const AutAssignment& aut_ass, const BasicTerm& x) {
     const mata::nfa::Nfa& full_aut = *aut_ass.at(x);
+    // callers must handle a language-empty full_aut themselves (by asserting the whole formula false), since
+    // there is no sound finite bound to give here: x has no possible value at all, so the notion of "value of
+    // to_int(x)" is moot and the caller is unsatisfiable for reasons unrelated to str.to_int.
+    SASSERT(!full_aut.is_lang_empty());
+
     const mata::nfa::Nfa only_digits_with_eps = AutAssignment::digit_automaton_with_epsilon();
 
     mata::nfa::Nfa digit_part = mata::nfa::reduce(mata::nfa::intersection(full_aut, only_digits_with_eps).trim());
@@ -138,6 +143,16 @@ LenNode ConversionHandler::get_to_int_bounds_formula(const AutAssignment& aut_as
         if (conv.type != ConversionType::TO_INT) {
             continue;
         }
+
+        if (aut_ass.at(conv.string_var)->is_lang_empty()) {
+            // conv.string_var has no possible value at all in aut_ass (this can happen as aut_ass here might be
+            // a speculative, not-yet-preprocessed automaton assignment, see the caller in
+            // DecisionProcedure::get_initial_lengths). There is no sound finite bound on to_int(conv.string_var)
+            // to give in this case, but we do know that aut_ass (and hence the whole formula) is unsatisfiable,
+            // so we can just soundly report false instead.
+            return LenNode(LenFormulaType::FALSE);
+        }
+
         auto [lower, upper] = get_to_int_value_bounds(aut_ass, conv.string_var);
         to_int_bounds.emplace_back(LenFormulaType::LEQ, std::vector<LenNode>{ LenNode(lower), conv.number_var });
         if (upper.has_value()) {

--- a/src/smt/theory_str_noodler/conversion_handler.h
+++ b/src/smt/theory_str_noodler/conversion_handler.h
@@ -216,6 +216,10 @@ namespace smt::noodler {
          *
          * @param aut_ass Automata assignment giving the language of @p x (and the alphabet used for complementing)
          * @param x The (unflattened, top-level) string variable occurring in "i = str.to_int(x)"
+         *
+         * @pre The language of @p x in @p aut_ass is non-empty (there is no sound finite bound to give otherwise,
+         * since @p aut_ass -- and hence the whole formula -- would then already be unsatisfiable regardless of
+         * to_int; callers should check for this themselves, see get_to_int_bounds_formula).
          */
         static std::pair<rational, std::optional<rational>> get_to_int_value_bounds(const AutAssignment& aut_ass, const BasicTerm& x);
 
@@ -225,7 +229,9 @@ namespace smt::noodler {
          * in @p aut_ass.
          *
          * Meant to be conjoined to a length formula as a cheap pre-check, before running the full decision
-         * procedure. Returns LenNode(LenFormulaType::TRUE) if there are no TO_INT conversions.
+         * procedure. Returns LenNode(LenFormulaType::TRUE) if there are no TO_INT conversions. If some TO_INT
+         * conversion's string variable has an empty language in @p aut_ass , returns LenNode(LenFormulaType::FALSE) instead, since
+         * @p aut_ass is then unsatisfiable regardless of the to_int bounds.
          */
         LenNode get_to_int_bounds_formula(const AutAssignment& aut_ass) const;
     };

--- a/src/test/noodler/e2e/issue-421-to-int-assertion.smt2
+++ b/src/test/noodler/e2e/issue-421-to-int-assertion.smt2
@@ -1,0 +1,18 @@
+; https://github.com/VeriFIT/z3-noodler/issues/421
+; Used to trigger an assertion failure ("minus_one_possible") in
+; ConversionHandler::get_to_int_value_bounds (conversion_handler.cpp). The speculative
+; length pre-check in DecisionProcedure::get_initial_lengths calls this function with the
+; raw (not-yet-preprocessed) automaton assignment, where a to_int conversion's string
+; variable can legitimately have an empty-language automaton (e.g. because the SAT core is
+; currently exploring a branch where `v` is speculatively required to contain "n", which is
+; incompatible with the digit-only membership constraint). This does not mean the formula is
+; unsatisfiable overall, so the code must not assert that it can't happen.
+(set-logic QF_SLIA)
+(set-info :status sat)
+(declare-const v String)
+(declare-const on Int)
+(assert (= "" (ite false (str.at v 1) (let ((p0 (str.indexof (let ((p0 (str.indexof v "n" 0))) (str.substr v 0 p0)) ":" 0))) (str.substr (str.at v 1) 0 p0)))))
+(assert (str.in_re v (re.range "0" "9")))
+(assert (= on (str.to_int v)))
+(assert (> on 0))
+(check-sat)


### PR DESCRIPTION
Fixes #421, an assertion failure (`minus_one_possible`) that could be triggered in `conversion_handler.cpp` on formulas mixing `str.to_int` with other string functions (`str.at`, `str.indexof`, `str.substr`) under a regex membership constraint.

The root cause: `DecisionProcedure::get_initial_lengths` runs a "cheap pre-check" that conjoins sound bounds on every `str.to_int` conversion's result into a length formula, computed via `ConversionHandler::get_to_int_bounds_formula`. This pre-check is deliberately run on the *raw*, not-yet-preprocessed automaton assignment built straight from the currently asserted literals — before the SAT core has settled on a consistent branch. In the reported instance, the SAT core was speculatively exploring a branch where `v` was required to contain `"n"` (from the internal axiomatization of `str.indexof`), which is incompatible with `v`'s digit-only membership constraint. That made `v`'s automaton language-empty in this (soon-to-be-rejected) branch — a normal, expected transient state during search, not an invariant violation. `get_to_int_value_bounds` asserted this could never happen, so it crashed instead of handling it.

The fix moves the emptiness check up to `get_to_int_bounds_formula`: before computing bounds for a conversion, it now checks whether the string variable's automaton is language-empty in the given assignment, and if so returns `LenNode(LenFormulaType::FALSE)` immediately. This is more than just avoiding the crash — an empty automaton for the variable means the entire (sub)formula is unsatisfiable regardless of `to_int`, so reporting `false` lets the length pre-check prune the branch right away instead of silently returning a vacuous bound and letting the infeasibility be rediscovered later elsewhere. `get_to_int_value_bounds` keeps its original logic and assertion, now documented as a precondition (`@pre` the automaton is non-empty) that the caller is responsible for upholding.

Added `src/test/noodler/e2e/issue-421-to-int-assertion.smt2` as a regression test reproducing the original issue.
